### PR TITLE
Fix macOS "damaged" Gatekeeper error

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Download the latest build for your platform from the
 | Platform | Download |
 |----------|----------|
 | Windows  | Portable `.exe` or Installer `.exe` |
-| macOS    | `.dmg` |
+| macOS \* | `.dmg` |
 | Linux    | `.AppImage` or `.deb` |
+
+\* Special instruction. See [here](https://github.com/drizztdourden08/relic-of-the-past/wiki/Getting-Started-Installation#relic-of-the-past-is-damaged-and-cant-be-opened).
 
 Then launch the app and select your ROM when prompted. See the [Quick Start](docs/getting-started/quick-start.md)
 and [Installation](docs/getting-started/installation.md) guides for details.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,9 +62,24 @@ The app isn't code-signed, so Windows may show a "Windows protected your PC" war
 
 1. Open the `.dmg` file
 2. Drag **Relic of the Past** into the Applications folder
-3. On first launch, right-click and choose **Open** to get past Gatekeeper, since the app is unsigned
+3. On first launch, right-click the app and choose **Open**, then confirm in the dialog
 
-macOS may say the app is from an unidentified developer. Right-click and choose Open to get past it.
+The app is ad-hoc signed but not notarized by Apple, so macOS shows it as coming
+from an unidentified developer. Right-click → **Open** clears this, and you only
+see it once.
+
+### "Relic of the Past is damaged and can't be opened"
+
+If macOS says the app is **damaged** and offers only to move it to the Bin, the
+file picked up a quarantine flag during download. The app isn't actually damaged.
+Clear the flag in Terminal:
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/Relic of the Past.app"
+```
+
+Then open the app normally. Alternatively, copying the `.dmg` onto the Mac from a
+USB drive or another computer avoids the quarantine flag entirely.
 
 Auto-update is supported on macOS via the `.zip` companion file included in each release.
 

--- a/scripts/build/electron-builder.config.js
+++ b/scripts/build/electron-builder.config.js
@@ -43,6 +43,10 @@ module.exports = {
     target: ['dmg', 'zip'],
     icon: 'apps/web/public/logos/logo-512.png',
     artifactName: 'rotp-macos.${ext}',
+    // Ad-hoc signature (no Apple Developer ID). On Apple Silicon this stops
+    // Gatekeeper reporting the app as "damaged"; users still right-click → Open
+    // once to clear the unidentified-developer prompt.
+    identity: '-',
   },
   linux: {
     target: ['AppImage', 'deb'],


### PR DESCRIPTION
Fixes #17

- Ad-hoc sign the macOS build so Apple Silicon stops flagging it as damaged.
- Document the quarantine workaround in the installation docs and README.