### PR TITLE
feat(language): in-game dialogue language switching + language inspector

### DIFF
--- a/apps/desktop/electron/assets/compile-rom-assets.ts
+++ b/apps/desktop/electron/assets/compile-rom-assets.ts
@@ -1,0 +1,56 @@
+/* @layer electron-main @kind logic */
+/**
+ * Compile a ROM's zelda3_assets.dat, baking in every extracted language pack so the
+ * core can switch language at runtime via the INI. Also exposes a recompile pass used
+ * when the set of language packs changes (extract / delete).
+ */
+import { writeFile, access } from 'fs/promises';
+import { loadRom } from '@shared/asset-extraction/rom/rom-loader';
+import { compileResources } from '@shared/asset-extraction/compile-resources';
+import { getUserDataPath } from '../lib/paths';
+import { getAssetFileName, hasAssetForRom, listRoms } from '../roms/store';
+import { logToRenderer } from '../lib/renderer-log';
+import { loadPackedLanguages } from '../languages/language-pack';
+import { errMessage } from '../lib/result';
+
+type CompileResult = { success: boolean; error?: string };
+
+/** Build (or rebuild) the asset blob for one ROM, including all extracted languages. */
+const compileRomAssets = async (romFile: string): Promise<CompileResult> => {
+  const localRomPath = getUserDataPath('roms', romFile);
+  try {
+    await access(localRomPath);
+  } catch {
+    return { success: false, error: `ROM file not found: ${romFile}` };
+  }
+
+  try {
+    const rom = loadRom(localRomPath);
+    const extraLanguages = await loadPackedLanguages();
+    logToRenderer('core', 'info', `ROM loaded: ${rom.language} (${rom.description})`);
+    if (extraLanguages.length > 0) {
+      logToRenderer('app', 'info', `Baking ${extraLanguages.length} language pack(s): ${extraLanguages.map((e) => e.code).join(', ')}`);
+    }
+    const dat = compileResources(rom, { extraLanguages });
+    const assetFile = getAssetFileName(romFile);
+    await writeFile(getUserDataPath('assets', assetFile), dat);
+    logToRenderer('app', 'info', `Assets cached as ${assetFile} (${(dat.length / 1024).toFixed(0)} KB)`);
+    return { success: true };
+  } catch (err) {
+    const msg = errMessage(err);
+    logToRenderer('error', 'error', `Asset compilation failed: ${msg}`);
+    return { success: false, error: msg };
+  }
+};
+
+/** Recompile every ROM that already has a cached blob (after a language pack changes). */
+const recompileAllAssets = async (): Promise<void> => {
+  const roms = await listRoms();
+  for (const romFile of roms) {
+    if (await hasAssetForRom(romFile)) {
+      await compileRomAssets(romFile);
+    }
+  }
+};
+
+export { compileRomAssets, recompileAllAssets };

--- a/apps/desktop/electron/assets/ipc-handlers.ts
+++ b/apps/desktop/electron/assets/ipc-handlers.ts
@@ -1,11 +1,10 @@
 import { handle } from '../lib/ipc/handle';
-import { readFile, writeFile, access } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { getUserDataPath } from '../lib/paths';
 import { hasAssetForRom, getAssetFileName } from '../roms/store';
 import { logToRenderer } from '../lib/renderer-log';
 import { toArrayBufferOrNull } from '../lib/buffer';
-import { loadRom } from '@shared/asset-extraction/rom/rom-loader';
-import { compileResources } from '@shared/asset-extraction/compile-resources';
+import { compileRomAssets } from './compile-rom-assets';
 
 const registerAssetHandlers = () => {
   handle('assets:check', (_event, romFile: string) => hasAssetForRom(romFile));
@@ -19,30 +18,8 @@ const registerAssetHandlers = () => {
   });
 
   handle('assets:extract', async (_event, romFile: string) => {
-    const localRomPath = getUserDataPath('roms', romFile);
-    const assetFile = getAssetFileName(romFile);
-    const cachedAssetsPath = getUserDataPath('assets', assetFile);
-
-    try {
-      await access(localRomPath);
-    } catch {
-      return { success: false, error: `ROM file not found: ${romFile}` };
-    }
-
     logToRenderer('app', 'info', `Compiling assets from ${romFile}...`);
-
-    try {
-      const rom = loadRom(localRomPath);
-      logToRenderer('core', 'info', `ROM loaded: ${rom.language} (${rom.description})`);
-      const dat = compileResources(rom);
-      await writeFile(cachedAssetsPath, dat);
-      logToRenderer('app', 'info', `Assets cached as ${assetFile} (${(dat.length / 1024).toFixed(0)} KB)`);
-      return { success: true };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      logToRenderer('error', 'error', `Asset compilation failed: ${msg}`);
-      return { success: false, error: msg };
-    }
+    return compileRomAssets(romFile);
   });
 };
 

--- a/apps/desktop/electron/languages/ipc-handlers.ts
+++ b/apps/desktop/electron/languages/ipc-handlers.ts
@@ -1,15 +1,15 @@
 /* @layer electron-main @kind logic */
 import { handle } from '../lib/ipc/handle';
-import { join } from 'path';
-import { readFile, writeFile, mkdir, readdir, access, rm } from 'fs/promises';
+import { access, rm } from 'fs/promises';
 import { getUserDataPath } from '../lib/paths';
 import { logToRenderer } from '../lib/renderer-log';
 import { resolveSourceFiles, type ImportSource } from '../lib/import-source';
 import { ROM_EXTENSIONS } from '../lib/extensions';
 import { loadRom } from '@shared/asset-extraction/rom/rom-loader';
-import { decodeStrings, formatDialogueText } from '@shared/asset-extraction/text/dialogue-decoder';
 import { fail, errMessage } from '../lib/result';
 import { makeImportReporter } from '../lib/import-progress';
+import { extractLanguagePack, listLanguageSummaries, readLanguagePack } from './language-pack';
+import { recompileAllAssets } from '../assets/compile-rom-assets';
 
 type ExtractResult = { success: boolean; error?: string };
 
@@ -19,11 +19,14 @@ const extractDialogueFromRom = async (romAbsPath: string, langCode: string): Pro
   try {
     report('decode', undefined, undefined, 'Decoding dialogue…');
     const rom = loadRom(romAbsPath, true);
-    const strings = decodeStrings((addr: number) => rom.getByte(addr), rom.language);
-    const langDir = getUserDataPath('languages', langCode);
-    await mkdir(langDir, { recursive: true });
-    await writeFile(join(langDir, 'dialogue.txt'), formatDialogueText(strings), 'utf-8');
-    logToRenderer('app', 'info', `Language '${langCode}' extracted successfully (${strings.length} strings)`);
+    // The picked code must match the ROM's region, or the font/encoder configs won't line up.
+    if (rom.language !== langCode) {
+      throw new Error(`Selected '${langCode}' but this ROM is '${rom.language}' (${rom.description}). Pick the matching language.`);
+    }
+    const meta = await extractLanguagePack(rom, rom.language);
+    logToRenderer('app', 'info', `Language '${rom.language}' extracted (${meta.lineCount} strings, ${meta.glyphCount} glyphs)`);
+    report('extract', undefined, undefined, 'Baking into assets…');
+    await recompileAllAssets();
     report('done');
     return { success: true };
   } catch (err) {
@@ -47,7 +50,6 @@ const extractFromSource = async (source: ImportSource, langCode: string): Promis
   try {
     if (resolved.files.length === 0) throw new Error('No ROM file (.sfc/.smc) found in the source');
     if (resolved.files.length > 1) throw new Error(`Multiple ROM files found (${resolved.files.length}). Provide exactly one ROM.`);
-    // extractDialogueFromRom emits its own decode/done.
     return await extractDialogueFromRom(resolved.files[0], langCode);
   } catch (err) {
     report('error', undefined, undefined, errMessage(err));
@@ -58,19 +60,7 @@ const extractFromSource = async (source: ImportSource, langCode: string): Promis
 };
 
 const registerLanguageHandlers = () => {
-  handle('languages:list', async () => {
-    const langDir = getUserDataPath('languages');
-    try {
-      const entries = await readdir(langDir, { withFileTypes: true });
-      const langs: { code: string; fileCount: number }[] = [];
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const files = await readdir(join(langDir, entry.name));
-        langs.push({ code: entry.name, fileCount: files.length });
-      }
-      return langs;
-    } catch { return []; }
-  });
+  handle('languages:list', () => listLanguageSummaries());
 
   handle('languages:extract', async (_event, romFile: string, langCode: string) => {
     const localRomPath = getUserDataPath('roms', romFile);
@@ -86,14 +76,12 @@ const registerLanguageHandlers = () => {
   handle('languages:extractFromUrl', (_event, url: string, langCode: string) =>
     extractFromSource({ kind: 'url', url }, langCode));
 
-  handle('languages:delete', (_event, langCode: string) =>
-    rm(getUserDataPath('languages', langCode), { recursive: true, force: true }));
-
-  handle('languages:getDialogue', async (_event, langCode: string) => {
-    try {
-      return await readFile(getUserDataPath('languages', langCode, 'dialogue.txt'), 'utf-8');
-    } catch { return null; }
+  handle('languages:delete', async (_event, langCode: string) => {
+    await rm(getUserDataPath('languages', langCode), { recursive: true, force: true });
+    await recompileAllAssets();
   });
+
+  handle('languages:getLanguage', (_event, langCode: string) => readLanguagePack(langCode));
 };
 
 export { registerLanguageHandlers };

--- a/apps/desktop/electron/languages/language-pack.ts
+++ b/apps/desktop/electron/languages/language-pack.ts
@@ -1,0 +1,128 @@
+/* @layer electron-main @kind logic */
+/**
+ * Language pack persistence. A pack lives in userData/Data/languages/<code>/ and
+ * holds everything needed to (a) bake the language into an asset blob and (b) show
+ * it in the inspector UI — without needing the source ROM again:
+ *
+ *   dialogue.txt    decoded strings ("N: text"), source for re-compression + UI
+ *   font.bin        raw 2bpp glyph sheet (256 tiles x 16 bytes)
+ *   font-width.bin  per-glyph width table
+ *   meta.json       LanguageMeta (glyph/line counts, encoder, flags, source ROM)
+ */
+import { join } from 'path';
+import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
+import type { RomData } from '@shared/asset-extraction/rom/rom-types';
+import { extractLangEntry, buildPackedEntry } from '@shared/asset-extraction/text/build-language-entry';
+import type { PackedLangEntry } from '@shared/asset-extraction/text/build-language-entry';
+import { parseDialogueText, dialogueTexts } from '@shared/asset-extraction/text/parse-dialogue-text';
+import type { LanguageMeta, LanguagePack, LanguageSummary } from '@shared/types/language';
+import { getUserDataPath } from '../lib/paths';
+
+const langDir = (code: string): string => getUserDataPath('languages', code);
+const dialoguePath = (code: string): string => join(langDir(code), 'dialogue.txt');
+const fontPath = (code: string): string => join(langDir(code), 'font.bin');
+const fontWidthPath = (code: string): string => join(langDir(code), 'font-width.bin');
+const metaPath = (code: string): string => join(langDir(code), 'meta.json');
+
+/** Extract one language from its ROM and persist the full pack. Returns the code stored. */
+const extractLanguagePack = async (rom: RomData, code: string): Promise<LanguageMeta> => {
+  const entry = extractLangEntry(rom, code, 1);
+  const dir = langDir(code);
+  await mkdir(dir, { recursive: true });
+
+  const dialogue = entry.lines.map((l) => `${l.id}: ${l.content}`).join('\n') + '\n';
+  const meta: LanguageMeta = {
+    code,
+    glyphCount: entry.glyphCount,
+    lineCount: entry.lineCount,
+    encoder: entry.encoder,
+    flags: entry.flags,
+    source: rom.description,
+  };
+
+  await Promise.all([
+    writeFile(dialoguePath(code), dialogue, 'utf-8'),
+    writeFile(fontPath(code), entry.fontData),
+    writeFile(fontWidthPath(code), entry.fontWidth),
+    writeFile(metaPath(code), JSON.stringify(meta, null, 2), 'utf-8'),
+  ]);
+  return meta;
+};
+
+/** All extracted language codes (directories that contain a meta.json). */
+const listLanguageCodes = async (): Promise<string[]> => {
+  try {
+    const entries = await readdir(getUserDataPath('languages'), { withFileTypes: true });
+    const codes: string[] = [];
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      try {
+        await readFile(metaPath(e.name));
+        codes.push(e.name);
+      } catch { /* incomplete pack — skip */ }
+    }
+    return codes;
+  } catch {
+    return [];
+  }
+};
+
+const readMeta = async (code: string): Promise<LanguageMeta | null> => {
+  try {
+    return JSON.parse(await readFile(metaPath(code), 'utf-8')) as LanguageMeta;
+  } catch {
+    return null;
+  }
+};
+
+const listLanguageSummaries = async (): Promise<LanguageSummary[]> => {
+  const codes = await listLanguageCodes();
+  const metas = await Promise.all(codes.map(readMeta));
+  return metas
+    .filter((m): m is LanguageMeta => m !== null)
+    .map((m) => ({ code: m.code, glyphCount: m.glyphCount, lineCount: m.lineCount }));
+};
+
+/** Full inspector payload for one language. */
+const readLanguagePack = async (code: string): Promise<LanguagePack | null> => {
+  const meta = await readMeta(code);
+  if (!meta) return null;
+  try {
+    const [text, font] = await Promise.all([
+      readFile(dialoguePath(code), 'utf-8'),
+      readFile(fontPath(code)),
+    ]);
+    return {
+      meta,
+      lines: parseDialogueText(text),
+      font: { tiles: Array.from(font), glyphCount: meta.glyphCount },
+    };
+  } catch {
+    return null;
+  }
+};
+
+/** Pre-packed entries for every extracted language, ready to bake into an asset blob. */
+const loadPackedLanguages = async (): Promise<PackedLangEntry[]> => {
+  const codes = await listLanguageCodes();
+  const entries = await Promise.all(codes.map(async (code) => {
+    try {
+      const [text, fontData, fontWidth] = await Promise.all([
+        readFile(dialoguePath(code), 'utf-8'),
+        readFile(fontPath(code)),
+        readFile(fontWidthPath(code)),
+      ]);
+      return buildPackedEntry({ code, texts: dialogueTexts(text), fontData, fontWidth, index: 1 });
+    } catch {
+      return null;
+    }
+  }));
+  return entries.filter((e): e is PackedLangEntry => e !== null);
+};
+
+export {
+  extractLanguagePack,
+  listLanguageSummaries,
+  readLanguagePack,
+  loadPackedLanguages,
+};

--- a/apps/desktop/src/App/behavior/useProfileManagement.ts
+++ b/apps/desktop/src/App/behavior/useProfileManagement.ts
@@ -52,8 +52,8 @@ const useProfileManagement = (params: {
     await loadMsuPack(profile, settings);
 
     const msuPath = (profile.msuPack && settings.enableMSU !== 'false') ? '/msu/' : undefined;
-    const ini = serializeToIni(settings, msuPath);
-    log.app(`Loaded profile settings (aspect: ${settings.aspectRatio}, viewport: ${settings.viewportConstraint}, renderer: ${settings.newRenderer ? 'new' : 'old'})`);
+    const ini = serializeToIni(settings, msuPath, profile.language);
+    log.app(`Loaded profile settings (aspect: ${settings.aspectRatio}, viewport: ${settings.viewportConstraint}, renderer: ${settings.newRenderer ? 'new' : 'old'}, language: ${profile.language ?? 'us'})`);
 
     // Configure auto-save before game starts
     setAutoSaveConfig({

--- a/apps/desktop/src/lib/game/settings.ts
+++ b/apps/desktop/src/lib/game/settings.ts
@@ -110,7 +110,7 @@ const boolToIni = (v: boolean): string => {
   return v ? '1' : '0';
 };
 
-const serializeToIni = (settings: GameSettings, msuPath?: string): string => {
+const serializeToIni = (settings: GameSettings, msuPath?: string, language?: string): string => {
   // Build ExtendedAspectRatio value with modifiers
   const parts: string[] = [];
   if (settings.extendY) parts.push('extend_y');
@@ -120,7 +120,7 @@ const serializeToIni = (settings: GameSettings, msuPath?: string): string => {
   const aspectValue = parts.join(', ');
 
   return `[General]
-Autosave = ${boolToIni(settings.autosave)}
+${language ? `Language = ${language}\n` : ''}Autosave = ${boolToIni(settings.autosave)}
 DisplayPerfInTitle = ${boolToIni(settings.displayPerfInTitle)}
 DisableFrameDelay = ${boolToIni(settings.disableFrameDelay)}
 ExtendedAspectRatio = ${aspectValue}

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/LanguageManager.tsx
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/LanguageManager.tsx
@@ -1,9 +1,11 @@
 /* @layer renderer-components @kind component */
 import { useState, useEffect, useCallback } from 'react';
 import type { CSSProperties } from 'react';
+import type { LanguageSummary } from '@shared/types/language';
 import { ImportForm } from './ImportForm';
+import { LANGUAGE_NAMES } from './language-names';
+import { LanguageDetail } from './language-detail';
 import { Box } from '../../../../../design-system/primitives/Box';
-import { Text } from '../../../../../design-system/primitives/Text';
 import { IconButton } from '../../../../../design-system/primitives/IconButton';
 import { Select } from '../../../../../design-system/primitives/Select';
 import { Field } from '../../../../../design-system/primitives/Field';
@@ -13,25 +15,6 @@ import { ListItemRow } from '../../../../../design-system/composites/ListItemRow
 
 const IL: Record<string, CSSProperties> = {
   importForm: { marginBottom: 0, paddingBottom: 'var(--space-xs)' },
-  col: { display: 'flex', flexDirection: 'column', height: '100%' },
-};
-
-interface LanguageInfo {
-  code: string;
-  fileCount: number;
-}
-
-const LANGUAGE_NAMES: Record<string, string> = {
-  en: 'English',
-  de: 'German (Deutsch)',
-  fr: 'French (Français)',
-  'fr-c': 'French Canadian',
-  es: 'Spanish (Español)',
-  pl: 'Polish (Polski)',
-  pt: 'Portuguese (Português)',
-  nl: 'Dutch (Nederlands)',
-  sv: 'Swedish (Svenska)',
-  redux: 'Redux',
 };
 
 interface LanguageManagerProps {
@@ -40,11 +23,9 @@ interface LanguageManagerProps {
 }
 
 const LanguageManager = (props: LanguageManagerProps) => {
-  const { romStatuses, onDeleteConfirm } = props;
-  const [languages, setLanguages] = useState<LanguageInfo[]>([]);
+  const { onDeleteConfirm } = props;
+  const [languages, setLanguages] = useState<LanguageSummary[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
-  const [dialogue, setDialogue] = useState<string | null>(null);
-  const [loadingDialogue, setLoadingDialogue] = useState(false);
   const [extractLang, setExtractLang] = useState('');
 
   const refresh = useCallback(async () => {
@@ -53,16 +34,6 @@ const LanguageManager = (props: LanguageManagerProps) => {
   }, []);
 
   useEffect(() => { refresh(); }, [refresh]);
-
-  // Load dialogue when selection changes
-  useEffect(() => {
-    if (!selected) { setDialogue(null); return; }
-    setLoadingDialogue(true);
-    window.api.getDialogue(selected).then((text) => {
-      setDialogue(text);
-      setLoadingDialogue(false);
-    });
-  }, [selected]);
 
   const handleUrlImport = useCallback(async (url: string) => {
     if (!extractLang) return { success: false, message: 'Select a language first' };
@@ -93,14 +64,13 @@ const LanguageManager = (props: LanguageManagerProps) => {
     const name = LANGUAGE_NAMES[code] ?? code;
     onDeleteConfirm('Delete Language', `Delete language pack "${name}"? This cannot be undone.`, async () => {
       await window.api.deleteLanguage(code);
-      if (selected === code) { setSelected(null); setDialogue(null); }
+      if (selected === code) setSelected(null);
       await refresh();
     });
   }, [selected, refresh, onDeleteConfirm]);
 
   const list = (
     <>
-      {/* Language selector + ROM import form */}
       <Box className="import-form" style={IL.importForm}>
         <Field label="Language">
           <Select
@@ -135,7 +105,7 @@ const LanguageManager = (props: LanguageManagerProps) => {
             key={lang.code}
             icon="🌐"
             name={LANGUAGE_NAMES[lang.code] ?? lang.code}
-            meta={`${lang.fileCount} file${lang.fileCount !== 1 ? 's' : ''}`}
+            meta={`${lang.glyphCount} glyphs · ${lang.lineCount} lines`}
             selected={selected === lang.code}
             onClick={() => setSelected(lang.code)}
             action={
@@ -149,17 +119,8 @@ const LanguageManager = (props: LanguageManagerProps) => {
     </>
   );
 
-  const detail = !selected ? (
-    <Text>Select a language to view dialogue entries</Text>
-  ) : loadingDialogue ? (
-    <Text>Loading…</Text>
-  ) : dialogue ? (
-    <Box style={IL.col}>
-      <Text as="h3" className="detail-panel__title">{LANGUAGE_NAMES[selected] ?? selected}</Text>
-      <Box className="dialogue-viewer">{dialogue}</Box>
-    </Box>
-  ) : (
-    <Text>No dialogue data available</Text>
+  const detail = (
+    <LanguageDetail code={selected} name={selected ? (LANGUAGE_NAMES[selected] ?? selected) : ''} />
   );
 
   return <MasterDetailLayout list={list} detail={detail} detailEmpty={!selected} />;

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/LanguageDetail.css
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/LanguageDetail.css
@@ -1,0 +1,90 @@
+/* @layer renderer-components @kind style */
+
+/* The detail pane (.master-detail__detail) is already the bounded overflow-y:auto
+   scroll container, so this content just flows naturally and the pane scrolls —
+   no nested heights/scroll regions that would squeeze the glyph canvas. */
+.language-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.language-detail__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.language-detail__font-wrap {
+  padding: var(--space-sm);
+  background: var(--c-inset);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-md);
+}
+
+/* width:100% fills the pane; height:auto lets the canvas's 16:7 intrinsic ratio
+   set the displayed height so every glyph row is shown. */
+.language-detail__font {
+  display: block;
+  width: 100%;
+  height: auto;
+  color: var(--c-text);
+  image-rendering: pixelated;
+}
+
+.language-detail__meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.language-detail__lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.language-detail__lines-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.dialogue-line {
+  display: flex;
+  gap: var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.dialogue-line:hover {
+  background: var(--c-hover);
+}
+
+.dialogue-line__id {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--c-text-faint);
+}
+
+.dialogue-line__content {
+  flex: 1;
+  overflow-wrap: anywhere;
+}
+
+.dialogue-line__text {
+  color: var(--c-text);
+  white-space: pre-wrap;
+}
+
+.dialogue-line__code {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--c-text-muted);
+  background: var(--c-inset);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-xs);
+}

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/LanguageDetail.tsx
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/LanguageDetail.tsx
@@ -1,0 +1,55 @@
+/* @layer renderer-components @kind component */
+/**
+ * Language inspector — two scrollable tabs: "Font" (glyph sheet + metadata) and
+ * "Dialogue" (the full line list). Each tab owns its own scroll region.
+ */
+import { useState } from 'react';
+import { Box } from '../../../../../../design-system/primitives/Box';
+import { Text } from '../../../../../../design-system/primitives/Text';
+import { TabBar } from '../../../../../../design-system/primitives/TabBar';
+import { SectionHeader } from '../../../../../../design-system/primitives/SectionHeader';
+import { FontSheet } from './sub-components/FontSheet';
+import { LanguageMeta } from './sub-components/LanguageMeta';
+import { DialogueLines } from './sub-components/DialogueLines';
+import { useLanguageDetail } from './behavior/useLanguageDetail';
+import type { LanguageDetailProps } from './language-detail.type';
+import './LanguageDetail.css';
+
+const TABS = [
+  { id: 'font', label: 'Font', icon: '🔤' },
+  { id: 'dialogue', label: 'Dialogue', icon: '💬' },
+];
+
+const LanguageDetail = (props: LanguageDetailProps) => {
+  const { code, name } = props;
+  const { pack, loading } = useLanguageDetail(code);
+  const [tab, setTab] = useState('font');
+
+  if (!code) return <Text>Select a language to inspect its font and dialogue</Text>;
+  if (loading) return <Text>Loading…</Text>;
+  if (!pack) return <Text>No data available for this language</Text>;
+
+  return (
+    <Box className="language-detail">
+      <Text as="h3" className="detail-panel__title">{name}</Text>
+      <TabBar tabs={TABS} activeTab={tab} onTabChange={setTab} />
+
+      {tab === 'font' ? (
+        <Box className="language-detail__panel">
+          <SectionHeader title="Font" subtitle={`${pack.font.glyphCount} glyphs`} />
+          <Box className="language-detail__font-wrap">
+            <FontSheet tiles={pack.font.tiles} glyphCount={pack.font.glyphCount} />
+          </Box>
+          <SectionHeader title="Details" />
+          <LanguageMeta meta={pack.meta} name={name} />
+        </Box>
+      ) : (
+        <Box className="language-detail__panel">
+          <DialogueLines lines={pack.lines} />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export { LanguageDetail };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/behavior/tokenizeDialogue.ts
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/behavior/tokenizeDialogue.ts
@@ -1,0 +1,23 @@
+/* @layer renderer-components @kind logic */
+/**
+ * Split a dialogue string into plain-text runs and bracketed control tokens
+ * (e.g. [Scroll], [Name], [Speed 00]) so a line can render codes as chips.
+ */
+import type { DialogueToken } from '../language-detail.type';
+
+const TOKEN_RE = /\[[^\]]*\]/g;
+
+const tokenizeDialogue = (content: string): DialogueToken[] => {
+  const tokens: DialogueToken[] = [];
+  let last = 0;
+  for (const match of content.matchAll(TOKEN_RE)) {
+    const start = match.index;
+    if (start > last) tokens.push({ type: 'text', value: content.slice(last, start) });
+    tokens.push({ type: 'code', value: match[0] });
+    last = start + match[0].length;
+  }
+  if (last < content.length) tokens.push({ type: 'text', value: content.slice(last) });
+  return tokens;
+};
+
+export { tokenizeDialogue };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/behavior/useLanguageDetail.ts
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/behavior/useLanguageDetail.ts
@@ -1,0 +1,25 @@
+/* @layer renderer-components @kind hook */
+import { useState, useEffect } from 'react';
+import type { LanguagePack } from '@shared/types/language';
+
+/** Load the full inspector payload for a language code (re-fetches when code changes). */
+const useLanguageDetail = (code: string | null) => {
+  const [pack, setPack] = useState<LanguagePack | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!code) { setPack(null); return; }
+    let cancelled = false;
+    setLoading(true);
+    window.api.getLanguage(code).then((result) => {
+      if (cancelled) return;
+      setPack(result);
+      setLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [code]);
+
+  return { pack, loading };
+};
+
+export { useLanguageDetail };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/index.ts
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/index.ts
@@ -1,0 +1,2 @@
+/* @layer renderer-components @kind barrel */
+export { LanguageDetail } from './LanguageDetail';

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/language-detail.type.ts
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/language-detail.type.ts
@@ -1,0 +1,27 @@
+/* @layer renderer-components @kind logic */
+import type { LanguageMeta } from '@shared/types/language';
+
+/** A run within a dialogue line: literal text or a bracketed control token. */
+interface DialogueToken {
+  type: 'text' | 'code';
+  value: string;
+}
+
+interface LanguageDetailProps {
+  /** Language code to inspect, or null when nothing is selected. */
+  code: string | null;
+  /** Display name for the selected language. */
+  name: string;
+}
+
+interface FontSheetProps {
+  tiles: number[];
+  glyphCount: number;
+}
+
+interface LanguageMetaPanelProps {
+  meta: LanguageMeta;
+  name: string;
+}
+
+export type { DialogueToken, LanguageDetailProps, FontSheetProps, LanguageMetaPanelProps };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/DialogueLineRow.tsx
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/DialogueLineRow.tsx
@@ -1,0 +1,30 @@
+/* @layer renderer-components @kind component */
+import { useMemo } from 'react';
+import { Box } from '../../../../../../../design-system/primitives/Box';
+import { Text } from '../../../../../../../design-system/primitives/Text';
+import { tokenizeDialogue } from '../behavior/tokenizeDialogue';
+import type { DialogueLine } from '@shared/types/language';
+
+const DialogueLineRow = (props: { line: DialogueLine }) => {
+  const { line } = props;
+  const tokens = useMemo(() => tokenizeDialogue(line.content), [line.content]);
+
+  return (
+    <Box className="dialogue-line">
+      <Text className="dialogue-line__id">{String(line.id).padStart(3, '0')}</Text>
+      <Box className="dialogue-line__content">
+        {tokens.map((tok, i) => (
+          <Text
+            key={i}
+            as="span"
+            className={tok.type === 'code' ? 'dialogue-line__code' : 'dialogue-line__text'}
+          >
+            {tok.value}
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export { DialogueLineRow };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/DialogueLines.tsx
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/DialogueLines.tsx
@@ -1,0 +1,41 @@
+/* @layer renderer-components @kind component */
+import { useState, useMemo } from 'react';
+import { Box } from '../../../../../../../design-system/primitives/Box';
+import { TextInput } from '../../../../../../../design-system/primitives/TextInput';
+import { SectionHeader } from '../../../../../../../design-system/primitives/SectionHeader';
+import { EmptyState } from '../../../../../../../design-system/primitives/EmptyState';
+import { DialogueLineRow } from './DialogueLineRow';
+import type { DialogueLine } from '@shared/types/language';
+
+const DialogueLines = (props: { lines: DialogueLine[] }) => {
+  const { lines } = props;
+  const [filter, setFilter] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return lines;
+    return lines.filter((l) => l.content.toLowerCase().includes(q) || String(l.id) === q);
+  }, [lines, filter]);
+
+  return (
+    <Box className="language-detail__lines">
+      <SectionHeader
+        title={`Dialogue (${lines.length})`}
+        action={
+          <TextInput
+            value={filter}
+            onChange={(e) => setFilter(e.currentTarget.value)}
+            placeholder="Filter…"
+          />
+        }
+      />
+      <Box className="language-detail__lines-scroll">
+        {filtered.length === 0
+          ? <EmptyState message="No matching lines" />
+          : filtered.map((line) => <DialogueLineRow key={line.id} line={line} />)}
+      </Box>
+    </Box>
+  );
+};
+
+export { DialogueLines };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/FontSheet.tsx
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/FontSheet.tsx
@@ -1,0 +1,69 @@
+/* @layer renderer-components @kind component */
+/**
+ * Renders a language's dialogue font. The font is 256 8x8 2bpp tiles that pair up
+ * into 128 characters of 8x16 (top tile + bottom tile). For character c:
+ *   topTile = (c >> 4) * 32 + (c & 15),  bottomTile = topTile + 16
+ * (16 chars per row; each char-row spans two tile-rows). We decode both halves and
+ * paint them stacked, using the element's themed `color`.
+ */
+import { useRef, useEffect } from 'react';
+import { Canvas } from '../../../../../../../design-system/primitives/Canvas';
+import { decode2bppTile } from '@shared/asset-extraction/graphics/bitplane-decoder';
+import type { FontSheetProps } from '../language-detail.type';
+
+const COLS = 16;
+const SCALE = 3;
+const CHAR_W = 8;
+const CHAR_H = 16;
+const CELL_W = CHAR_W * SCALE;
+const CELL_H = CHAR_H * SCALE;
+const ALPHA = [0, 0.4, 0.7, 1];
+
+const FontSheet = (props: FontSheetProps) => {
+  const { tiles, glyphCount } = props;
+  const ref = useRef<HTMLCanvasElement>(null);
+  const rows = Math.ceil(glyphCount / COLS);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const data = Uint8Array.from(tiles);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = getComputedStyle(canvas).color;
+
+    const paintTile = (tileIndex: number, ox: number, oy: number) => {
+      const pixels = decode2bppTile(data, tileIndex * 16);
+      for (let y = 0; y < 8; y++) {
+        for (let x = 0; x < 8; x++) {
+          const v = pixels[y * 8 + x];
+          if (v === 0) continue;
+          ctx.globalAlpha = ALPHA[v];
+          ctx.fillRect(ox + x * SCALE, oy + y * SCALE, SCALE, SCALE);
+        }
+      }
+    };
+
+    for (let c = 0; c < glyphCount; c++) {
+      const ox = (c % COLS) * CELL_W;
+      const oy = Math.floor(c / COLS) * CELL_H;
+      const topTile = (c >> 4) * 32 + (c & 15);
+      paintTile(topTile, ox, oy);
+      paintTile(topTile + 16, ox, oy + 8 * SCALE);
+    }
+    ctx.globalAlpha = 1;
+  }, [tiles, glyphCount]);
+
+  return (
+    <Canvas
+      ref={ref}
+      width={COLS * CELL_W}
+      height={rows * CELL_H}
+      className="language-detail__font"
+    />
+  );
+};
+
+export { FontSheet };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/LanguageMeta.tsx
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-detail/sub-components/LanguageMeta.tsx
@@ -1,0 +1,25 @@
+/* @layer renderer-components @kind component */
+import { StatRow } from '../../../../../../../design-system/primitives/StatRow';
+import { Box } from '../../../../../../../design-system/primitives/Box';
+import type { LanguageMetaPanelProps } from '../language-detail.type';
+
+const ENCODER_LABELS: Record<string, string> = {
+  org: 'Original (US/JP)',
+  new: 'European (EU)',
+};
+
+const LanguageMeta = (props: LanguageMetaPanelProps) => {
+  const { meta, name } = props;
+  return (
+    <Box className="language-detail__meta">
+      <StatRow label="Name" value={name} />
+      <StatRow label="Code" value={meta.code} mono />
+      <StatRow label="Glyphs" value={meta.glyphCount} mono />
+      <StatRow label="Lines" value={meta.lineCount} mono />
+      <StatRow label="Text format" value={ENCODER_LABELS[meta.encoder] ?? meta.encoder} />
+      <StatRow label="Source" value={meta.source} />
+    </Box>
+  );
+};
+
+export { LanguageMeta };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-names.ts
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/language-names.ts
@@ -1,0 +1,18 @@
+/* @layer renderer-components @kind logic */
+/** Display names for supported dialogue language codes. */
+const LANGUAGE_NAMES: Record<string, string> = {
+  en: 'English',
+  de: 'German (Deutsch)',
+  fr: 'French (Français)',
+  'fr-c': 'French Canadian',
+  es: 'Spanish (Español)',
+  pl: 'Polish (Polski)',
+  pt: 'Portuguese (Português)',
+  nl: 'Dutch (Nederlands)',
+  sv: 'Swedish (Svenska)',
+  redux: 'Redux',
+};
+
+const languageLabel = (code: string): string => LANGUAGE_NAMES[code] ?? code;
+
+export { LANGUAGE_NAMES, languageLabel };

--- a/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/profile-manager/ProfileDetailPanel.tsx
+++ b/apps/desktop/src/ui/domains/app/views/DataManager/sub-components/profile-manager/ProfileDetailPanel.tsx
@@ -9,6 +9,7 @@ import { Text } from '../../../../../../design-system/primitives/Text';
 import { Select } from '../../../../../../design-system/primitives/Select';
 import { Button } from '../../../../../../design-system/primitives/Button';
 import { formatRelativeTime } from '../../../../../../../utils';
+import { languageLabel } from '../language-names';
 
 const IL: Record<string, CSSProperties> = {
   col: { display: 'flex', flexDirection: 'column', height: '100%' },
@@ -47,7 +48,7 @@ const ProfileDetailPanel = (props: ProfileDetailPanelProps) => {
             }}
             options={[
               { value: '', label: 'Default (English)' },
-              ...languages.map((l) => ({ value: l.code, label: l.code })),
+              ...languages.map((l) => ({ value: l.code, label: languageLabel(l.code) })),
             ]}
             placeholder="Default (English)"
           />
@@ -82,7 +83,7 @@ const ProfileDetailPanel = (props: ProfileDetailPanelProps) => {
         <Text className="detail-panel__label">ROM</Text>
         <Text className="detail-panel__value">{profile.romFile}</Text>
         <Text className="detail-panel__label">Language</Text>
-        <Text className="detail-panel__value">{profile.language || 'English (default)'}</Text>
+        <Text className="detail-panel__value">{profile.language ? languageLabel(profile.language) : 'English (default)'}</Text>
         <Text className="detail-panel__label">MSU Pack</Text>
         <Text className="detail-panel__value">{profile.msuPack || 'None'}</Text>
         <Text className="detail-panel__label">Created</Text>

--- a/shared/asset-extraction/compile-dialogue.ts
+++ b/shared/asset-extraction/compile-dialogue.ts
@@ -1,51 +1,24 @@
 /* @layer shared-asset-extraction @kind logic */
 /**
- * Dialogue asset compilation — text encoding, dictionary, and font data.
+ * Dialogue asset compilation — packs the US ROM dialogue plus any extra language
+ * packs into the parallel kDialogue / kDialogueFont / kDialogueMap arrays. The
+ * running game selects one at startup via the INI `Language` key.
  */
 import type { RomData } from './rom/rom-types';
 import type { AssetBuilder } from './asset-builder';
 import { packArrays } from './asset-builder';
-import { decodeStrings } from './text/dialogue-decoder';
-import { compressStrings, encodeDictionary } from './text/dialogue-encoder';
-import { usesNewFormat } from './text/data/language-data';
+import { extractLangEntry } from './text/build-language-entry';
+import type { PackedLangEntry } from './text/build-language-entry';
 
-const buildDialogue = (rom: RomData, A: AssetBuilder): void => {
-  const lang = 'us';
+const buildDialogue = (rom: RomData, A: AssetBuilder, extras: PackedLangEntry[] = []): void => {
+  // US is always index 0; extras follow in the order provided.
+  const us = extractLangEntry(rom, 'us', 0);
+  const all: PackedLangEntry[] = [us, ...extras];
 
-  // 1. Decode dialogue strings from ROM
-  const decoded = decodeStrings((addr) => rom.getByte(addr), lang);
-  let texts = decoded.map(d => d.text);
-
-  // US ROM has 396 strings — insert the extra control string at index 4
-  if (texts.length === 396) {
-    const extraStr = '[Speed 00]0- [Number 00]. 1- [Number 01][2]2- [Number 02]. 3- [Number 03]';
-    texts = [...texts.slice(0, 4), extraStr, ...texts.slice(4)];
-  }
-
-  // 2. Compress dialogue strings and encode dictionary
-  const compressed = compressStrings(texts, lang);
-  const dict = encodeDictionary(lang);
-
-  // 3. Pack into nested format: pack([dict_packed, dialogue_packed])
-  const dictPacked = packArrays(dict.map(d => Buffer.from(d)));
-  const dialoguePacked = packArrays(compressed.map(c => Buffer.from(c)));
-  const langData = packArrays([dictPacked, dialoguePacked]);
-
-  // 4. Font data from ROM (2-bit tile format)
-  const fontData = Buffer.from(rom.getBytes(0x8E8000, 256 * 16));
-  const fontWidth = Buffer.from(rom.getBytes(0x8ECADF, 99));
-  const fontPacked = packArrays([fontData, fontWidth]);
-
-  // 5. Language mapping
-  const flags = usesNewFormat(lang) ? 1 : 0;
-  const mappingData = packArrays([
-    Buffer.from(lang, 'utf8'),
-    Buffer.from([0, 0, flags]),
-  ]);
-
-  A.addPacked('kDialogue', [langData]);
-  A.addPacked('kDialogueFont', [fontPacked]);
-  A.addPacked('kDialogueMap', [mappingData]);
+  A.addPacked('kDialogue', all.map((e) => e.langData));
+  A.addPacked('kDialogueFont', all.map((e) => e.fontPacked));
+  A.addPacked('kDialogueMap', all.map((e, i) =>
+    packArrays([Buffer.from(e.code, 'utf8'), Buffer.from([i, i, e.flags])])));
 };
 
 export { buildDialogue };

--- a/shared/asset-extraction/compile-resources.ts
+++ b/shared/asset-extraction/compile-resources.ts
@@ -12,12 +12,15 @@ import { buildOverworldCompressed, buildOverworldTables } from './compile-overwo
 import { buildDungeonRooms, buildDefaultAndOverlayRooms, buildDungeonSecrets, buildDungeonAttrs, buildEnemyDamageData, buildDungeonSprites, buildDungeonMap } from './compile-dungeons';
 import { buildDialogue } from './compile-dialogue';
 import { buildSoundBanks } from './compile-sound';
+import type { PackedLangEntry } from './text/build-language-entry';
 
 interface CompileOptions {
   /** If true, skip dialogue (requires language extraction) */
   skipDialogue?: boolean;
   /** If true, skip sound banks (requires music compiler) */
   skipMusic?: boolean;
+  /** Extra language packs to bake in alongside US (index 0). */
+  extraLanguages?: PackedLangEntry[];
 }
 
 const compileResources = (rom: RomData, options: CompileOptions = {}): Buffer => {
@@ -35,7 +38,7 @@ const compileResources = (rom: RomData, options: CompileOptions = {}): Buffer =>
   buildSpriteGfx(rom, A);
   buildBgGfx(rom, A);
   buildMisc(rom, A);
-  if (!options.skipDialogue) buildDialogue(rom, A);
+  if (!options.skipDialogue) buildDialogue(rom, A, options.extraLanguages);
   buildDungeonMap(rom, A);
   buildTilemaps(rom, A);
   buildOverworldCompressed(rom, A);

--- a/shared/asset-extraction/text/build-language-entry.ts
+++ b/shared/asset-extraction/text/build-language-entry.ts
@@ -1,0 +1,107 @@
+/* @layer shared-asset-extraction @kind logic */
+/**
+ * Build the binary dialogue + font entry the game core expects for one language.
+ *
+ * The core's kDialogue / kDialogueFont / kDialogueMap are parallel arrays; index 0
+ * is the US ROM, extras follow. ZeldaSetLanguage(code) looks the code up in
+ * kDialogueMap and pulls dialogue/font by the stored index.
+ *
+ * Ported from: core/zelda3/assets/compile_resources.py print_dialogue().
+ */
+import type { RomData } from '../rom/rom-types';
+import type { DialogueLine } from '@shared/types/language';
+import { packArrays } from '../asset-builder';
+import { decodeStrings } from './dialogue-decoder';
+import { compressStrings, encodeDictionary } from './dialogue-encoder';
+import { kLanguages, usesNewFormat } from './data/language-data';
+import { kFontTypes, FONT_TILE_BYTES } from './data/font-data';
+
+/** Extra control string the US ROM omits; inserted at index 4 to reach 397 strings. */
+const EXTRA_STRING = '[Speed 00]0- [Number 00]. 1- [Number 01][2]2- [Number 02]. 3- [Number 03]';
+
+/** Pre-packed per-language data ready to drop into the dialogue arrays. */
+interface PackedLangEntry {
+  code: string;
+  langData: Buffer;
+  fontPacked: Buffer;
+  /** Dialogue map flags: bit0 = new format, bit1 = no US ROM match. */
+  flags: number;
+}
+
+/** Full result of extracting one language from its ROM (persisted by the language store). */
+interface ExtractedLangEntry extends PackedLangEntry {
+  /** Raw 2bpp glyph sheet (256 tiles x 16 bytes). */
+  fontData: Buffer;
+  /** Per-glyph width table. */
+  fontWidth: Buffer;
+  glyphCount: number;
+  lineCount: number;
+  encoder: 'org' | 'new';
+  lines: DialogueLine[];
+}
+
+const dialogueFlags = (code: string, index: number): number => {
+  return (usesNewFormat(code) ? 1 : 0) | (index > 0 ? 2 : 0);
+};
+
+/** Insert the missing control string so a 396-string ROM becomes the canonical 397. */
+const normalizeTexts = (texts: string[]): string[] => {
+  if (texts.length !== 396) return texts;
+  return [...texts.slice(0, 4), EXTRA_STRING, ...texts.slice(4)];
+};
+
+const buildLangData = (texts: string[], code: string): Buffer => {
+  const dictPacked = packArrays(encodeDictionary(code).map((d) => Buffer.from(d)));
+  const dialoguePacked = packArrays(compressStrings(texts, code).map((c) => Buffer.from(c)));
+  return packArrays([dictPacked, dialoguePacked]);
+};
+
+const buildFontPacked = (fontData: Buffer, fontWidth: Buffer): Buffer => {
+  return packArrays([fontData, fontWidth]);
+};
+
+/** Build a fully pre-packed entry from already-decoded texts + persisted font bytes. */
+const buildPackedEntry = (params: {
+  code: string;
+  texts: string[];
+  fontData: Buffer;
+  fontWidth: Buffer;
+  index: number;
+}): PackedLangEntry => {
+  const { code, texts, fontData, fontWidth, index } = params;
+  return {
+    code,
+    langData: buildLangData(texts, code),
+    fontPacked: buildFontPacked(fontData, fontWidth),
+    flags: dialogueFlags(code, index),
+  };
+};
+
+/** Extract a language directly from its ROM (used at US compile time and at pack extraction). */
+const extractLangEntry = (rom: RomData, code: string, index: number): ExtractedLangEntry => {
+  if (!kLanguages[code]) throw new Error(`Unknown language: ${code}`);
+  const font = kFontTypes[code];
+  if (!font) throw new Error(`No font source for language: ${code}`);
+
+  const decoded = decodeStrings((addr) => rom.getByte(addr), code);
+  const texts = normalizeTexts(decoded.map((d) => d.text));
+
+  const fontData = rom.getBytes(font.tileAddr, FONT_TILE_BYTES);
+  const fontWidth = rom.getBytes(font.widthAddr, font.widthCount);
+
+  return {
+    code,
+    langData: buildLangData(texts, code),
+    fontPacked: buildFontPacked(fontData, fontWidth),
+    flags: dialogueFlags(code, index),
+    fontData,
+    fontWidth,
+    glyphCount: font.widthCount,
+    lineCount: texts.length,
+    encoder: kLanguages[code].encoder,
+    lines: texts.map((content, i) => ({ id: i + 1, content })),
+  };
+};
+
+export { extractLangEntry, buildPackedEntry, buildLangData, buildFontPacked, dialogueFlags, EXTRA_STRING };
+export type { PackedLangEntry, ExtractedLangEntry };

--- a/shared/asset-extraction/text/data/font-data.ts
+++ b/shared/asset-extraction/text/data/font-data.ts
@@ -1,0 +1,41 @@
+/* @layer shared-asset-extraction @kind data */
+/**
+ * Per-language dialogue font sources.
+ *
+ * Each language stores its 8x8 2bpp glyph tiles and a per-glyph width table at
+ * language-specific ROM addresses. The official EU ROMs (de/fr/fr-c) keep their
+ * font at a different bank than the US ROM; the translation hacks reuse the US
+ * font slot but vary the glyph count.
+ *
+ * Ported from: core/zelda3/assets/sprite_sheets.py kFontTypes.
+ */
+
+/** Every dialogue font is 256 tiles of 16 bytes (8x8, 2bpp). */
+const FONT_TILE_COUNT = 256;
+const FONT_TILE_BYTES = FONT_TILE_COUNT * 16;
+
+interface FontSource {
+  /** SNES address of the 256-tile 2bpp glyph sheet. */
+  tileAddr: number;
+  /** SNES address of the per-glyph width table. */
+  widthAddr: number;
+  /** Number of glyphs in the width table (the language's effective alphabet size). */
+  widthCount: number;
+}
+
+const kFontTypes: Record<string, FontSource> = {
+  us: { tileAddr: 0x8e8000, widthAddr: 0x8ecadf, widthCount: 99 },
+  de: { tileAddr: 0xcc6e8, widthAddr: 0x8cdecf, widthCount: 112 },
+  fr: { tileAddr: 0xcc6e8, widthAddr: 0x8cdeaf, widthCount: 112 },
+  'fr-c': { tileAddr: 0xcd078, widthAddr: 0x8ce83f, widthCount: 112 },
+  en: { tileAddr: 0x8e8000, widthAddr: 0x8ecaff, widthCount: 102 },
+  es: { tileAddr: 0x8e8000, widthAddr: 0x8ecadf, widthCount: 99 },
+  pl: { tileAddr: 0x8e8000, widthAddr: 0x8ecadf, widthCount: 99 },
+  pt: { tileAddr: 0x8e8000, widthAddr: 0x8ecadf, widthCount: 121 },
+  redux: { tileAddr: 0x8e8000, widthAddr: 0x8ecadf, widthCount: 99 },
+  nl: { tileAddr: 0x8e8000, widthAddr: 0x8ecadf, widthCount: 99 },
+  sv: { tileAddr: 0x8e8000, widthAddr: 0x8ecadf, widthCount: 99 },
+};
+
+export { kFontTypes, FONT_TILE_COUNT, FONT_TILE_BYTES };
+export type { FontSource };

--- a/shared/asset-extraction/text/index.ts
+++ b/shared/asset-extraction/text/index.ts
@@ -4,3 +4,8 @@ export type { LanguageConfig } from './data/language-data';
 export { decodeStrings, decodeStringsWithConfig, formatDialogueText } from './dialogue-decoder';
 export type { DecodedString } from './dialogue-decoder';
 export { compressStrings, encodeDictionary } from './dialogue-encoder';
+export { kFontTypes, FONT_TILE_COUNT, FONT_TILE_BYTES } from './data/font-data';
+export type { FontSource } from './data/font-data';
+export { extractLangEntry, buildPackedEntry, buildLangData, buildFontPacked, dialogueFlags } from './build-language-entry';
+export type { PackedLangEntry, ExtractedLangEntry } from './build-language-entry';
+export { parseDialogueText, dialogueTexts } from './parse-dialogue-text';

--- a/shared/asset-extraction/text/parse-dialogue-text.ts
+++ b/shared/asset-extraction/text/parse-dialogue-text.ts
@@ -1,0 +1,25 @@
+/* @layer shared-asset-extraction @kind logic */
+/**
+ * Parse a stored dialogue.txt dump (the inverse of formatDialogueText) back into
+ * structured lines. Each line is "N: <content>"; content never contains a newline
+ * (control codes are bracketed, e.g. [Scroll]), so a plain line split is safe.
+ */
+import type { DialogueLine } from '@shared/types/language';
+
+const LINE_RE = /^(\d+): (.*)$/;
+
+const parseDialogueText = (text: string): DialogueLine[] => {
+  const lines: DialogueLine[] = [];
+  for (const raw of text.split('\n')) {
+    const m = LINE_RE.exec(raw);
+    if (m) lines.push({ id: Number(m[1]), content: m[2] });
+  }
+  return lines;
+};
+
+/** Just the content strings, ordered by id — ready to feed back to compressStrings. */
+const dialogueTexts = (text: string): string[] => {
+  return parseDialogueText(text).map((l) => l.content);
+};
+
+export { parseDialogueText, dialogueTexts };

--- a/shared/ipc/invoke-contract.ts
+++ b/shared/ipc/invoke-contract.ts
@@ -9,6 +9,7 @@ import type { Profile, AppState } from '@shared/types/profile';
 import type { NormalSaveInfo, AutoSaveInfo, QuickSaveSlotInfo } from '@shared/types/saves';
 import type { PlaySession } from '@shared/types/session';
 import type { ShadowCastingProject, ScreenShadowData } from '@shared/types/shadow-casting';
+import type { LanguagePack, LanguageSummary } from '@shared/types/language';
 
 type Result = { success: boolean; error?: string };
 type MsuResult = { success: boolean; fileCount?: number; error?: string };
@@ -95,12 +96,12 @@ interface InvokeContract {
   'msu:readTrackFile': (packName: string, fileName: string) => Promise<ArrayBuffer>;
 
   // Languages
-  'languages:list': () => Promise<Array<{ code: string; fileCount: number }>>;
+  'languages:list': () => Promise<LanguageSummary[]>;
   'languages:extract': (romFile: string, langCode: string) => Promise<Result>;
   'languages:extractFromFile': (filePath: string, langCode: string) => Promise<Result>;
   'languages:extractFromUrl': (url: string, langCode: string) => Promise<Result>;
   'languages:delete': (langCode: string) => Promise<void>;
-  'languages:getDialogue': (langCode: string) => Promise<string | null>;
+  'languages:getLanguage': (langCode: string) => Promise<LanguagePack | null>;
 
   // Sessions + tracker
   'sessions:list': (profileId: string) => Promise<PlaySession[]>;

--- a/shared/ipc/maps.ts
+++ b/shared/ipc/maps.ts
@@ -70,7 +70,7 @@ const INVOKE_MAP = {
   extractLanguageFromFile: 'languages:extractFromFile',
   extractLanguageFromUrl: 'languages:extractFromUrl',
   deleteLanguage: 'languages:delete',
-  getDialogue: 'languages:getDialogue',
+  getLanguage: 'languages:getLanguage',
   listSessions: 'sessions:list',
   saveSession: 'sessions:save',
   saveTrackerState: 'tracker:save',

--- a/shared/types/language.ts
+++ b/shared/types/language.ts
@@ -1,0 +1,50 @@
+/* @layer shared-types @kind logic */
+/**
+ * Language pack types — shared between the extraction pipeline, the Electron
+ * language store, and the renderer's language inspector UI.
+ */
+
+interface LanguageMeta {
+  /** Language code, e.g. 'fr', 'de', 'fr-c'. */
+  code: string;
+  /** Number of glyphs in the font's width table (effective alphabet size). */
+  glyphCount: number;
+  /** Number of dialogue strings. */
+  lineCount: number;
+  /** Text compression format used by this language. */
+  encoder: 'org' | 'new';
+  /** Dialogue map flags: bit0 = new format, bit1 = no US ROM match. */
+  flags: number;
+  /** Human description of the ROM the pack was extracted from. */
+  source: string;
+}
+
+interface DialogueLine {
+  /** 1-based line number as shown in-game tooling. */
+  id: number;
+  /** Decoded text, including bracketed control tokens (e.g. [Scroll], [Name]). */
+  content: string;
+}
+
+interface LanguageFont {
+  /** Raw 2bpp glyph-sheet bytes (256 tiles x 16 bytes). */
+  tiles: number[];
+  /** Number of glyphs to display from the sheet. */
+  glyphCount: number;
+}
+
+/** Full payload for the language inspector UI. */
+interface LanguagePack {
+  meta: LanguageMeta;
+  lines: DialogueLine[];
+  font: LanguageFont;
+}
+
+/** Summary row for the language list. */
+interface LanguageSummary {
+  code: string;
+  glyphCount: number;
+  lineCount: number;
+}
+
+export type { LanguageMeta, DialogueLine, LanguageFont, LanguagePack, LanguageSummary };

--- a/tests/asset-extraction/dialogue-text-roundtrip.test.ts
+++ b/tests/asset-extraction/dialogue-text-roundtrip.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { formatDialogueText } from '@shared/asset-extraction/text/dialogue-decoder';
+import { parseDialogueText, dialogueTexts } from '@shared/asset-extraction/text/parse-dialogue-text';
+
+/**
+ * Extra language packs are re-compressed from the stored dialogue.txt, so parsing
+ * must be the exact inverse of formatDialogueText — including the control string the
+ * formatter injects when a ROM yields 396 strings.
+ */
+describe('dialogue text round-trip', () => {
+  const asDecoded = (texts: string[]) => texts.map((text) => ({ text, srcData: [] }));
+
+  it('parses ids and content back from a formatted dump', () => {
+    const texts = [
+      'Hello [Name]!',
+      'Press [A] to continue.[Scroll]Then [B].',
+      'Une porte secrète… [Waitkey]',
+    ];
+    const dump = formatDialogueText(asDecoded(texts));
+    const parsed = parseDialogueText(dump);
+
+    expect(parsed).toEqual([
+      { id: 1, content: texts[0] },
+      { id: 2, content: texts[1] },
+      { id: 3, content: texts[2] },
+    ]);
+    expect(dialogueTexts(dump)).toEqual(texts);
+  });
+
+  it('preserves the injected control string for 396-string ROMs', () => {
+    const texts = Array.from({ length: 396 }, (_, i) => `line ${i}`);
+    const dump = formatDialogueText(asDecoded(texts));
+    const parsed = parseDialogueText(dump);
+
+    expect(parsed).toHaveLength(397);
+    // Formatter inserts the extra control string at index 4 (1-based id 5).
+    expect(parsed[4].content).toContain('[Number 00]');
+    expect(parsed[0].content).toBe('line 0');
+  });
+
+  it('ignores blank trailing lines', () => {
+    const dump = '1: first\n2: second\n';
+    expect(parseDialogueText(dump)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Problem

Selecting a language on a profile changed a stored field and the detail display.

1. `loadProfileForGame` read the profile but dropped `profile.language`.
2. `serializeToIni` emitted no `Language` key, so the core got `ZeldaSetLanguage(NULL)`.
3. The asset blob baked **only US** dialogue — `kDialogueMap` had a single entry, so any other code failed the runtime lookup and fell back to English.

This PR fixes all of the above.

## Migration / notes
- People with already extracted language will need to do it again in order for the game to have everything it needs to properly display.