### PR TITLE
Don't send rumble to controllers that don't support vibration

### DIFF
--- a/apps/desktop/electron/input/hid-reader.ts
+++ b/apps/desktop/electron/input/hid-reader.ts
@@ -24,6 +24,7 @@ import { ForwardStats } from './hid-forward-stats';
 import type { WorkerResult, WorkerMessage } from './hid-worker-protocol';
 import { emit } from '../lib/ipc/handle';
 import type { EventContract } from '@shared/ipc';
+import { findController } from '@shared/input/register-all';
 
 class HidInputReader {
   // Non-private so hid-reader-scan can operate on the instance (compile-time only).
@@ -109,10 +110,17 @@ class HidInputReader {
     }
   }
 
+  /** Whether the controller for this device key declares rumble support. */
+  private deviceSupportsVibration(deviceKey: string): boolean {
+    const [vid, pid] = deviceKey.split(':');
+    return findController(vid, pid)?.supportsVibration() ?? false;
+  }
+
   /** Vibrate an HID controller for a given duration and intensity. */
   vibrate(deviceKey: string, durationMs: number, intensity: number): boolean {
     const dev = this.devices.find(d => d.key === deviceKey);
     if (!dev) return false;
+    if (!this.deviceSupportsVibration(deviceKey)) return false;
     const frames = buildSegmentFrames(durationMs, intensity);
     writeFramesDirect(dev, frames);
     return true;
@@ -126,6 +134,9 @@ class HidInputReader {
       this.log(msg);
       this.send('hid:error', { deviceKey, error: msg });
       return { ok: false, error: msg };
+    }
+    if (!this.deviceSupportsVibration(deviceKey)) {
+      return { ok: false, error: 'controller does not support vibration' };
     }
 
     const frames = buildPatternFrames(pattern, gapMs);

--- a/apps/desktop/src/lib/input/haptic-bridge.ts
+++ b/apps/desktop/src/lib/input/haptic-bridge.ts
@@ -15,6 +15,7 @@
 import { handleHapticEvent, setVibrateFunction, updateHapticSettings } from '@shared/input/haptics';
 import type { HapticSettings } from '@shared/input/haptics';
 import type { VibrationSegment } from '@shared/input/base';
+import { findController } from '@shared/input/register-all';
 import { webHidReader } from './hid-reader';
 
 let initialized = false;
@@ -82,7 +83,12 @@ const dispatchVibration = (pattern: VibrationSegment[], gapMs?: number): void =>
 const sendToController = (pattern: VibrationSegment[], gapMs?: number): void => {
   const keys = webHidReader.getConnectedDeviceKeys();
   if (keys.length === 0) return;
-  window.api.vibratePattern(keys[0], pattern, gapMs ?? 0);
+  const key = keys[0];
+  // Only dispatch to controllers that actually rumble. Writing haptic frames to a
+  // non-vibrating pad still pauses its HID read stream, which stalls input.
+  const [vid, pid] = key.split(':');
+  if (!findController(vid, pid)?.supportsVibration()) return;
+  window.api.vibratePattern(key, pattern, gapMs ?? 0);
 };
 
 const scheduleDecay = (ms: number): void => {

--- a/shared/input/data/presets/gamecube-wireless.ts
+++ b/shared/input/data/presets/gamecube-wireless.ts
@@ -17,7 +17,7 @@
  * - NO stick click buttons (no L3/R3)
  */
 
-import { BaseController, type ControllerButton, type ControllerAxis, type ControllerContext, type ParsedInput, type StickDefaults, type VibrationSegment } from '../../base';
+import { BaseController, type ControllerButton, type ControllerAxis, type ControllerContext, type ParsedInput, type StickDefaults } from '../../base';
 import { registerController } from '../../registry';
 import type { ButtonMapping, ButtonIcon } from '../../../types/controls';
 import { icon, btn, axis } from './builders';
@@ -68,9 +68,6 @@ const ICONS: Record<string, ButtonIcon> = {
 
 // ── Haptic Patterns ──
 
-const HAPTIC_STRONG: number[] = [0x93, 0x35, 0x36, 0x1c, 0x0d];
-const HAPTIC_MEDIUM: number[] = [0x75, 0x19, 0x41, 0x9b, 0x03];
-const HAPTIC_LIGHT:  number[] = [0x48, 0x71, 0x20, 0x5a, 0x02];
 const HAPTIC_SILENT: number[] = [0x3f, 0x01, 0xf0, 0x19, 0x00];
 
 // ── SNES Button Mappings ──
@@ -424,47 +421,6 @@ class GameCubeWirelessController extends BaseController {
   // ── Haptics ──
 
   supportsVibration(): boolean { return false; }
-
-  async vibrate(ctx: ControllerContext, pattern: VibrationSegment[], gapMs: number = 0): Promise<{ ok: boolean; error?: string }> {
-    const segments: { haptic: number[]; frames: number }[] = [];
-    for (const seg of pattern) {
-      const clamped = Math.max(0, Math.min(1, seg.intensity));
-      const haptic = clamped >= 0.7 ? HAPTIC_STRONG
-        : clamped >= 0.3 ? HAPTIC_MEDIUM
-        : HAPTIC_LIGHT;
-      segments.push({ haptic, frames: Math.max(1, Math.ceil(seg.durationMs / 4)) });
-    }
-
-    const gapFrames = Math.max(0, Math.ceil(gapMs / 4));
-    let counter = 0;
-    let errors = 0;
-
-    for (let s = 0; s < segments.length; s++) {
-      const { haptic, frames } = segments[s];
-      for (let i = 0; i < frames; i++) {
-        const buf = this.buildHapticFrame(haptic, counter);
-        const ok = await ctx.hidWrite(buf);
-        if (!ok) errors++;
-        counter = (counter + 1) & 0x0F;
-      }
-      if (gapFrames > 0 && s < segments.length - 1) {
-        for (let i = 0; i < gapFrames; i++) {
-          const buf = this.buildHapticFrame(HAPTIC_SILENT, counter);
-          const ok = await ctx.hidWrite(buf);
-          if (!ok) errors++;
-          counter = (counter + 1) & 0x0F;
-        }
-      }
-    }
-
-    // End with silence
-    const silentBuf = this.buildHapticFrame(HAPTIC_SILENT, counter);
-    await ctx.hidWrite(silentBuf);
-
-    return errors === 0
-      ? { ok: true }
-      : { ok: false, error: `${errors} HID write(s) failed` };
-  }
 
   private buildHapticFrame(pattern: number[], counter: number): number[] {
     // Report 0x10: rumble only

--- a/shared/input/data/presets/switch-pro-2.ts
+++ b/shared/input/data/presets/switch-pro-2.ts
@@ -11,7 +11,7 @@
  * - 21 buttons including grip buttons (GL/GR) and C button
  */
 
-import { BaseController, type ControllerButton, type ControllerAxis, type ControllerContext, type ParsedInput, type StickDefaults, type VibrationSegment } from '../../base';
+import { BaseController, type ControllerButton, type ControllerAxis, type ControllerContext, type ParsedInput, type StickDefaults } from '../../base';
 import { registerController } from '../../registry';
 import type { ButtonMapping, ButtonIcon } from '../../../types/controls';
 import { icon, btn, axis } from './builders';
@@ -154,9 +154,6 @@ const INIT_SEQUENCE: number[][] = [
 
 // ── Haptic Patterns ──
 
-const HAPTIC_STRONG: number[] = [0x93, 0x35, 0x36, 0x1c, 0x0d];
-const HAPTIC_MEDIUM: number[] = [0x75, 0x19, 0x41, 0x9b, 0x03];
-const HAPTIC_LIGHT:  number[] = [0x48, 0x71, 0x20, 0x5a, 0x02];
 const HAPTIC_SILENT: number[] = [0x3f, 0x01, 0xf0, 0x19, 0x00];
 
 // ── SNES Button Mappings ──
@@ -423,55 +420,6 @@ class SwitchPro2Controller extends BaseController {
   // ── Haptics ──
 
   supportsVibration(): boolean { return true; }
-
-  async vibrate(ctx: ControllerContext, pattern: VibrationSegment[], gapMs: number = 0): Promise<{ ok: boolean; error?: string }> {
-    // Ensure USB init has been performed (haptic engine must be enabled)
-    if (!this.usbInitDone.has(ctx.deviceKey)) {
-      await this.init(ctx);
-    }
-
-    const segments: { haptic: number[]; frames: number }[] = [];
-    for (const seg of pattern) {
-      const clamped = Math.max(0, Math.min(1, seg.intensity));
-      const haptic = clamped >= 0.7 ? HAPTIC_STRONG
-        : clamped >= 0.3 ? HAPTIC_MEDIUM
-        : HAPTIC_LIGHT;
-      segments.push({ haptic, frames: Math.max(1, Math.ceil(seg.durationMs / 4)) });
-    }
-
-    const gapFrames = Math.max(0, Math.ceil(gapMs / 4));
-    let counter = 0;
-    let errors = 0;
-
-    for (let s = 0; s < segments.length; s++) {
-      const { haptic, frames } = segments[s];
-      for (let i = 0; i < frames; i++) {
-        const buf = this.buildHapticFrame(haptic, counter);
-        const ok = await ctx.hidWrite(buf);
-        if (!ok) errors++;
-        counter = (counter + 1) & 0x0F;
-      }
-      // Gap between segments
-      if (gapFrames > 0 && s < segments.length - 1) {
-        for (let i = 0; i < gapFrames; i++) {
-          const buf = this.buildHapticFrame(HAPTIC_SILENT, counter);
-          const ok = await ctx.hidWrite(buf);
-          if (!ok) errors++;
-          counter = (counter + 1) & 0x0F;
-        }
-      }
-    }
-
-    // End with silence
-    const buf = this.buildHapticFrame(HAPTIC_SILENT, counter);
-    const ok = await ctx.hidWrite(buf);
-    if (!ok) errors++;
-
-    if (errors > 0) {
-      return { ok: false, error: `${errors} frame write(s) failed` };
-    }
-    return { ok: true };
-  }
 
   // ── Stick Defaults ──
 

--- a/shared/input/data/presets/switch-pro.ts
+++ b/shared/input/data/presets/switch-pro.ts
@@ -11,7 +11,7 @@
  * - 17 buttons
  */
 
-import { BaseController, type ControllerButton, type ControllerAxis, type ControllerContext, type ParsedInput, type StickDefaults, type VibrationSegment } from '../../base';
+import { BaseController, type ControllerButton, type ControllerAxis, type ControllerContext, type ParsedInput, type StickDefaults } from '../../base';
 import { registerController } from '../../registry';
 import type { ButtonMapping, ButtonIcon } from '../../../types/controls';
 import { icon, btn } from './builders';
@@ -41,9 +41,6 @@ const ICONS: Record<string, ButtonIcon> = {
 
 // ── Haptic Patterns ──
 
-const HAPTIC_STRONG: number[] = [0x93, 0x35, 0x36, 0x1c, 0x0d];
-const HAPTIC_MEDIUM: number[] = [0x75, 0x19, 0x41, 0x9b, 0x03];
-const HAPTIC_LIGHT:  number[] = [0x48, 0x71, 0x20, 0x5a, 0x02];
 const HAPTIC_SILENT: number[] = [0x3f, 0x01, 0xf0, 0x19, 0x00];
 
 // ── HID Init ──
@@ -253,48 +250,6 @@ class SwitchProController extends BaseController {
   // ── Haptics ──
 
   supportsVibration(): boolean { return true; }
-
-  async vibrate(ctx: ControllerContext, pattern: VibrationSegment[], gapMs: number = 0): Promise<{ ok: boolean; error?: string }> {
-    const segments: { haptic: number[]; frames: number }[] = [];
-    for (const seg of pattern) {
-      const clamped = Math.max(0, Math.min(1, seg.intensity));
-      const haptic = clamped >= 0.7 ? HAPTIC_STRONG
-        : clamped >= 0.3 ? HAPTIC_MEDIUM
-        : HAPTIC_LIGHT;
-      segments.push({ haptic, frames: Math.max(1, Math.ceil(seg.durationMs / 4)) });
-    }
-
-    const gapFrames = Math.max(0, Math.ceil(gapMs / 4));
-    let counter = 0;
-    let errors = 0;
-
-    for (let s = 0; s < segments.length; s++) {
-      const { haptic, frames } = segments[s];
-      for (let i = 0; i < frames; i++) {
-        const buf = this.buildHapticFrame(haptic, counter);
-        const ok = await ctx.hidWrite(buf);
-        if (!ok) errors++;
-        counter = (counter + 1) & 0x0F;
-      }
-      if (gapFrames > 0 && s < segments.length - 1) {
-        for (let i = 0; i < gapFrames; i++) {
-          const buf = this.buildHapticFrame(HAPTIC_SILENT, counter);
-          const ok = await ctx.hidWrite(buf);
-          if (!ok) errors++;
-          counter = (counter + 1) & 0x0F;
-        }
-      }
-    }
-
-    // End with silence
-    const ok = await ctx.hidWrite(this.buildHapticFrame(HAPTIC_SILENT, counter));
-    if (!ok) errors++;
-
-    if (errors > 0) {
-      return { ok: false, error: `${errors} frame write(s) failed` };
-    }
-    return { ok: true };
-  }
 
   // ── Stick Defaults ──
 


### PR DESCRIPTION
## Problem

On a controller that doesn't support rumble (e.g. the NSO SNES that we just opened a PR for), holding or spamming a button like charging a spin attack froze movement for ~1 second at a time.

## Root cause

The haptic bridge dispatched every game vibration event to the first connected HID device. Controller didn't know how to handle that and froze the game until haptics run was done.

## Fix

Gate `sendToController()` on the resolved controller's `supportsVibration()`, so non-rumble controllers never receive haptic writes.