### PR TITLE
Fix dual-layer BFS reachability (void constraint, ledge crossing, 1-wide ledges)

### DIFF
--- a/apps/web/src/App/behavior/dump-nav/builders.ts
+++ b/apps/web/src/App/behavior/dump-nav/builders.ts
@@ -27,6 +27,7 @@ interface FloodFillDumpInput {
   dualLayerGrids: { layer0: number[][]; layer1: number[][]; stairTiles: Array<{ row: number; col: number }> } | null;
   linkLayer: 0 | 1 | null;
   staircaseType: number | null;
+  startPos?: { row: number; col: number };
   roomLayout: {
     intraEdges?: EdgeName[];
     shape?: string;
@@ -93,19 +94,31 @@ const formatTravelDests = (travelDests: number[] | null): TravelDest[] | null =>
     label: i === 0 ? 'pit/block' : `stair${i - 1}`,
   })).filter(td => td.room !== 0) : null;
 
-const computeFloodFill = (input: FloodFillDumpInput): FloodFillDump | null => {
-  const { roomIndex, attrGrid, dualLayerGrids, linkLayer, staircaseType, roomLayout } = input;
-  if (!attrGrid) return null;
-
-  // Convert flat Uint8Array to 64x64 grid
+const toGrid = (flat: Uint8Array): number[][] => {
   const grid: number[][] = [];
   for (let r = 0; r < 64; r++) {
-    grid.push(Array.from(attrGrid.slice(r * 64, (r + 1) * 64)));
+    grid.push(Array.from(flat.slice(r * 64, (r + 1) * 64)));
   }
+  return grid;
+};
+
+/** Encode the reachable grid as 64 strings of base-36 ReachState digits (0 = unreachable). */
+const encodeReachableRows = (reachable: number[][]): string[] =>
+  reachable.map(row => row.map(v => v.toString(36)).join(''));
+
+/** Encode a raw attr grid as 64 strings of 2-char hex bytes (for baselines/diagnosis). */
+const encodeAttrRows = (grid: number[][]): string[] =>
+  grid.map(row => row.map(v => v.toString(16).padStart(2, '0')).join(''));
+
+const computeFloodFill = (input: FloodFillDumpInput): FloodFillDump | null => {
+  const { roomIndex, attrGrid, dualLayerGrids, linkLayer, staircaseType, roomLayout, startPos } = input;
+  if (!attrGrid) return null;
+
+  const grid = toGrid(attrGrid);
   const opts: FloodFillOptions = {
     tileContext: 'interior-dungeon',
     inventory: new Set(),
-    startPos: undefined,
+    startPos,
     dualLayerGrids: dualLayerGrids ?? undefined,
     stairTiles: dualLayerGrids?.stairTiles,
     startLayer: linkLayer ?? undefined,
@@ -141,6 +154,12 @@ const computeFloodFill = (input: FloodFillDumpInput): FloodFillDump | null => {
   return {
     reachableCount: result.reachableCount,
     totalTiles: result.totalTiles,
+    reachableRows: encodeReachableRows(result.reachable),
+    ledges: result.ledges.map(({ startRow, startCol, endRow, endCol }) => ({ startRow, startCol, endRow, endCol })),
+    attrRows: {
+      layer0: encodeAttrRows(dualLayerGrids?.layer0 ?? grid),
+      layer1: dualLayerGrids ? encodeAttrRows(dualLayerGrids.layer1) : null,
+    },
     connections: connections.map(c => ({
       edge: c.edge,
       targetScreen: c.targetScreen,
@@ -162,4 +181,32 @@ const computeFloodFill = (input: FloodFillDumpInput): FloodFillDump | null => {
   };
 };
 
-export { collectEntranceData, formatStairs, formatTravelDests, computeFloodFill };
+const computeOverworldFloodFill = (
+  screenIndex: number,
+  attrGrid: Uint8Array | null,
+  startPos?: { row: number; col: number },
+): FloodFillDump | null => {
+  if (!attrGrid) return null;
+
+  const result = floodFillScreen(toGrid(attrGrid), screenIndex, { tileContext: 'overworld', inventory: new Set(), startPos });
+  const connections = getConnections(result);
+
+  return {
+    reachableCount: result.reachableCount,
+    totalTiles: result.totalTiles,
+    reachableRows: encodeReachableRows(result.reachable),
+    ledges: result.ledges.map(({ startRow, startCol, endRow, endCol }) => ({ startRow, startCol, endRow, endCol })),
+    attrRows: { layer0: encodeAttrRows(toGrid(attrGrid)), layer1: null },
+    connections: connections.map(c => ({
+      edge: c.edge,
+      targetScreen: c.targetScreen,
+      targetScreenHex: `0x${c.targetScreen.toString(16).padStart(4, '0')}`,
+      freeTileCount: c.freeTileCount,
+      itemTileCount: c.itemTileCount,
+      positions: c.positions,
+    })),
+    scrollBoundary: null,
+  };
+};
+
+export { collectEntranceData, formatStairs, formatTravelDests, computeFloodFill, computeOverworldFloodFill };

--- a/apps/web/src/App/behavior/dump-nav/types.ts
+++ b/apps/web/src/App/behavior/dump-nav/types.ts
@@ -37,6 +37,12 @@ interface TravelDest {
 interface FloodFillDump {
   reachableCount: number;
   totalTiles: number;
+  /** 64 rows of 64 base-36 chars — one ReachState digit per tile (0 = unreachable). */
+  reachableRows: string[];
+  /** One-way ledge traversals produced by cliff preprocessing (start → landing). */
+  ledges: Array<{ startRow: number; startCol: number; endRow: number; endCol: number }>;
+  /** Raw attr grids as 64 rows of 2-char hex bytes; layer1 only for dual-layer rooms. */
+  attrRows: { layer0: string[]; layer1: string[] | null };
   connections: unknown[];
   scrollBoundary: unknown;
 }

--- a/apps/web/src/App/behavior/useDumpNav.ts
+++ b/apps/web/src/App/behavior/useDumpNav.ts
@@ -26,12 +26,14 @@ import {
   wasmGetLinkLayer,
   wasmGetStaircaseType,
   wasmBuildRoomAttrGrid,
+  wasmBuildOverworldAttrGrid,
   wasmGetToggleFloorPositions,
   wasmGetIndoorDualLayerGrids,
 } from '../../lib/game';
 import { resolveCurrentScreenDetailed } from '@shared/game/data/screens';
 import type { VariantGameState } from '@shared/game/data/screens';
-import { collectEntranceData, formatStairs, formatTravelDests, computeFloodFill } from './dump-nav/builders';
+import { collectEntranceData, formatStairs, formatTravelDests, computeFloodFill, computeOverworldFloodFill } from './dump-nav/builders';
+import { linkStartTile } from '@shared/game/navigation/link-start-tile';
 
 interface DumpNavDeps {
   activeProfile: Profile | null;
@@ -132,11 +134,20 @@ const useDumpNav = ({ activeProfile, loadProfileForGame }: DumpNavDeps) => {
       const toggleFloorPositions = isIndoors ? wasmGetToggleFloorPositions() : [];
 
       // ─── Flood fill + connections (for internal edge verification) ───
+      // Seed the flood from Link's hitbox tile (same derivation as the navigation widget).
+      const startPos = viewport
+        ? linkStartTile({
+            linkX: viewport.linkX,
+            linkY: viewport.linkY,
+            screenWorldX: isIndoors ? Math.floor(viewport.linkX / 512) * 512 : (overworldScreenIndex & 7) * 512,
+            screenWorldY: isIndoors ? Math.floor(viewport.linkY / 512) * 512 : ((overworldScreenIndex >> 3) & 7) * 512,
+          })
+        : undefined;
       const floodFillData = isIndoors
         ? computeFloodFill({
-            roomIndex, attrGrid, dualLayerGrids: wasmGetIndoorDualLayerGrids(), linkLayer, staircaseType, roomLayout,
+            roomIndex, attrGrid, dualLayerGrids: wasmGetIndoorDualLayerGrids(), linkLayer, staircaseType, roomLayout, startPos,
           })
-        : null;
+        : computeOverworldFloodFill(overworldScreenIndex, wasmBuildOverworldAttrGrid(overworldScreenIndex), startPos);
 
       const dump = {
         slot,
@@ -197,6 +208,7 @@ const useDumpNav = ({ activeProfile, loadProfileForGame }: DumpNavDeps) => {
           intraEdges: roomLayout.intraEdges,
         } : null,
         linkLayer,
+        linkStart: startPos ?? null,
         staircaseType,
         toggleFloorPositions: toggleFloorPositions.map(p => ({
           pos: `0x${p.pos.toString(16).padStart(4, '0')}`,

--- a/apps/web/src/ui/domains/widgets/navigation/nav-flood/prepare.ts
+++ b/apps/web/src/ui/domains/widgets/navigation/nav-flood/prepare.ts
@@ -7,6 +7,7 @@ import {
 import type { wasmGetViewportInfo } from '../../../../../lib/game';
 import { getCompletedChecks } from '../../../../../lib/game/tracker';
 import type { TileAttrContext } from '@shared/game/navigation/tile-attrs';
+import { linkStartTile } from '@shared/game/navigation/link-start-tile';
 
 type Point = { x: number; y: number };
 type DualLayerGrids = { layer0: number[][]; layer1: number[][]; stairTiles: Array<{ row: number; col: number }> };
@@ -124,35 +125,7 @@ const computeStartContext = (args: {
       ? (Math.floor(vp.linkY / 512) * 512)
       : (((primaryScreenIndex >> 3) & 7) * 512);
 
-    const relPixelX = vp.linkX - screenWorldX;
-    const relPixelY = (vp.linkY + 8) - screenWorldY; // collision hitbox starts 8px below sprite top
-
-    // Match overlay debug footprint: Link's hitbox is the lower 16x16 (skip head).
-    const tileMinCol = Math.floor(relPixelX / 8);
-    const tileMaxCol = Math.floor((relPixelX + 15) / 8);
-    const tileMinRow = Math.floor(relPixelY / 8);
-    const tileMaxRow = Math.floor((relPixelY + 15) / 8);
-
-    const centerCol = relPixelX / 8 + 0.5;
-    const centerRow = relPixelY / 8 + 0.5;
-    const clamp = (v: number) => Math.max(0, Math.min(63, v));
-
-    let best: { row: number; col: number } | null = null;
-    let bestD2 = Number.POSITIVE_INFINITY;
-    for (let r = tileMinRow; r <= tileMaxRow; r++) {
-      for (let c = tileMinCol; c <= tileMaxCol; c++) {
-        const rr = clamp(r);
-        const cc = clamp(c);
-        const dr = rr - centerRow;
-        const dc = cc - centerCol;
-        const d2 = dr * dr + dc * dc;
-        if (d2 < bestD2) {
-          bestD2 = d2;
-          best = { row: rr, col: cc };
-        }
-      }
-    }
-    startPos = best ?? { row: clamp(Math.floor(centerRow)), col: clamp(Math.floor(centerCol)) };
+    startPos = linkStartTile({ linkX: vp.linkX, linkY: vp.linkY, screenWorldX, screenWorldY });
   }
 
   return { startPos, tileContext, rawAttrGrid, dualLayerGrids, linkLayer };

--- a/shared/game/navigation/flood-fill/screen-prep.ts
+++ b/shared/game/navigation/flood-fill/screen-prep.ts
@@ -53,18 +53,56 @@ const prepareScreen = (rawAttrGrid: number[][], tileContext: TileAttrContext, dy
   return { grid, ledges, dynamicBlockerCells };
 };
 
+/** Max boundary-gap width still considered a doorway (standard dungeon passages are 4 tiles). */
+const DOORWAY_MAX_WIDTH = 6;
+
+/**
+ * Boundary 0x00 cells that are safe to seed the void flood from. Walkable exit corridors
+ * (room transitions) reach the grid edge as narrow, wall-flanked gaps — standard dungeon
+ * doorways are 4 tiles wide — and must NOT seed the flood, or it walks up the corridor and
+ * wipes the room's real floor (e.g. room 0x72's lower floor via its open south passage).
+ * Structural void touches the edge in wide open spans, which do seed.
+ */
+const collectVoidSeeds = (layer: number[][]): Array<[number, number]> => {
+  const seeds: Array<[number, number]> = [];
+  const edges: Array<{ at: (i: number) => [number, number] }> = [
+    { at: (i) => [0, i] },              // north edge
+    { at: (i) => [GRID_SIZE - 1, i] },  // south edge
+    { at: (i) => [i, 0] },              // west edge
+    { at: (i) => [i, GRID_SIZE - 1] },  // east edge
+  ];
+
+  for (const edge of edges) {
+    let runStart = -1;
+    for (let i = 0; i <= GRID_SIZE; i++) {
+      const isOpen = i < GRID_SIZE && layer[edge.at(i)[0]][edge.at(i)[1]] === 0x00;
+      if (isOpen && runStart < 0) runStart = i;
+      if (isOpen || runStart < 0) continue;
+
+      // Run [runStart, i) ended — a doorway needs walls on BOTH flanks (grid corners don't count).
+      const runLen = i - runStart;
+      const hasFlankBefore = runStart > 0;
+      const hasFlankAfter = i < GRID_SIZE;
+      const isDoorway = runLen <= DOORWAY_MAX_WIDTH && hasFlankBefore && hasFlankAfter;
+      if (!isDoorway) {
+        for (let j = runStart; j < i; j++) seeds.push(edge.at(j));
+      }
+      runStart = -1;
+    }
+  }
+  return seeds;
+};
+
 const constrainVoidTiles = (thisLayer: number[][], _otherLayer: number[][]): number[][] => {
-  // Step 1: Flood from boundary through 0x00 tiles to find void-connected regions
+  // Step 1: Flood from boundary through 0x00 tiles to find void-connected regions,
+  // seeding only from wide-open boundary spans (doorway gaps are walkable exits).
   const isVoid: boolean[][] = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(false));
   const queue: Array<[number, number]> = [];
 
-  for (let r = 0; r < GRID_SIZE; r++) {
-    for (let c = 0; c < GRID_SIZE; c++) {
-      if ((r === 0 || r === GRID_SIZE - 1 || c === 0 || c === GRID_SIZE - 1) && thisLayer[r][c] === 0x00) {
-        isVoid[r][c] = true;
-        queue.push([r, c]);
-      }
-    }
+  for (const [r, c] of collectVoidSeeds(thisLayer)) {
+    if (isVoid[r][c]) continue;
+    isVoid[r][c] = true;
+    queue.push([r, c]);
   }
   while (queue.length > 0) {
     const [qr, qc] = queue.shift()!;

--- a/shared/game/navigation/link-start-tile.ts
+++ b/shared/game/navigation/link-start-tile.ts
@@ -1,0 +1,46 @@
+/* @layer shared-game @kind logic */
+/** Convert Link's world-pixel position to his flood-fill start tile on a 64×64 screen grid. */
+
+interface LinkStartTileArgs {
+  linkX: number;
+  linkY: number;
+  screenWorldX: number;
+  screenWorldY: number;
+}
+
+/**
+ * Nearest tile of Link's 16×16 collision hitbox (the lower half of the sprite —
+ * head skipped, hitbox starts 8px below sprite top), matching the overlay debug footprint.
+ */
+const linkStartTile = ({ linkX, linkY, screenWorldX, screenWorldY }: LinkStartTileArgs): { row: number; col: number } => {
+  const relPixelX = linkX - screenWorldX;
+  const relPixelY = (linkY + 8) - screenWorldY;
+
+  const tileMinCol = Math.floor(relPixelX / 8);
+  const tileMaxCol = Math.floor((relPixelX + 15) / 8);
+  const tileMinRow = Math.floor(relPixelY / 8);
+  const tileMaxRow = Math.floor((relPixelY + 15) / 8);
+
+  const centerCol = relPixelX / 8 + 0.5;
+  const centerRow = relPixelY / 8 + 0.5;
+  const clamp = (v: number) => Math.max(0, Math.min(63, v));
+
+  let best: { row: number; col: number } | null = null;
+  let bestD2 = Number.POSITIVE_INFINITY;
+  for (let r = tileMinRow; r <= tileMaxRow; r++) {
+    for (let c = tileMinCol; c <= tileMaxCol; c++) {
+      const rr = clamp(r);
+      const cc = clamp(c);
+      const dr = rr - centerRow;
+      const dc = cc - centerCol;
+      const d2 = dr * dr + dc * dc;
+      if (d2 < bestD2) {
+        bestD2 = d2;
+        best = { row: rr, col: cc };
+      }
+    }
+  }
+  return best ?? { row: clamp(Math.floor(centerRow)), col: clamp(Math.floor(centerCol)) };
+};
+
+export { linkStartTile };

--- a/shared/game/navigation/screen-data/cliff-preprocessing.ts
+++ b/shared/game/navigation/screen-data/cliff-preprocessing.ts
@@ -1,13 +1,10 @@
 /* @layer shared-game @kind logic */
 import type { TilePassability, LedgeTraversal } from '../types';
 import { GRID_SIZE } from '../types';
+import { computeIndoorLedgeDirs, HORIZ_LEDGE_ATTRS, VERT_LEDGE_ATTRS } from './indoor-ledge-dirs';
 
 const processStraightCliffs = (grid: TilePassability[][], rawAttr: number[][], ledges: LedgeTraversal[], isIndoors = false): void => {
   const CLIFF_TRIGGERS = new Set([0x28, 0x29, 0x2a, 0x2b, 0x2f]);
-  // Horizontal ledge attrs (0x2a/0x2b) — direction inferred from surrounding walls
-  const HORIZ_LEDGE_ATTRS = new Set([0x2a, 0x2b]);
-  // Vertical ledge attrs (0x28/0x29) — direction inferred from surrounding walls
-  const VERT_LEDGE_ATTRS = new Set([0x28, 0x29]);
   // Outdoors: fixed directions; Indoors: 0x28/0x29/0x2a/0x2b use wall inference, only 0x2f is hardcoded
   const CLIFF_DIRS: Record<number, { dr: number; dc: number; dir: 'n' | 's' | 'e' | 'w' }> = isIndoors
     ? {
@@ -25,6 +22,10 @@ const processStraightCliffs = (grid: TilePassability[][], rawAttr: number[][], l
     ? new Set([0x01, 0x02, 0x03, 0x04, 0x1a, 0x12, 0x13, 0x1b])
     : new Set([0x01, 0x02, 0x03, 0x1a, 0x12, 0x13, 0x1b]);
 
+  // Indoor 0x28/0x29/0x2a/0x2b: precompute every trigger's inferred direction so each
+  // can check its neighbors' directions, not just their attrs.
+  const indoorDirs = isIndoors ? computeIndoorLedgeDirs(rawAttr, CLIFF_WALL) : null;
+
   for (let row = 0; row < GRID_SIZE; row++) {
     for (let col = 0; col < GRID_SIZE; col++) {
       const attr = rawAttr[row][col];
@@ -32,60 +33,15 @@ const processStraightCliffs = (grid: TilePassability[][], rawAttr: number[][], l
 
       let dr: number, dc: number, dir: 'n' | 's' | 'e' | 'w';
 
-      if (isIndoors && HORIZ_LEDGE_ATTRS.has(attr)) {
-        // 0x2a/0x2b indoor: direction inferred from which side has the cliff face (walls).
-        // The jump goes TOWARD the wall/cliff face and over it.
-        const hasWallEast = col < 63 && CLIFF_WALL.has(rawAttr[row][col + 1]);
-        const hasWallWest = col > 0 && CLIFF_WALL.has(rawAttr[row][col - 1]);
-        if (hasWallEast && !hasWallWest) {
-          dr = 0; dc = 1; dir = 'e';
-        } else if (hasWallWest && !hasWallEast) {
-          dr = 0; dc = -1; dir = 'w';
-        } else {
-          // Ambiguous — check further for walls
-          let wallsEast = 0, wallsWest = 0;
-          for (let d = 1; d <= 3 && col + d < GRID_SIZE; d++) {
-            if (CLIFF_WALL.has(rawAttr[row][col + d])) wallsEast++;
-          }
-          for (let d = 1; d <= 3 && col - d >= 0; d++) {
-            if (CLIFF_WALL.has(rawAttr[row][col - d])) wallsWest++;
-          }
-          if (wallsEast > wallsWest) {
-            dr = 0; dc = 1; dir = 'e';
-          } else if (wallsWest > wallsEast) {
-            dr = 0; dc = -1; dir = 'w';
-          } else {
-            // Default fallback: east
-            dr = 0; dc = 1; dir = 'e';
-          }
-        }
-      } else if (isIndoors && VERT_LEDGE_ATTRS.has(attr)) {
-        // 0x28/0x29 indoor: direction inferred from which side has the cliff face (walls).
-        // The jump goes TOWARD the wall/cliff face and over it.
-        const hasWallSouth = row < 63 && CLIFF_WALL.has(rawAttr[row + 1][col]);
-        const hasWallNorth = row > 0 && CLIFF_WALL.has(rawAttr[row - 1][col]);
-        if (hasWallSouth && !hasWallNorth) {
-          dr = 1; dc = 0; dir = 's';
-        } else if (hasWallNorth && !hasWallSouth) {
-          dr = -1; dc = 0; dir = 'n';
-        } else {
-          // Ambiguous — check further for walls
-          let wallsSouth = 0, wallsNorth = 0;
-          for (let d = 1; d <= 3 && row + d < GRID_SIZE; d++) {
-            if (CLIFF_WALL.has(rawAttr[row + d][col])) wallsSouth++;
-          }
-          for (let d = 1; d <= 3 && row - d >= 0; d++) {
-            if (CLIFF_WALL.has(rawAttr[row - d][col])) wallsNorth++;
-          }
-          if (wallsSouth > wallsNorth) {
-            dr = 1; dc = 0; dir = 's';
-          } else if (wallsNorth > wallsSouth) {
-            dr = -1; dc = 0; dir = 'n';
-          } else {
-            // Default fallback: south
-            dr = 1; dc = 0; dir = 's';
-          }
-        }
+      if (indoorDirs && (HORIZ_LEDGE_ATTRS.has(attr) || VERT_LEDGE_ATTRS.has(attr))) {
+        ({ dr, dc, dir } = indoorDirs.get(row * GRID_SIZE + col)!);
+
+        // Link's body is 2 tiles wide: a jump only exists where a perpendicular neighbor
+        // trigger jumps the SAME way. Kills false 1-wide arrows (e.g. beside staircases,
+        // where a lone trigger's neighbor infers the opposite direction).
+        const [pr, pc] = dr !== 0 ? [0, 1] : [1, 0];
+        const sameDir = (r2: number, c2: number) => indoorDirs.get(r2 * GRID_SIZE + c2)?.dir === dir;
+        if (!sameDir(row - pr, col - pc) && !sameDir(row + pr, col + pc)) continue;
       } else {
         const fixed = CLIFF_DIRS[attr];
         if (!fixed) continue;

--- a/shared/game/navigation/screen-data/indoor-ledge-dirs.ts
+++ b/shared/game/navigation/screen-data/indoor-ledge-dirs.ts
@@ -1,0 +1,67 @@
+/* @layer shared-game @kind logic */
+/** Indoor ledge-direction inference: 0x28/0x29/0x2A/0x2B jump toward the adjacent wall face. */
+import { GRID_SIZE } from '../types';
+
+interface LedgeDir {
+  dr: number;
+  dc: number;
+  dir: 'n' | 's' | 'e' | 'w';
+}
+
+const HORIZ_LEDGE_ATTRS = new Set([0x2a, 0x2b]);
+const VERT_LEDGE_ATTRS = new Set([0x28, 0x29]);
+
+const inferAxisDir = (
+  wallAt: (d: number) => boolean,
+  negDir: LedgeDir,
+  posDir: LedgeDir,
+): LedgeDir => {
+  const hasWallNeg = wallAt(-1);
+  const hasWallPos = wallAt(1);
+  if (hasWallPos && !hasWallNeg) return posDir;
+  if (hasWallNeg && !hasWallPos) return negDir;
+
+  // Ambiguous — count walls up to 3 tiles out on each side
+  let neg = 0, pos = 0;
+  for (let d = 1; d <= 3; d++) {
+    if (wallAt(d)) pos++;
+    if (wallAt(-d)) neg++;
+  }
+  if (pos > neg) return posDir;
+  if (neg > pos) return negDir;
+  return posDir; // default fallback (east / south)
+};
+
+/**
+ * Compute the inferred jump direction for every indoor straight-ledge trigger tile.
+ * Keyed by row * GRID_SIZE + col. Pure inference — no grid mutation — so callers can
+ * check neighbor directions (Link's 2-wide body needs a same-direction pair).
+ */
+const computeIndoorLedgeDirs = (rawAttr: number[][], cliffWall: ReadonlySet<number>): Map<number, LedgeDir> => {
+  const dirs = new Map<number, LedgeDir>();
+  const wall = (r: number, c: number) =>
+    r >= 0 && r < GRID_SIZE && c >= 0 && c < GRID_SIZE && cliffWall.has(rawAttr[r][c]);
+
+  for (let row = 0; row < GRID_SIZE; row++) {
+    for (let col = 0; col < GRID_SIZE; col++) {
+      const attr = rawAttr[row][col];
+      if (HORIZ_LEDGE_ATTRS.has(attr)) {
+        dirs.set(row * GRID_SIZE + col, inferAxisDir(
+          (d) => wall(row, col + d),
+          { dr: 0, dc: -1, dir: 'w' },
+          { dr: 0, dc: 1, dir: 'e' },
+        ));
+      } else if (VERT_LEDGE_ATTRS.has(attr)) {
+        dirs.set(row * GRID_SIZE + col, inferAxisDir(
+          (d) => wall(row + d, col),
+          { dr: -1, dc: 0, dir: 'n' },
+          { dr: 1, dc: 0, dir: 's' },
+        ));
+      }
+    }
+  }
+  return dirs;
+};
+
+export { computeIndoorLedgeDirs, HORIZ_LEDGE_ATTRS, VERT_LEDGE_ATTRS };
+export type { LedgeDir };

--- a/shared/game/navigation/strategies/dual-layer.ts
+++ b/shared/game/navigation/strategies/dual-layer.ts
@@ -68,19 +68,17 @@ class DualLayerStrategy implements LayerStrategy {
     if (hitLedge && !ledgeFallMatch) return [];
 
     if (hitLedge && ledgeFallMatch) {
-      // Full 2x2 body must be ledge tiles for Link to jump — 1-wide ledges are invalid
-      let fullBodyLedge = true;
-      for (const [br, bc] of bodyTiles(nr, nc)) {
-        const t = this.grids[0][br][bc];
-        if (t.type !== 'ledge' || !canLeaveLedge(t.dir, dr, dc)) {
-          fullBodyLedge = false;
-          break;
-        }
+      // Link's 2-wide leading edge must sit fully on jump tiles pointing the same way —
+      // a 1-wide ledge can't carry his 2x2 body. Checking the whole body at the entry
+      // position is wrong: it straddles the trigger line AND the approach floor, which
+      // only coincides with ledge tiles when the band happens to be 2+ deep (south fans).
+      // 1-deep north/east/west trigger lines must still fire the cross.
+      for (const [tr, tc] of newTiles) {
+        const t = this.grids[0][tr][tc];
+        if (t.type !== 'ledge' || !canLeaveLedge(t.dir, dr, dc)) return [];
       }
-      if (!fullBodyLedge) return [];
 
-      const results = this.expandLedgeCross(nr, nc, dr, dc, requirements, inventory, bounds);
-      return results;
+      return this.expandLedgeCross(nr, nc, dr, dc, requirements, inventory, bounds);
     }
 
     // ─── Stair detection ───
@@ -154,7 +152,10 @@ class DualLayerStrategy implements LayerStrategy {
         for (const [lr2, lc2] of ledgeTiles) {
           this.traversedLedgeTiles.push({ row: lr2, col: lc2, reqs: requirements });
         }
-        return [];
+        // Enqueue the landing on layer 1 so the flood continues into the lower
+        // area. Recording the traversed ledge tiles above only draws the overlay
+        // arrow; without this return the dropped-to region never gets flooded.
+        return [{ row: lr, col: lc, layer: 1, requirements: newReqs }];
       }
     }
     return [];

--- a/tests/game/navigation/cliff-preprocessing.test.ts
+++ b/tests/game/navigation/cliff-preprocessing.test.ts
@@ -1,0 +1,58 @@
+/* @layer tests @kind test */
+import { describe, it, expect } from 'vitest';
+import { processStraightCliffs } from '../../../shared/game/navigation/screen-data/cliff-preprocessing';
+import type { TilePassability, LedgeTraversal } from '../../../shared/game/navigation/types';
+import { GRID_SIZE } from '../../../shared/game/navigation/types';
+
+// Regression for room 0x71 (Lobby): lone 0x28 triggers flanking a staircase produced
+// 1-wide up-arrows Link's 2x2 body can never use. Indoors, a trigger is only a real
+// jump when a perpendicular neighbor trigger infers the SAME direction.
+
+const emptyAttr = (): number[][] =>
+  Array.from({ length: GRID_SIZE }, () => new Array<number>(GRID_SIZE).fill(0));
+
+const freeGrid = (): TilePassability[][] =>
+  Array.from({ length: GRID_SIZE }, () => new Array<TilePassability>(GRID_SIZE).fill({ type: 'free' }));
+
+const run = (rawAttr: number[][]): { grid: TilePassability[][]; ledges: LedgeTraversal[] } => {
+  const grid = freeGrid();
+  const ledges: LedgeTraversal[] = [];
+  processStraightCliffs(grid, rawAttr, ledges, true);
+  return { grid, ledges };
+};
+
+describe('processStraightCliffs (indoor) — 2-wide same-direction rule', () => {
+  it('drops a lone trigger beside a staircase whose neighbor infers the opposite direction', () => {
+    const rawAttr = emptyAttr();
+    // Lobby pattern around the stairs: row 22 triggers at cols 12-13; col 12 is walled
+    // 3-deep on both sides (ambiguous → 's' fallback), col 13 has wall north only ('n').
+    rawAttr[22][12] = 0x28;
+    rawAttr[22][13] = 0x28;
+    for (const r of [19, 20, 21]) { rawAttr[r][12] = 0x04; rawAttr[r][13] = 0x04; }
+    for (const r of [23, 24, 25]) rawAttr[r][12] = 0x04; // south walls under col 12 only
+    rawAttr[22][14] = 0x02; // stair-side wall
+
+    const { grid, ledges } = run(rawAttr);
+
+    // col 13 ('n') has no same-direction perpendicular neighbor → no ledge, no arrow.
+    expect(grid[22][13].type).not.toBe('ledge');
+    expect(ledges.some(l => l.startRow === 22 && l.startCol === 13)).toBe(false);
+  });
+
+  it('keeps a wide same-direction fan (room 0x72 north jump)', () => {
+    const rawAttr = emptyAttr();
+    // Trigger row 53 cols 6-9, wall band rows 51-52 above, open floor elsewhere.
+    for (let c = 6; c <= 9; c++) {
+      rawAttr[53][c] = 0x28;
+      rawAttr[52][c] = 0x01;
+      rawAttr[51][c] = 0x04;
+    }
+
+    const { grid, ledges } = run(rawAttr);
+
+    for (let c = 6; c <= 9; c++) {
+      expect(grid[53][c]).toEqual({ type: 'ledge', dir: 'n' });
+      expect(ledges.some(l => l.startRow === 53 && l.startCol === c)).toBe(true);
+    }
+  });
+});

--- a/tests/game/navigation/constrain-void-tiles.test.ts
+++ b/tests/game/navigation/constrain-void-tiles.test.ts
@@ -1,0 +1,45 @@
+/* @layer tests @kind test */
+import { describe, it, expect } from 'vitest';
+import { constrainVoidTiles } from '../../../shared/game/navigation/flood-fill/screen-prep';
+import { GRID_SIZE } from '../../../shared/game/navigation/types';
+
+// Regression for room 0x72 (East Corridor): the lower floor on layer 1 reaches the grid
+// edge through an OPEN south passage (bare 0x00 corridor flanked by walls — no 0x80 door
+// attrs stamped). The void flood used to seed from every boundary 0x00, walk up that
+// corridor and wall the entire floor (309 tiles) — BFS from the lower layer found ~0
+// tiles and upper-layer stair/ledge crosses had no landing. Doorway-shaped boundary gaps
+// (narrow, wall-flanked) are walkable exits and must not seed the void flood; wide open
+// spans are structural void and must.
+
+const grid = (fill: number): number[][] =>
+  Array.from({ length: GRID_SIZE }, () => new Array<number>(GRID_SIZE).fill(fill));
+
+describe('constrainVoidTiles — doorway gaps do not seed the void flood', () => {
+  // Model of 0x72's layer 1: void ocean everywhere, a walled floor region in the south
+  // half (rows 40-58, cols 10-35), and a 4-wide exit corridor from the floor to the south
+  // edge (rows 59-63, cols 20-23) flanked by 0x02 walls.
+  const layer = grid(0x00);
+  for (let c = 10; c <= 35; c++) { layer[40][c] = 0x01; layer[58][c] = 0x01; } // floor N/S walls
+  for (let r = 40; r <= 58; r++) { layer[r][10] = 0x01; layer[r][35] = 0x01; } // floor W/E walls
+  for (let c = 20; c <= 23; c++) layer[58][c] = 0x00;                          // opening to corridor
+  for (let r = 59; r < GRID_SIZE; r++) { layer[r][19] = 0x02; layer[r][24] = 0x02; } // corridor flanks
+
+  const constrained = constrainVoidTiles(layer, grid(0x00));
+
+  it('keeps the enclosed floor walkable', () => {
+    expect(constrained[50][20]).toBe(0x00);
+    expect(constrained[45][30]).toBe(0x00);
+  });
+
+  it('keeps the wall-flanked exit corridor open down to the edge', () => {
+    expect(constrained[60][21]).toBe(0x00);
+    expect(constrained[63][20]).toBe(0x00);
+    expect(constrained[63][23]).toBe(0x00);
+  });
+
+  it('still walls the wide-open structural void', () => {
+    expect(constrained[0][0]).toBe(0x01);   // ocean corner
+    expect(constrained[20][32]).toBe(0x01); // ocean interior
+    expect(constrained[63][40]).toBe(0x01); // south edge outside the flanked gap
+  });
+});

--- a/tests/game/navigation/dual-layer-ledge.test.ts
+++ b/tests/game/navigation/dual-layer-ledge.test.ts
@@ -1,0 +1,75 @@
+/* @layer tests @kind test */
+import { describe, it, expect } from 'vitest';
+import { DualLayerStrategy } from '../../../shared/game/navigation/strategies/dual-layer';
+import type { QuadrantBounds, BFSCell } from '../../../shared/game/navigation/strategies/layer-strategy';
+import type { TilePassability } from '../../../shared/game/navigation/types';
+import { GRID_SIZE } from '../../../shared/game/navigation/types';
+
+// Regression for commit 2de348d9: tagging ledge tiles as traversal accidentally replaced
+// expandLedgeCross's landing-cell return with `return []`, so a ledge drop drew the overlay
+// arrow but never flooded the layer-1 area it lands in. Any dungeon room reachable ONLY by
+// dropping off a ledge (e.g. room 0x72 East Corridor) under-reported reachability ever since.
+
+const fill = (tile: TilePassability): TilePassability[][] =>
+  Array.from({ length: GRID_SIZE }, () => new Array<TilePassability>(GRID_SIZE).fill(tile));
+
+const zeros = (): number[][] =>
+  Array.from({ length: GRID_SIZE }, () => new Array<number>(GRID_SIZE).fill(0));
+
+const FULL_BOUNDS: QuadrantBounds = { minRow: 0, maxRow: GRID_SIZE - 1, minCol: 0, maxCol: GRID_SIZE - 1 };
+
+describe('DualLayerStrategy — ledge drop enqueues its layer-1 landing', () => {
+  it('returns the landing cell on layer 1 when Link drops south off a 2-wide ledge', () => {
+    // Layer 0: walkable, with a south-facing ledge band at rows 11-12, cols 20-21.
+    const layer0 = fill({ type: 'free' });
+    for (const r of [11, 12]) {
+      for (const c of [20, 21]) layer0[r][c] = { type: 'ledge', dir: 's' };
+    }
+    // Layer 1: open floor — the lower area Link falls into.
+    const layer1 = fill({ type: 'free' });
+
+    const strategy = new DualLayerStrategy([layer0, layer1], [zeros(), zeros()], 'interior-dungeon', 0);
+
+    // Body at (10,20) on layer 0 steps south into the ledge and jumps.
+    const cell: BFSCell = { row: 10, col: 20, layer: 0, requirements: new Set() };
+    const results = strategy.expand(cell, 1, 0, new Set(), FULL_BOUNDS);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ row: 13, col: 20, layer: 1 });
+  });
+
+  // Regression for room 0x72's west walkway: a NORTH jump enters a 1-deep trigger line
+  // (the wall extension continues beyond it). The old check required Link's whole 2x2
+  // body on ledge tiles at the entry position — which straddles the approach floor, so
+  // 1-deep north/east/west fans never fired and the lower floor stayed unflooded.
+  it('crosses a 1-deep north trigger line (leading edge fully on ledges)', () => {
+    const layer0 = fill({ type: 'free' });
+    // Trigger line row 20 + wall extension rows 18-19, cols 20-21, all jumping north.
+    for (const r of [18, 19, 20]) {
+      for (const c of [20, 21]) layer0[r][c] = { type: 'ledge', dir: 'n' };
+    }
+    const layer1 = fill({ type: 'free' });
+    const strategy = new DualLayerStrategy([layer0, layer1], [zeros(), zeros()], 'interior-dungeon', 0);
+
+    // Body at (21,20) steps north: leading edge (row 20) is fully on n-ledges.
+    const cell: BFSCell = { row: 21, col: 20, layer: 0, requirements: new Set() };
+    const results = strategy.expand(cell, -1, 0, new Set(), FULL_BOUNDS);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ row: 16, col: 20, layer: 1 });
+  });
+
+  it('refuses a 1-wide ledge — the 2-wide leading edge cannot fit', () => {
+    const layer0 = fill({ type: 'free' });
+    // Single-column ledge at col 20, rows 18-20.
+    for (const r of [18, 19, 20]) layer0[r][20] = { type: 'ledge', dir: 'n' };
+    const layer1 = fill({ type: 'free' });
+    const strategy = new DualLayerStrategy([layer0, layer1], [zeros(), zeros()], 'interior-dungeon', 0);
+
+    // Both possible approach bodies straddle the 1-wide column — no jump either way.
+    for (const col of [19, 20]) {
+      const cell: BFSCell = { row: 21, col, layer: 0, requirements: new Set() };
+      expect(strategy.expand(cell, -1, 0, new Set(), FULL_BOUNDS)).toHaveLength(0);
+    }
+  });
+});


### PR DESCRIPTION
Three navigation BFS bugs found while working through rooms 0x71 and 0x72. The void constraint was walling real lower floors whose only path to the grid edge is an open door passage — doorway-shaped boundary gaps no longer seed the void flood. Dual-layer ledge crossings never fired for 1-deep north/east/west trigger lines because the check straddled the approach floor; it now validates Link's 2-wide leading edge on same-direction jump tiles, and the layer-1 landing is enqueued again (lost in 2de348d9). Indoor cliff preprocessing also emitted 1-wide ledges Link's 2x2 body can't use; a trigger now needs a same-direction perpendicular neighbor.

East Corridor floods 0 → 1650 from the lower floor and 58 → 1708 from the west walkway; the false jump arrows in the Lobby are gone. Unit tests cover all three fixes.

Also enriches --dump-nav so the nav regression baselines have teeth: overworld screens get flood data, the flood seeds from Link's tile like the widget, and dumps include the reachable grid, ledges and raw attr grids.