### PR TITLE
Hide the native HUD on normal game start

### DIFF
--- a/apps/desktop/src/lib/game/lifecycle.ts
+++ b/apps/desktop/src/lib/game/lifecycle.ts
@@ -11,7 +11,7 @@ import { getModule, setModule, setProfileId, getProfileId, setState, setInput, g
 import { startSramSync, stopSramSync } from './sram-sync';
 import { startAutoSave, stopAutoSave, saveOnQuit } from './auto-save';
 import { resetMasterVolume } from './audio-volume';
-import { reassertVolumes } from './live-settings';
+import { reassertLiveFlagsAfterLoad } from './live-settings';
 import { initTrackerBridge, destroyTrackerBridge } from './tracker';
 import { startSession, endSession } from './session-tracker';
 import { getInputManager } from '../input/input-manager';
@@ -205,8 +205,11 @@ const startGame = async (canvas: HTMLCanvasElement, assetData: Uint8Array, confi
     log.wasm('WASM module running');
     canvas.focus();
 
-    // ─── Apply saved volume settings immediately ───
-    reassertVolumes();
+    // ─── Apply saved live flags (HUD/pause/backdrop hide, volumes) immediately ───
+    // A freshly-loaded module starts with every flag at default, so push the primed
+    // values now — otherwise the native HUD-hide flag stays off and the original HUD
+    // renders alongside the enhanced overlay.
+    reassertLiveFlagsAfterLoad();
 
     // ─── Input manager: wire JS-driven input to WASM ───
     const inputMgr = getInputManager();


### PR DESCRIPTION
@
When the enhanced HUD is on, starting the game normally showed both the new overlay and the old native HUD at once. The native HUD is hidden by a WASM flag that only got pushed after a save-state load, never on a fresh start, so the original HUD stayed visible until you loaded a state.

The start path now re-asserts the full set of primed live flags (HUD/pause/backdrop hide, volumes) once the module is running, the same way the save-state load path already does.
@