### PR TITLE
Gate input to a profile's mapped devices, plus profile switching and per-device haptics

### DIFF
--- a/apps/web/src/App/behavior/load-profile-helpers.ts
+++ b/apps/web/src/App/behavior/load-profile-helpers.ts
@@ -4,6 +4,7 @@ import { setMsuData, setLinkSpriteData, getInputManager } from '../../lib/game';
 import type { mergeSettings } from '../../lib/game/settings';
 import { log } from '../../lib/log-bus';
 import { readInputProfiles } from '@app/lib/storage/profile-data-store';
+import { updateActiveInputProfileId } from '@app/lib/storage/profile-store';
 import * as msuStore from '@app/lib/storage/msu-store';
 import { readLinkSprite } from '@app/lib/storage/link-sprites-store';
 import type { InputProfile } from '@shared/types/controls';
@@ -17,7 +18,10 @@ const loadInputProfile = async (profileId: string, settings: Settings) => {
     if (inputProfiles.length > 0) {
       const activeId = settings.activeInputProfileId;
       const active = inputProfiles.find(p => p.id === activeId) ?? inputProfiles[0];
-      getInputManager().setProfile(active);
+      const mgr = getInputManager();
+      mgr.setProfiles(inputProfiles);
+      mgr.setActiveProfilePersist((id) => { void updateActiveInputProfileId(profileId, id); });
+      mgr.setProfile(active);
       log.app(`Loaded input profile: ${active.name}`);
     }
   } catch {

--- a/apps/web/src/lib/game/live-settings.ts
+++ b/apps/web/src/lib/game/live-settings.ts
@@ -15,7 +15,7 @@
 import type { GameSettings } from '@shared/types/settings';
 import { getModule } from './wasm-bridge';
 import { setMasterVolume } from './audio-volume';
-import { updateHapticBridgeSettings } from '../input/haptic-bridge';
+import { updateHapticBridgeSettings, updateHapticDevices } from '../input/haptic-bridge';
 import { DEFAULT_SETTINGS } from './settings';
 import { log } from '../log-bus';
 import { buildFeatureFlags, buildPpuFlags, buildFeatureWords } from './live-settings-flags';
@@ -92,6 +92,7 @@ const pushLiveSettings = (settings: GameSettings): boolean => {
 
     // Haptic feedback settings (JS-only, no WASM needed)
     updateHapticBridgeSettings(settings.haptics ?? DEFAULT_SETTINGS.haptics);
+    updateHapticDevices(settings.hapticDevices);
 
     log.app(`Live settings pushed — features: 0x${features.toString(16)}, ppu: 0x${ppuFlags.toString(16)}`);
     return true;

--- a/apps/web/src/lib/game/settings.ts
+++ b/apps/web/src/lib/game/settings.ts
@@ -119,6 +119,7 @@ const DEFAULT_SETTINGS: GameSettings = {
     dashVibration: true,
     environmentalEffects: true,
   },
+  hapticDevices: {},
 };
 
 const boolToIni = (v: boolean): string => {
@@ -214,6 +215,7 @@ MiscBugFixes = ${boolToIni(settings.miscBugFixes)}
 GameChangingBugFixes = ${boolToIni(settings.gameChangingBugFixes)}
 CancelBirdTravel = ${boolToIni(settings.cancelBirdTravel)}
 DisableTelepathy = ${boolToIni(settings.disableTelepathy)}
+Haptics = ${boolToIni(!!settings.haptics?.enabled)}
 ${renderFlagsIni}
 `;
 };

--- a/apps/web/src/lib/input/function-actions.ts
+++ b/apps/web/src/lib/input/function-actions.ts
@@ -6,7 +6,18 @@
 
 import type { FunctionMapping, FunctionAction } from '@shared/types/controls';
 import { DEFAULT_FUNCTION_MAPPINGS } from '@shared/types/controls';
-import { webHidReader } from './hid-reader';
+import type { AllowedDevices } from './profile-devices';
+
+/** Merge saved mappings with defaults so newly-added actions always have a binding. */
+const mergeWithDefaults = (mappings: FunctionMapping[]): FunctionMapping[] => {
+  if (mappings.length === 0) return DEFAULT_FUNCTION_MAPPINGS;
+  const present = new Set(mappings.map(m => m.action));
+  const merged = [...mappings];
+  for (const def of DEFAULT_FUNCTION_MAPPINGS) {
+    if (!present.has(def.action)) merged.push(def);
+  }
+  return merged;
+};
 
 type FunctionKeyUpListener = (action: FunctionAction) => void;
 
@@ -37,7 +48,7 @@ class FunctionActionEngine {
   }
 
   setMappings(mappings: FunctionMapping[]): void {
-    this.functionMappings = mappings;
+    this.functionMappings = mergeWithDefaults(mappings);
     this.rebuild();
   }
 
@@ -94,31 +105,20 @@ class FunctionActionEngine {
    * Check gamepad/HID buttons against function mappings each frame.
    * Fires callbacks on rising edge, fires keyUp listeners on falling edge.
    */
-  checkGamepads(hidStates: Map<string, { buttons: boolean[]; axes: number[] }>): void {
-    // --- Web Gamepad API controllers (skip those handled by node-hid) ---
-    const gamepads = navigator.getGamepads();
-    const hidIds = new Set(webHidReader.getConnectedDeviceKeys());
-
-    for (const gp of gamepads) {
+  checkGamepads(hidStates: Map<string, { buttons: boolean[]; axes: number[] }>, allowed: AllowedDevices, gamepadVidPid: Map<number, { vid: string; pid: string }>): void {
+    // --- Web Gamepad API controllers — only devices in the active profile's map ---
+    for (const gp of navigator.getGamepads()) {
       if (!gp || !gp.connected) continue;
-      // Skip gamepads already handled by WebHID
-      const gpIdLower = gp.id.toLowerCase();
-      let isDuplicate = false;
-      for (const hidId of hidIds) {
-        const [vid, pid] = hidId.split(':');
-        if (gpIdLower.includes(`vendor: ${vid}`) && gpIdLower.includes(`product: ${pid}`)) {
-          isDuplicate = true;
-          break;
-        }
-      }
-      if (isDuplicate) continue;
-
+      const vp = gamepadVidPid.get(gp.index);
+      const key = vp ? `${vp.vid}:${vp.pid}` : null;
+      if (!key || !allowed.gamepadKeys.has(key)) continue;
       // Normalize Web Gamepad buttons (objects) to booleans, then share one code path.
       this.processDeviceState(`gamepad-${gp.index}`, gp.buttons.map((b) => b.pressed), gp.axes);
     }
 
     // --- WebHID controllers (Switch Pro, PlayStation, 8BitDo) ---
     for (const [deviceKey, state] of hidStates) {
+      if (!allowed.gamepadKeys.has(deviceKey)) continue;
       this.processDeviceState(deviceKey, state.buttons, state.axes);
     }
   }

--- a/apps/web/src/lib/input/haptic-bridge.ts
+++ b/apps/web/src/lib/input/haptic-bridge.ts
@@ -15,12 +15,22 @@
 import { handleHapticEvent, setVibrateFunction, updateHapticSettings } from '@shared/input/haptics';
 import type { HapticSettings } from '@shared/input/haptics';
 import type { VibrationSegment } from '@shared/input/base';
-import { findController } from '@shared/input/register-all';
+import { findController, findControllerById } from '@shared/input/register-all';
+import { parseGamepadId } from '@shared/input';
+import type { BaseController } from '@shared/input/base';
 import { getPlatform } from '@app/platform/get-platform';
 import { webHidReader } from './hid-reader';
+import { vibrateGamepadPattern } from './vibration';
+import { peekInputManager } from './input-manager';
 import * as controllersStore from './controllers-store';
 
 let initialized = false;
+
+// ─── Per-device haptics gate ───
+// Keyed by "vid:pid"; a key set to false mutes that device. Absent = enabled
+// (the supportsVibration() check still applies). Configured in the DEVICES panel.
+let hapticDevices: Record<string, boolean> = {};
+const deviceHapticsEnabled = (deviceKey: string): boolean => hapticDevices[deviceKey] !== false;
 
 // ─── Vibration Mixer State ───
 
@@ -84,15 +94,65 @@ const dispatchVibration = (pattern: VibrationSegment[], gapMs?: number): void =>
   }
 };
 
+// Xbox/XInput pads surface on both the Gamepad API and node-hid buses; mirror the
+// polling-engine's id match so the same physical pad isn't buzzed twice.
+const isGamepadServedByHid = (gp: Gamepad, hidKeys: Set<string>): boolean => {
+  const id = gp.id.toLowerCase();
+  for (const key of hidKeys) {
+    const [vid, pid] = key.split(':');
+    if (id.includes(`vendor: ${vid}`) && id.includes(`product: ${pid}`)) return true;
+  }
+  return false;
+};
+
+// Resolve the controller behind a Gamepad-API pad so its per-pad strength shaping applies.
+// Xbox/XInput rarely embeds vid/pid in the id, so fall back to the family keyword.
+const resolveGamepadController = (gp: Gamepad): BaseController | null => {
+  const parsed = parseGamepadId(gp.id);
+  if (parsed && parsed.vid !== '0000') {
+    const byId = findController(parsed.vid, parsed.pid);
+    if (byId) return byId;
+  }
+  const id = gp.id.toLowerCase();
+  if (id.includes('xbox') || id.includes('xinput')) return findControllerById('xbox');
+  return null;
+};
+
+// Apply a controller's strength curve to each segment. Magnitude only — durations are kept
+// exactly as authored, so a pad can hit harder without any event lasting longer.
+const shapeForController = (ctrl: BaseController | null, pattern: VibrationSegment[]): VibrationSegment[] => {
+  if (!ctrl) return pattern;
+  return pattern.map(seg => ({ durationMs: seg.durationMs, intensity: ctrl.shapeVibration(seg.intensity) }));
+};
+
 const sendToController = (pattern: VibrationSegment[], gapMs?: number): void => {
-  const keys = webHidReader.getConnectedDeviceKeys();
-  if (keys.length === 0) return;
-  const key = keys[0];
-  // Only dispatch to controllers that actually rumble. Writing haptic frames to a
-  // non-vibrating pad still pauses its HID read stream, which stalls input.
-  const [vid, pid] = key.split(':');
-  if (!findController(vid, pid)?.supportsVibration()) return;
-  controllersStore.vibratePattern(key, pattern, gapMs ?? 0);
+  const gap = gapMs ?? 0;
+
+  // HID controllers (Switch Pro, PlayStation, 8BitDo) via the node-hid worker. Only
+  // dispatch to pads that actually rumble — writing haptic frames to a non-vibrating
+  // pad still pauses its HID read stream, which stalls input.
+  const hidKeys = webHidReader.getConnectedDeviceKeys();
+  for (const key of hidKeys) {
+    if (!deviceHapticsEnabled(key)) continue;
+    const [vid, pid] = key.split(':');
+    const ctrl = findController(vid, pid);
+    if (ctrl?.supportsVibration()) {
+      controllersStore.vibratePattern(key, shapeForController(ctrl, pattern), gap);
+    }
+  }
+
+  // Gamepad API controllers (Xbox/XInput) rumble through the vibrationActuator, never
+  // node-hid — so they never show up in hidKeys above. Skip any pad already served
+  // over HID to avoid a double buzz.
+  const hidSet = new Set(hidKeys);
+  const gamepadVidPid = peekInputManager()?.gamepadVidPid;
+  for (const gp of navigator.getGamepads()) {
+    if (!gp || !gp.connected || isGamepadServedByHid(gp, hidSet)) continue;
+    if (!(gp as { vibrationActuator?: { playEffect?: unknown } }).vibrationActuator?.playEffect) continue;
+    const vp = gamepadVidPid?.get(gp.index);
+    if (vp && !deviceHapticsEnabled(`${vp.vid}:${vp.pid}`)) continue;
+    vibrateGamepadPattern(gp.index, shapeForController(resolveGamepadController(gp), pattern), gap);
+  }
 };
 
 const scheduleDecay = (ms: number): void => {
@@ -124,6 +184,10 @@ const updateHapticBridgeSettings = (settings: HapticSettings): void => {
   updateHapticSettings(settings);
 };
 
+const updateHapticDevices = (map: Record<string, boolean> | undefined): void => {
+  hapticDevices = map ?? {};
+};
+
 const destroyHapticBridge = (): void => {
   (window as any).__onHapticEvent = null;
   setVibrateFunction(null);
@@ -138,5 +202,6 @@ const destroyHapticBridge = (): void => {
 export {
   destroyHapticBridge,
   initHapticBridge,
-  updateHapticBridgeSettings
+  updateHapticBridgeSettings,
+  updateHapticDevices
 };

--- a/apps/web/src/lib/input/input-manager-events.ts
+++ b/apps/web/src/lib/input/input-manager-events.ts
@@ -3,6 +3,7 @@
 import { markActivated, updateActivationState } from './device-detector';
 import { resolveGamepadVidPid } from './gamepad-vid-pid';
 import { computeBitmask, snapshotGamepads } from './polling-engine';
+import { allowedDevices } from './profile-devices';
 import type { InputManager } from './input-manager';
 
 const isTextInput = (target: EventTarget | null): boolean => {
@@ -16,6 +17,7 @@ const rebuildMaps = (m: InputManager): void => {
   m.keyboardMap.clear();
   m.gamepadButtonMap.clear();
   m.gamepadAxisMap.clear();
+  m.allowed = allowedDevices(m.activeProfile);
   if (!m.activeProfile) return;
   for (const mapping of m.activeProfile.mappings) {
     const b = mapping.binding;
@@ -100,10 +102,16 @@ const pollFrame = (m: InputManager): void => {
 
   const windowFocused = document.hasFocus();
 
+  // Resolve vid:pid for any pad connected before its 'gamepadconnected' fired, so the
+  // device gate can match it against the active profile's map.
+  for (const gp of navigator.getGamepads()) {
+    if (gp && gp.connected && !m.gamepadVidPid.has(gp.index)) resolveGamepad(m, gp);
+  }
+
   m.currentGamepads = snapshotGamepads();
 
   if (windowFocused && !m.pauseManager.isPaused && !m.inputSuppressed) {
-    const mask = computeBitmask(m.keyStates, m.keyboardMap, m.gamepadButtonMap, m.gamepadAxisMap, m.hidStates);
+    const mask = computeBitmask(m.keyStates, m.keyboardMap, m.gamepadButtonMap, m.gamepadAxisMap, m.hidStates, m.allowed, m.gamepadVidPid);
     m.setInputFn?.(mask);
   }
 
@@ -113,7 +121,7 @@ const pollFrame = (m: InputManager): void => {
   }
 
   if (windowFocused && !m.inputSuppressed && m.functionActions.hasMappedGamepadButtons) {
-    m.functionActions.checkGamepads(m.hidStates);
+    m.functionActions.checkGamepads(m.hidStates, m.allowed, m.gamepadVidPid);
   }
 
   if (m.stateListeners.size > 0) {

--- a/apps/web/src/lib/input/input-manager-profiles.ts
+++ b/apps/web/src/lib/input/input-manager-profiles.ts
@@ -1,0 +1,43 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Profile management for InputManager — the saved-profile list, the active-profile
+ * change subscription, and the profile-cycle shortcut. Operates on the instance
+ * (like input-manager-{lifecycle,events}); the class exposes thin delegators.
+ */
+
+import type { InputProfile } from '@shared/types/controls';
+import type { ActiveProfileListener } from './input-manager-types';
+import type { InputManager } from './input-manager';
+
+/** Register the profile-next/prev function actions to cycle the active profile. */
+const wireProfileActions = (m: InputManager): void => {
+  m.functionActions.onAction('profile-next', () => cycleActiveProfile(m, 1));
+  m.functionActions.onAction('profile-prev', () => cycleActiveProfile(m, -1));
+};
+
+/** Keep the full profile list in sync so cycling can pick the next/previous one. */
+const setProfiles = (m: InputManager, profiles: InputProfile[]): void => {
+  m.profiles = profiles;
+};
+
+const subscribeActiveProfile = (m: InputManager, listener: ActiveProfileListener): () => void => {
+  m.activeProfileListeners.add(listener);
+  return () => m.activeProfileListeners.delete(listener);
+};
+
+/** Switch the active profile by an offset (+1 next, -1 previous), wrapping around. */
+const cycleActiveProfile = (m: InputManager, direction: 1 | -1): void => {
+  if (m.profiles.length < 2) return;
+  const currentIndex = m.profiles.findIndex(p => p.id === m.activeProfile?.id);
+  const base = currentIndex < 0 ? 0 : currentIndex;
+  const nextIndex = (base + direction + m.profiles.length) % m.profiles.length;
+  const next = m.profiles[nextIndex];
+  if (!next || next.id === m.activeProfile?.id) return;
+  m.setProfile(next);
+  m.persistActiveProfileId?.(next.id);
+  for (const fn of m.activeProfileListeners) {
+    try { fn(next); } catch { /* ignore */ }
+  }
+};
+
+export { wireProfileActions, setProfiles, subscribeActiveProfile, cycleActiveProfile };

--- a/apps/web/src/lib/input/input-manager-types.ts
+++ b/apps/web/src/lib/input/input-manager-types.ts
@@ -1,9 +1,12 @@
 /* @layer renderer-lib @kind types */
-import type { DetectedDevice } from '@shared/types/controls';
+import type { DetectedDevice, InputProfile } from '@shared/types/controls';
 import type { WebHidInputState } from './hid-reader';
 import type { GamepadSnapshot } from './polling-engine';
 
 type DeviceChangeListener = (devices: DetectedDevice[]) => void;
+
+/** Fires when the active input profile changes (e.g. via the profile-cycle shortcut). */
+type ActiveProfileListener = (profile: InputProfile) => void;
 
 /** Per-frame state listener — for InputCalibration, InputTester visualization */
 type InputStateListener = (
@@ -12,4 +15,4 @@ type InputStateListener = (
   pressedKeys: Set<string>,
 ) => void;
 
-export type { DeviceChangeListener, InputStateListener };
+export type { ActiveProfileListener, DeviceChangeListener, InputStateListener };

--- a/apps/web/src/lib/input/input-manager.ts
+++ b/apps/web/src/lib/input/input-manager.ts
@@ -29,10 +29,19 @@ import type { HidDeviceInfo } from './gamepad-vid-pid';
 import type { ControllerEntry } from './controller-lifecycle';
 import { startInput, stopInput, refreshDevicesImpl } from './input-manager-lifecycle';
 import { rebuildMaps, guardKeys, keyDown, keyUp, gamepadConnected, gamepadDisconnected, pollFrame } from './input-manager-events';
-import type { DeviceChangeListener, InputStateListener } from './input-manager-types';
+import { wireProfileActions, setProfiles as setProfilesImpl, subscribeActiveProfile, cycleActiveProfile as cycleActiveProfileImpl } from './input-manager-profiles';
+import type { AllowedDevices } from './profile-devices';
+import type { ActiveProfileListener, DeviceChangeListener, InputStateListener } from './input-manager-types';
 
 class InputManager {
   activeProfile: InputProfile | null = null;
+  // All saved input profiles, kept in sync so the profile-cycle shortcut can switch
+  // the active one during gameplay (settings screen not required).
+  profiles: InputProfile[] = [];
+  // Devices the active profile's map references — the input gate whitelists these.
+  allowed: AllowedDevices = { keyboard: false, gamepadKeys: new Set() };
+  activeProfileListeners = new Set<ActiveProfileListener>();
+  persistActiveProfileId: ((id: string) => void) | null = null;
   keyStates = new Map<string, boolean>();
   allPressedKeys = new Set<string>();
   animFrameId: number | null = null;
@@ -88,6 +97,7 @@ class InputManager {
       resumeAudio();
     };
     this.functionActions.onPauseToggle = () => this.pauseManager.togglePause();
+    wireProfileActions(this);
   }
 
   // ─── Event handler fields (stable identity for add/removeEventListener) ───
@@ -126,6 +136,23 @@ class InputManager {
 
   getProfile(): InputProfile | null {
     return this.activeProfile;
+  }
+
+  setProfiles(profiles: InputProfile[]): void {
+    setProfilesImpl(this, profiles);
+  }
+
+  /** Wire persistence of the active profile id (survives app restart). */
+  setActiveProfilePersist(fn: (id: string) => void): void {
+    this.persistActiveProfileId = fn;
+  }
+
+  onActiveProfileChange(listener: ActiveProfileListener): () => void {
+    return subscribeActiveProfile(this, listener);
+  }
+
+  cycleActiveProfile(direction: 1 | -1): void {
+    cycleActiveProfileImpl(this, direction);
   }
 
   setFunctionMappings(mappings: FunctionMapping[]): void {
@@ -222,9 +249,12 @@ const getInputManager = (): InputManager => {
   return instance;
 };
 
-export { InputManager, getInputManager };
+/** Return the existing InputManager without creating/starting one (null if none). */
+const peekInputManager = (): InputManager | null => instance;
+
+export { InputManager, getInputManager, peekInputManager };
 export { profileFromPreset, resolveFunctionMappingIcon } from './profile-utils';
-export type { DeviceChangeListener, InputStateListener } from './input-manager-types';
+export type { ActiveProfileListener, DeviceChangeListener, InputStateListener } from './input-manager-types';
 export type { PauseListener } from './pause-manager';
 export type { RawInputEvent, RawInputListener } from './raw-input-dispatcher';
 export type { GamepadSnapshot } from './polling-engine';

--- a/apps/web/src/lib/input/polling-engine.ts
+++ b/apps/web/src/lib/input/polling-engine.ts
@@ -8,6 +8,7 @@
 import type { SnesButton } from '@shared/types/controls';
 import { SNES_BUTTON_BITS } from '@shared/types/controls';
 import { webHidReader } from './hid-reader';
+import type { AllowedDevices } from './profile-devices';
 
 /** Gamepad snapshot matching the shape InputCalibration/InputTester need */
 interface GamepadSnapshot {
@@ -20,77 +21,55 @@ interface GamepadSnapshot {
   axes: number[];
 }
 
-const computeBitmask = (keyStates: Map<string, boolean>, keyboardMap: Map<string, SnesButton>, gamepadButtonMap: Map<number, SnesButton>, gamepadAxisMap: Map<string, SnesButton>, hidStates: Map<string, { buttons: boolean[]; axes: number[] }>): number => {
+/** OR a device's buttons + axes into the mask against the active profile's maps. */
+const applyDeviceState = (mask: number, buttons: readonly boolean[], axes: readonly number[], gamepadButtonMap: Map<number, SnesButton>, gamepadAxisMap: Map<string, SnesButton>): number => {
+  for (const [index, snesBtn] of gamepadButtonMap) {
+    if (index < buttons.length && buttons[index]) {
+      mask |= (1 << SNES_BUTTON_BITS[snesBtn]);
+    }
+  }
+  for (const [key, snesBtn] of gamepadAxisMap) {
+    const [axisStr, dir] = key.split(':');
+    const axisIndex = parseInt(axisStr, 10);
+    if (axisIndex < axes.length) {
+      const val = axes[axisIndex];
+      const threshold = 0.5;
+      if ((dir === '+' && val > threshold) || (dir === '-' && val < -threshold)) {
+        mask |= (1 << SNES_BUTTON_BITS[snesBtn]);
+      }
+    }
+  }
+  return mask;
+};
+
+const computeBitmask = (keyStates: Map<string, boolean>, keyboardMap: Map<string, SnesButton>, gamepadButtonMap: Map<number, SnesButton>, gamepadAxisMap: Map<string, SnesButton>, hidStates: Map<string, { buttons: boolean[]; axes: number[] }>, allowed: AllowedDevices, gamepadVidPid: Map<number, { vid: string; pid: string }>): number => {
   let mask = 0;
 
-  // Keyboard
-  for (const [code, pressed] of keyStates) {
-    if (pressed) {
-      const btn = keyboardMap.get(code);
-      if (btn !== undefined) {
-        mask |= (1 << SNES_BUTTON_BITS[btn]);
+  // Keyboard — only when the active profile actually binds keyboard keys
+  if (allowed.keyboard) {
+    for (const [code, pressed] of keyStates) {
+      if (pressed) {
+        const btn = keyboardMap.get(code);
+        if (btn !== undefined) {
+          mask |= (1 << SNES_BUTTON_BITS[btn]);
+        }
       }
     }
   }
 
-  // Web Gamepad API (XInput controllers like Xbox)
-  const gamepads = navigator.getGamepads();
-  const hidIds = new Set(webHidReader.getConnectedDeviceKeys());
-  for (const gp of gamepads) {
+  // Web Gamepad API (XInput controllers like Xbox) — only devices in the profile's map
+  for (const gp of navigator.getGamepads()) {
     if (!gp || !gp.connected) continue;
-
-    // Skip gamepad if already handled by node-hid
-    const gpIdLower = gp.id.toLowerCase();
-    let isDuplicate = false;
-    for (const hidId of hidIds) {
-      const [vid, pid] = hidId.split(':');
-      if (gpIdLower.includes(`vendor: ${vid}`) && gpIdLower.includes(`product: ${pid}`)) {
-        isDuplicate = true;
-        break;
-      }
-    }
-    if (isDuplicate) continue;
-
-    // Buttons
-    for (const [index, snesBtn] of gamepadButtonMap) {
-      if (index < gp.buttons.length && gp.buttons[index].pressed) {
-        mask |= (1 << SNES_BUTTON_BITS[snesBtn]);
-      }
-    }
-
-    // Axes
-    for (const [key, snesBtn] of gamepadAxisMap) {
-      const [axisStr, dir] = key.split(':');
-      const axisIndex = parseInt(axisStr, 10);
-      if (axisIndex < gp.axes.length) {
-        const val = gp.axes[axisIndex];
-        const threshold = 0.5;
-        if ((dir === '+' && val > threshold) || (dir === '-' && val < -threshold)) {
-          mask |= (1 << SNES_BUTTON_BITS[snesBtn]);
-        }
-      }
-    }
+    const vp = gamepadVidPid.get(gp.index);
+    const key = vp ? `${vp.vid}:${vp.pid}` : null;
+    if (!key || !allowed.gamepadKeys.has(key)) continue;
+    mask = applyDeviceState(mask, gp.buttons.map(b => b.pressed), gp.axes, gamepadButtonMap, gamepadAxisMap);
   }
 
-  // HID input (Switch Pro, PlayStation, 8BitDo)
-  for (const [, state] of hidStates) {
-    for (const [index, snesBtn] of gamepadButtonMap) {
-      if (index < state.buttons.length && state.buttons[index]) {
-        mask |= (1 << SNES_BUTTON_BITS[snesBtn]);
-      }
-    }
-
-    for (const [key, snesBtn] of gamepadAxisMap) {
-      const [axisStr, dir] = key.split(':');
-      const axisIndex = parseInt(axisStr, 10);
-      if (axisIndex < state.axes.length) {
-        const val = state.axes[axisIndex];
-        const threshold = 0.5;
-        if ((dir === '+' && val > threshold) || (dir === '-' && val < -threshold)) {
-          mask |= (1 << SNES_BUTTON_BITS[snesBtn]);
-        }
-      }
-    }
+  // HID input (Switch Pro, PlayStation, 8BitDo) — only devices in the profile's map
+  for (const [deviceKey, state] of hidStates) {
+    if (!allowed.gamepadKeys.has(deviceKey)) continue;
+    mask = applyDeviceState(mask, state.buttons, state.axes, gamepadButtonMap, gamepadAxisMap);
   }
 
   return mask;

--- a/apps/web/src/lib/input/profile-devices.ts
+++ b/apps/web/src/lib/input/profile-devices.ts
@@ -1,0 +1,40 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Profile Devices — resolves the set of physical devices a profile's map actually
+ * references. This is the whitelist the input engine gates on: only a keyboard (when
+ * the map has keyboard bindings) and gamepads whose vid:pid appears in the map may
+ * drive the game. A connected-but-unmapped controller contributes nothing.
+ */
+
+import type { InputProfile } from '@shared/types/controls';
+
+interface AllowedDevices {
+  keyboard: boolean;
+  gamepadKeys: Set<string>; // "vid:pid", lowercase, 4-hex
+}
+
+const padHex = (v: string): string => v.toLowerCase().padStart(4, '0');
+
+const allowedDevices = (profile: InputProfile | null): AllowedDevices => {
+  const gamepadKeys = new Set<string>();
+  if (!profile) return { keyboard: false, gamepadKeys };
+
+  let keyboard = false;
+  for (const m of profile.mappings) {
+    if (m.binding.type === 'keyboard') {
+      keyboard = true;
+    } else if (m.sourceVid && m.sourcePid) {
+      gamepadKeys.add(`${padHex(m.sourceVid)}:${padHex(m.sourcePid)}`);
+    }
+  }
+
+  const assigned = profile.assignedDevice;
+  if (assigned?.vendorId && assigned?.productId) {
+    gamepadKeys.add(`${padHex(assigned.vendorId)}:${padHex(assigned.productId)}`);
+  }
+
+  return { keyboard, gamepadKeys };
+};
+
+export { allowedDevices };
+export type { AllowedDevices };

--- a/apps/web/src/lib/storage/profile-store.ts
+++ b/apps/web/src/lib/storage/profile-store.ts
@@ -21,7 +21,15 @@ const getAppState = (): Promise<AppState> => store.getAppState(files());
 const readConfig = (id: string): Promise<Record<string, unknown> | null> => store.readConfig(files(), id);
 const writeConfig = (id: string, settings: Record<string, unknown>): Promise<void> => store.writeConfig(files(), id, settings);
 
+// Merge-write the active input profile id without clobbering other settings — used
+// when the profile-cycle shortcut switches profiles outside the settings screen.
+const updateActiveInputProfileId = async (id: string, activeInputProfileId: string): Promise<void> => {
+  const current = (await store.readConfig(files(), id)) ?? {};
+  await store.writeConfig(files(), id, { ...current, activeInputProfileId });
+};
+
 export {
   listProfiles, createProfile, updateProfile, deleteProfile,
   setLastProfile, updateLastPlayed, getAppState, readConfig, writeConfig,
+  updateActiveInputProfileId,
 };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useControlsSettings.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useControlsSettings.ts
@@ -10,6 +10,7 @@ import { useDeviceSync } from './useDeviceSync';
 import { useBindingState } from './useBindingState';
 import { useDragDrop } from './useDragDrop';
 import { useDisplayMappings } from './useDisplayMappings';
+import { useHapticDevices } from './useHapticDevices';
 
 const useControlsSettings = ({ settings, onChange, profileId }: UseControlsSettingsArgs) => {
   const [activeTab, setActiveTab] = useState<'controls' | 'enhanced' | 'shortcuts' | 'cheats'>('controls');
@@ -54,6 +55,15 @@ const useControlsSettings = ({ settings, onChange, profileId }: UseControlsSetti
 
   const { requiredInputs, displayMappings } = useDisplayMappings({ activeProfile, devices });
 
+  const {
+    hapticEnabledDevices,
+    hapticDragOver,
+    handleHapticDragOver,
+    handleHapticDragLeave,
+    handleHapticDrop,
+    disableHaptics,
+  } = useHapticDevices({ settings, onChange, devices });
+
   return {
     profiles,
     activeProfile,
@@ -70,6 +80,12 @@ const useControlsSettings = ({ settings, onChange, profileId }: UseControlsSetti
     requiredInputs,
     displayMappings,
     displayFunctionMappings,
+    hapticEnabledDevices,
+    hapticDragOver,
+    handleHapticDragOver,
+    handleHapticDragLeave,
+    handleHapticDrop,
+    disableHaptics,
     setActiveTab,
     setSidebarCollapsed,
     setDevicesCollapsed,

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useDisplayMappings.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useDisplayMappings.ts
@@ -8,6 +8,7 @@ import type { InputProfile, DetectedDevice } from '@shared/types/controls';
 import { SNES_BUTTONS } from '@shared/types/controls';
 import { findDeviceProfileByVidPid } from '@shared/input';
 import { publicAsset } from '@app/lib/assets/public-asset';
+import { allowedDevices } from '@app/lib/input/profile-devices';
 import { padHex } from './controls-settings.type';
 
 interface UseDisplayMappingsArgs {
@@ -19,7 +20,7 @@ const useDisplayMappings = ({ activeProfile, devices }: UseDisplayMappingsArgs) 
   const requiredInputs = useMemo(() => {
     if (!activeProfile) return [];
     const inputs: Array<{ type: 'keyboard' | 'gamepad'; label: string; iconSrc: string; connected: boolean }> = [];
-    const hasKeyboard = activeProfile.mappings.some(m => m.binding.type === 'keyboard');
+    const { keyboard: hasKeyboard, gamepadKeys: usedDeviceKeys } = allowedDevices(activeProfile);
     const hasGamepad = activeProfile.mappings.some(m => m.binding.type !== 'keyboard');
 
     const familyIconMap: Record<string, string> = {
@@ -39,17 +40,6 @@ const useDisplayMappings = ({ activeProfile, devices }: UseDisplayMappingsArgs) 
       });
     }
     if (hasGamepad) {
-      const usedDeviceKeys = new Set<string>();
-      for (const m of activeProfile.mappings) {
-        if (m.binding.type !== 'keyboard' && m.sourceVid && m.sourcePid) {
-          usedDeviceKeys.add(`${padHex(m.sourceVid)}:${padHex(m.sourcePid)}`);
-        }
-      }
-      const assigned = activeProfile.assignedDevice;
-      if (assigned?.vendorId && assigned?.productId) {
-        usedDeviceKeys.add(`${padHex(assigned.vendorId)}:${padHex(assigned.productId)}`);
-      }
-
       if (usedDeviceKeys.size > 0) {
         for (const key of usedDeviceKeys) {
           const [vid, pid] = key.split(':');

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useHapticDevices.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useHapticDevices.ts
@@ -1,0 +1,84 @@
+/* @layer renderer-components @kind hook */
+/**
+ * useHapticDevices — manages the per-device haptics enable map. A device that
+ * supports vibration is enabled by default; the settings only store explicit
+ * overrides. Devices are enabled by dropping them onto the haptics box and muted
+ * by removing their chip.
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import type { GameSettings } from '@shared/types/settings';
+import type { DetectedDevice } from '@shared/types/controls';
+import { findController, findControllerById } from '@shared/input/register-all';
+import { padHex } from './controls-settings.type';
+
+interface UseHapticDevicesArgs {
+  settings: GameSettings;
+  onChange: (patch: Partial<GameSettings>) => void;
+  devices: DetectedDevice[];
+}
+
+interface HapticDeviceChip {
+  key: string;
+  label: string;
+}
+
+const supportsVibration = (device: DetectedDevice): boolean => {
+  const ctrl = device.presetId
+    ? findControllerById(device.presetId)
+    : device.vendorId && device.productId
+      ? findController(device.vendorId, device.productId)
+      : null;
+  return ctrl?.supportsVibration() ?? false;
+};
+
+const useHapticDevices = ({ settings, onChange, devices }: UseHapticDevicesArgs) => {
+  const [hapticDragOver, setHapticDragOver] = useState(false);
+
+  const hapticEnabledDevices = useMemo<HapticDeviceChip[]>(() => {
+    const overrides = settings.hapticDevices ?? {};
+    return devices
+      .filter(d => d.type === 'gamepad' && d.vendorId && d.productId && supportsVibration(d))
+      .map(d => ({ key: `${padHex(d.vendorId!)}:${padHex(d.productId!)}`, label: d.displayName }))
+      .filter(chip => overrides[chip.key] !== false);
+  }, [devices, settings.hapticDevices]);
+
+  const handleHapticDragOver = useCallback((e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes('application/x-vid')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      setHapticDragOver(true);
+    }
+  }, []);
+
+  const handleHapticDragLeave = useCallback(() => setHapticDragOver(false), []);
+
+  const handleHapticDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setHapticDragOver(false);
+    const vid = e.dataTransfer.getData('application/x-vid');
+    const pid = e.dataTransfer.getData('application/x-pid');
+    if (!vid || !pid) return;
+    const key = `${padHex(vid)}:${padHex(pid)}`;
+    // Clearing the override returns the device to its default (enabled when supported).
+    const next = { ...(settings.hapticDevices ?? {}) };
+    delete next[key];
+    onChange({ hapticDevices: next });
+  }, [settings.hapticDevices, onChange]);
+
+  const disableHaptics = useCallback((key: string) => {
+    onChange({ hapticDevices: { ...(settings.hapticDevices ?? {}), [key]: false } });
+  }, [settings.hapticDevices, onChange]);
+
+  return {
+    hapticEnabledDevices,
+    hapticDragOver,
+    handleHapticDragOver,
+    handleHapticDragLeave,
+    handleHapticDrop,
+    disableHaptics,
+  };
+};
+
+export { useHapticDevices };
+export type { HapticDeviceChip };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useProfileActions.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls-settings/useProfileActions.ts
@@ -42,13 +42,23 @@ const useProfileActions = ({ settings, onChange, profileId }: UseProfileActionsA
       const activeId = settings.activeInputProfileId;
       const active = loaded.find(p => p.id === activeId) ?? loaded[0];
       setActiveProfile(active);
+      getInputManager().setProfiles(loaded);
       getInputManager().setProfile(active);
     })();
   }, [profileId, settings.activeInputProfileId]);
 
+  // ─── Reflect profile-cycle shortcut (PageUp/PageDown) into the UI + settings ───
+  useEffect(() => {
+    return getInputManager().onActiveProfileChange((profile) => {
+      setActiveProfile(profile);
+      onChange({ activeInputProfileId: profile.id });
+    });
+  }, [onChange]);
+
   // ─── Persist helper ───
   const persistProfiles = useCallback(async (updated: InputProfile[]) => {
     setProfiles(updated);
+    getInputManager().setProfiles(updated);
     await writeInputProfiles(profileId, updated);
   }, [profileId]);
 

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/ControlsDevices.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/ControlsDevices.tsx
@@ -4,6 +4,7 @@ import { Box } from '../../../../../../design-system/primitives/Box';
 import { Button } from '../../../../../../design-system/primitives/Button';
 import { Text } from '../../../../../../design-system/primitives/Text';
 import { DeviceCard } from './DeviceCard';
+import { HapticsDropBox } from './HapticsDropBox';
 import type { useControlsSettings } from '../useControlsSettings';
 
 type Ctrl = ReturnType<typeof useControlsSettings>;
@@ -41,6 +42,16 @@ const ControlsDevices = ({ ctrl }: { ctrl: Ctrl }) => {
         {ctrl.filteredDevices.length === 0 && (
           <Text as="p" className="controls-settings__no-devices">No devices detected</Text>
         )}
+      </Box>
+      <Box className="controls-settings__devices-column-expanded">
+        <HapticsDropBox
+          chips={ctrl.hapticEnabledDevices}
+          dragOver={ctrl.hapticDragOver}
+          onDragOver={ctrl.handleHapticDragOver}
+          onDragLeave={ctrl.handleHapticDragLeave}
+          onDrop={ctrl.handleHapticDrop}
+          onRemove={ctrl.disableHaptics}
+        />
       </Box>
       <Text as="p" className="controls-settings__devices-column-expanded controls-settings__device-hint">
         Click controller icon or drag onto bindings to assign.

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/HapticsDropBox.css
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/HapticsDropBox.css
@@ -1,0 +1,59 @@
+/* @layer renderer-components @kind style */
+.haptics-drop-box {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+}
+
+.haptics-drop-box__title {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--c-text-dim);
+}
+
+.haptics-drop-box__zone {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  min-height: 44px;
+  padding: var(--space-sm);
+  background: var(--c-surface);
+  border: 1px dashed var(--c-border);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.haptics-drop-box__zone--drag-over {
+  border-color: var(--c-gold);
+  border-style: solid;
+}
+
+.haptics-drop-box__empty {
+  font-size: var(--text-xs);
+  color: var(--c-text-dim);
+  margin: 0;
+}
+
+.haptics-drop-box__chip {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--c-info-soft);
+  color: var(--c-info);
+  border: 1px solid var(--c-info);
+  border-radius: var(--r-sm);
+  font-size: var(--text-xs);
+}
+
+.haptics-drop-box__chip-remove {
+  cursor: pointer;
+  font-weight: var(--weight-bold);
+}
+
+.haptics-drop-box__chip-remove:hover {
+  color: var(--c-danger);
+}

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/HapticsDropBox.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/HapticsDropBox.tsx
@@ -1,0 +1,55 @@
+/* @layer renderer-components @kind component */
+/**
+ * HapticsDropBox — drop a controller here to enable its haptics. Devices that
+ * support vibration are enabled by default and appear as chips; removing a chip
+ * mutes that device. Presentational — state lives in useHapticDevices.
+ */
+
+import { Box } from '../../../../../../design-system/primitives/Box';
+import { Text } from '../../../../../../design-system/primitives/Text';
+import type { HapticDeviceChip } from '../controls-settings/useHapticDevices';
+import './HapticsDropBox.css';
+
+interface HapticsDropBoxProps {
+  chips: HapticDeviceChip[];
+  dragOver: boolean;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragLeave: () => void;
+  onDrop: (e: React.DragEvent) => void;
+  onRemove: (key: string) => void;
+}
+
+const HapticsDropBox = (props: HapticsDropBoxProps) => {
+  const { chips, dragOver, onDragOver, onDragLeave, onDrop, onRemove } = props;
+
+  return (
+    <Box className="haptics-drop-box">
+      <Text className="haptics-drop-box__title">Haptics</Text>
+      <Box
+        className={`haptics-drop-box__zone ${dragOver ? 'haptics-drop-box__zone--drag-over' : ''}`}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+      >
+        {chips.length === 0 ? (
+          <Text as="p" className="haptics-drop-box__empty">Drop a controller here to enable rumble.</Text>
+        ) : (
+          chips.map(chip => (
+            <Box key={chip.key} className="haptics-drop-box__chip">
+              <Text className="haptics-drop-box__chip-label">{chip.label}</Text>
+              <Text
+                className="haptics-drop-box__chip-remove"
+                title="Mute haptics for this device"
+                onClick={() => onRemove(chip.key)}
+              >
+                ✕
+              </Text>
+            </Box>
+          ))
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export { HapticsDropBox };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/InputProfileList.css
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/InputProfileList.css
@@ -71,6 +71,19 @@
   text-overflow: ellipsis;
 }
 
+.input-profile-list__item-badge {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--r-sm);
+  background: var(--c-gold-soft);
+  color: var(--c-gold);
+  border: 1px solid var(--c-gold);
+}
+
 .input-profile-list__item-input {
   flex: 1;
   min-width: 0;

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/InputProfileList.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/InputProfileList.tsx
@@ -99,6 +99,9 @@ const InputProfileList = (props: InputProfileListProps) => {
             ) : (
               <Text className="input-profile-list__item-name">{profile.name}</Text>
             )}
+            {profile.id === activeId && editingId !== profile.id && (
+              <Text className="input-profile-list__item-badge" title="Active — drives the game">Active</Text>
+            )}
             {editingId !== profile.id && (
               <Text
                 className="input-profile-list__item-edit"

--- a/shared/input/base.ts
+++ b/shared/input/base.ts
@@ -121,6 +121,12 @@ abstract class BaseController {
   async vibrate(_ctx: ControllerContext, _pattern: VibrationSegment[], _gapMs?: number): Promise<{ ok: boolean; error?: string }> {
     return { ok: false, error: 'vibration not supported' };
   }
+  /**
+   * Map a 0–1 pattern intensity to the motor magnitude this pad should actually play, so each
+   * controller can compensate for how strong its rumble tech feels. Callers apply this to
+   * strength only — segment durations are never changed. Default: identity (no adjustment).
+   */
+  shapeVibration(intensity: number): number { return intensity; }
 
   // ── Stick Calibration ──
   getStickDefaults(): StickDefaults | null { return null; }

--- a/shared/input/data/presets/xbox.ts
+++ b/shared/input/data/presets/xbox.ts
@@ -105,6 +105,13 @@ class XboxController extends BaseController {
   readonly axes = AXES;
 
   supportsVibration(): boolean { return true; }
+
+  // Xbox dual-rumble is a linear ERM magnitude that feels weak at low values — and the motors
+  // barely move below ~0.25 — versus Switch HD rumble's punchy pre-baked pulses. Lift onto a
+  // floor and boost so short combat pulses land hard. Strength only; duration is untouched.
+  shapeVibration(intensity: number): number {
+    return intensity <= 0 ? 0 : Math.min(1, 0.3 + intensity * 0.85);
+  }
 }
 
 registerController(new XboxController());

--- a/shared/types/controls/functions.ts
+++ b/shared/types/controls/functions.ts
@@ -12,6 +12,7 @@ const SHORTCUT_ACTIONS = [
   'load-state-9', 'load-state-10', 'load-state-11', 'load-state-12',
   'pause', 'reset',
   'fullscreen', 'turbo',
+  'profile-next', 'profile-prev',
 ] as const;
 
 const CHEAT_ACTIONS = [
@@ -51,6 +52,8 @@ const FUNCTION_ACTION_LABELS: Record<FunctionAction, string> = {
   'reset': 'Reset',
   'fullscreen': 'Fullscreen',
   'turbo': 'Turbo',
+  'profile-next': 'Next Input Profile',
+  'profile-prev': 'Previous Input Profile',
   'cheat-health': 'Restore Health',
   'cheat-equipment': 'Restore Equipment',
   'cheat-keys': 'Give All Keys',
@@ -94,6 +97,8 @@ const DEFAULT_FUNCTION_MAPPINGS: FunctionMapping[] = [
   { action: 'reset', binding: { type: 'keyboard', code: 'KeyR', modifiers: { ctrl: true } }, icon: null },
   { action: 'fullscreen', binding: { type: 'keyboard', code: 'Enter', modifiers: { alt: true } }, icon: null },
   { action: 'turbo', binding: { type: 'keyboard', code: 'Tab' }, icon: null },
+  { action: 'profile-next', binding: { type: 'keyboard', code: 'PageDown' }, icon: null },
+  { action: 'profile-prev', binding: { type: 'keyboard', code: 'PageUp' }, icon: null },
   { action: 'cheat-health', binding: { type: 'keyboard', code: 'KeyW' }, icon: null },
   { action: 'cheat-equipment', binding: { type: 'keyboard', code: 'KeyW', modifiers: { shift: true } }, icon: null },
   { action: 'cheat-keys', binding: { type: 'keyboard', code: 'KeyO' }, icon: null },

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -152,6 +152,9 @@ interface GameSettings {
 
   // ─── Haptics ───
   haptics: HapticSettings;
+  // Per-device haptics override map, keyed by "vid:pid". Absent key = default
+  // (enabled when the device supports vibration). Set false to mute a device.
+  hapticDevices?: Record<string, boolean>;
 }
 
 export type { GameSettings, HapticSettings };

--- a/tests/input/device-gate.test.ts
+++ b/tests/input/device-gate.test.ts
@@ -1,0 +1,76 @@
+/* @layer test @kind test */
+/**
+ * Device gate — input from a controller only reaches the game when that device
+ * appears in the active profile's map. A connected-but-unmapped pad is dropped.
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import type { InputProfile, ButtonMapping, SnesButton } from '@shared/types/controls';
+import { SNES_BUTTON_BITS } from '@shared/types/controls';
+import { allowedDevices } from '@app/lib/input/profile-devices';
+import { computeBitmask } from '@app/lib/input/polling-engine';
+
+beforeAll(() => {
+  vi.stubGlobal('navigator', { getGamepads: () => [] });
+});
+
+const gamepadBinding = (snes: SnesButton, index: number, vid: string, pid: string): ButtonMapping => ({
+  snesButton: snes,
+  binding: { type: 'gamepad-button', index },
+  icon: null,
+  sourceVid: vid,
+  sourcePid: pid,
+});
+
+const makeProfile = (mappings: ButtonMapping[], assigned: InputProfile['assignedDevice']): InputProfile => ({
+  id: 'p1', name: 'Test', deviceType: 'gamepad', deviceFamily: 'xbox',
+  mappings, isDefault: false, assignedDevice: assigned, createdAt: 0, modifiedAt: 0,
+});
+
+describe('allowedDevices', () => {
+  it('collects binding sources and the assigned device as vid:pid keys', () => {
+    const profile = makeProfile(
+      [gamepadBinding('A', 0, '045e', '02ff')],
+      { vendorId: '045e', productId: '02ff', displayName: 'Xbox', deviceFamily: 'xbox', presetId: 'xbox' },
+    );
+    const allowed = allowedDevices(profile);
+    expect(allowed.keyboard).toBe(false);
+    expect([...allowed.gamepadKeys]).toEqual(['045e:02ff']);
+  });
+
+  it('flags keyboard when the map has a keyboard binding', () => {
+    const profile = makeProfile(
+      [{ snesButton: 'A', binding: { type: 'keyboard', code: 'KeyZ' }, icon: null }],
+      null,
+    );
+    expect(allowedDevices(profile).keyboard).toBe(true);
+  });
+});
+
+describe('computeBitmask device gate', () => {
+  const gamepadButtonMap = new Map<number, SnesButton>([[0, 'A']]);
+  const empty = new Map();
+  const noGamepads = new Map<number, { vid: string; pid: string }>();
+
+  it('passes input from a device in the active profile map', () => {
+    const allowed = { keyboard: false, gamepadKeys: new Set(['057e:2009']) };
+    const hidStates = new Map([['057e:2009', { buttons: [true], axes: [] }]]);
+    const mask = computeBitmask(empty, empty, gamepadButtonMap, empty, hidStates, allowed, noGamepads);
+    expect(mask).toBe(1 << SNES_BUTTON_BITS.A);
+  });
+
+  it('drops input from a connected device that is NOT in the map', () => {
+    const allowed = { keyboard: false, gamepadKeys: new Set(['045e:02ff']) };
+    const hidStates = new Map([['057e:2009', { buttons: [true], axes: [] }]]);
+    const mask = computeBitmask(empty, empty, gamepadButtonMap, empty, hidStates, allowed, noGamepads);
+    expect(mask).toBe(0);
+  });
+
+  it('ignores keyboard input when the profile has no keyboard bindings', () => {
+    const allowed = { keyboard: false, gamepadKeys: new Set<string>() };
+    const keyStates = new Map([['KeyZ', true]]);
+    const keyboardMap = new Map<string, SnesButton>([['KeyZ', 'A']]);
+    const mask = computeBitmask(keyStates, keyboardMap, empty, empty, new Map(), allowed, noGamepads);
+    expect(mask).toBe(0);
+  });
+});

--- a/tests/input/haptic-dispatch.test.ts
+++ b/tests/input/haptic-dispatch.test.ts
@@ -1,0 +1,84 @@
+/* @layer tests @kind test */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HapticSettings } from '@shared/types/settings';
+import { HapticEventType } from '@shared/input/haptics';
+
+// In-game haptics must reach BOTH controller buses: node-hid pads (Switch Pro, DualSense, 8BitDo)
+// and Gamepad-API/XInput pads (Xbox), which rumble through the vibrationActuator and never appear
+// on the HID bus. Regression guard for the Xbox case where sendToController only looked at HID.
+
+const h = vi.hoisted(() => ({
+  hidKeys: [] as string[],
+  gamepads: [] as unknown[],
+  vibrateGamepadPattern: vi.fn(),
+  hidVibrate: vi.fn(),
+}));
+
+vi.mock('../../apps/web/src/lib/input/hid-reader', () => ({
+  webHidReader: { getConnectedDeviceKeys: () => h.hidKeys },
+}));
+vi.mock('../../apps/web/src/lib/input/vibration', () => ({
+  vibrateGamepadPattern: h.vibrateGamepadPattern,
+}));
+vi.mock('../../apps/web/src/lib/input/controllers-store', () => ({
+  vibratePattern: h.hidVibrate,
+}));
+vi.mock('@app/platform/get-platform', () => ({
+  getPlatform: () => ({ device: { vibrate: () => {} } }),
+}));
+
+import { initHapticBridge, destroyHapticBridge } from '../../apps/web/src/lib/input/haptic-bridge';
+
+const settings = (): HapticSettings => ({
+  enabled: true, intensity: 100,
+  swordSwing: true, swordHitEnemy: true, swordClink: true, damageTaken: true,
+  itemUse: true, dashVibration: true, environmentalEffects: true,
+});
+
+const xboxPad = (over: Record<string, unknown> = {}): unknown => ({
+  index: 0, id: 'Xbox 360 Controller (XInput STANDARD GAMEPAD)', connected: true,
+  mapping: 'standard', buttons: [], axes: [],
+  vibrationActuator: { playEffect: () => {} },
+  ...over,
+});
+
+const swing = () => (globalThis as unknown as { window: { __onHapticEvent: (t: number, p: number) => void } })
+  .window.__onHapticEvent(HapticEventType.SWORD_SWING, 0);
+
+beforeEach(() => {
+  h.hidKeys = [];
+  h.gamepads = [];
+  h.vibrateGamepadPattern.mockClear();
+  h.hidVibrate.mockClear();
+  vi.stubGlobal('window', {});
+  vi.stubGlobal('navigator', { getGamepads: () => h.gamepads });
+  destroyHapticBridge(); // reset module state (mixer + __onHapticEvent) between cases
+  initHapticBridge(settings());
+});
+
+describe('haptic dispatch — Gamepad API (Xbox/XInput)', () => {
+  it('rumbles an Xbox pad that is present only on the Gamepad API', () => {
+    h.gamepads = [xboxPad()];
+    swing();
+    expect(h.vibrateGamepadPattern).toHaveBeenCalledTimes(1);
+    expect(h.vibrateGamepadPattern.mock.calls[0][0]).toBe(0); // gp.index
+    // Sword-swing authored at 0.35; Xbox shaping boosts the magnitude before dispatch.
+    const shaped = h.vibrateGamepadPattern.mock.calls[0][1] as { intensity: number }[];
+    expect(shaped[0].intensity).toBeCloseTo(0.5975, 3);
+    expect(h.hidVibrate).not.toHaveBeenCalled();
+  });
+
+  it('skips a pad with no vibrationActuator', () => {
+    h.gamepads = [xboxPad({ vibrationActuator: undefined })];
+    swing();
+    expect(h.vibrateGamepadPattern).not.toHaveBeenCalled();
+  });
+
+  it('does not double-buzz a pad already served over node-hid', () => {
+    // Same physical pad on both buses: HID key + a Gamepad-API entry whose id embeds the vid/pid.
+    h.hidKeys = ['045e:028e'];
+    h.gamepads = [xboxPad({ id: 'xbox controller (Vendor: 045e Product: 028e)' })];
+    swing();
+    expect(h.vibrateGamepadPattern).not.toHaveBeenCalled(); // deduped away from the gamepad bus
+  });
+});

--- a/tests/input/haptic-gates.test.ts
+++ b/tests/input/haptic-gates.test.ts
@@ -1,0 +1,149 @@
+/* @layer tests @kind test */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { HapticSettings } from '@shared/types/settings';
+import {
+  HapticEventType, EnvironmentalEvent,
+  updateHapticSettings, setVibrateFunction, handleHapticEvent,
+  handleDashPulse, handleDeath, handleSpinAttack, handleEnvironmental, resetDashState,
+} from '@shared/input/haptics';
+import { DEFAULT_SETTINGS, serializeToIni } from '../../apps/web/src/lib/game/settings';
+import { buildFeatureFlags } from '../../apps/web/src/lib/game/live-settings-flags';
+
+// Haptics has two gate layers that must both pass for an in-game event to rumble:
+//   1. The C master gate (enhanced_features0 & kFeatures0_Haptics) — off ⇒ zero JS host-calls.
+//      Its bit reaches the core via the boot INI (Haptics key) and the live push (buildFeatureFlags).
+//   2. Seven JS granular gates in the haptic service — one per event category — that drop an event
+//      when its toggle is off even though the C hook fired.
+// This locks both layers: the master bit is wired on both paths, and each granular gate blocks its
+// own category while enabled, and only its own.
+
+const HAPTICS_BIT = 1048576; // kFeatures0_Haptics — must match features.h / live-settings-flags.ts
+
+const settings = (over: Partial<HapticSettings> = {}): HapticSettings => ({
+  enabled: true, intensity: 100,
+  swordSwing: true, swordHitEnemy: true, swordClink: true, damageTaken: true,
+  itemUse: true, dashVibration: true, environmentalEffects: true,
+  ...over,
+});
+
+// Advance the clock a long way on every read so per-pattern cooldowns (module-level state that
+// persists across cases) never block a fresh fire — we assert gating, not debounce timing.
+let clock = 0;
+vi.spyOn(performance, 'now').mockImplementation(() => (clock += 100_000));
+
+let calls: number;
+beforeEach(() => {
+  calls = 0;
+  setVibrateFunction(() => { calls++; });
+  resetDashState();
+});
+
+// Fire every event entry point once; returns how many reached the vibrate function.
+const fireAll = () => {
+  handleHapticEvent(HapticEventType.SWORD_SWING, 0);
+  handleHapticEvent(HapticEventType.SWORD_HIT_ENEMY, 8);
+  handleHapticEvent(HapticEventType.SWORD_CLINK, 0);
+  handleHapticEvent(HapticEventType.DAMAGE_TAKEN, 8);
+  handleHapticEvent(HapticEventType.ITEM_USED, 1 /* BOMBS */);
+  handleHapticEvent(HapticEventType.ENVIRONMENTAL, EnvironmentalEvent.BOMB_EXPLODE);
+  handleDashPulse();
+};
+
+describe('haptics master gate (C-side kFeatures0_Haptics)', () => {
+  it('sends the feature bit on the live path when enabled, and clears it when disabled', () => {
+    expect(buildFeatureFlags({ ...DEFAULT_SETTINGS, haptics: settings() }) & HAPTICS_BIT).toBe(HAPTICS_BIT);
+    expect(buildFeatureFlags({ ...DEFAULT_SETTINGS, haptics: settings({ enabled: false }) }) & HAPTICS_BIT).toBe(0);
+  });
+
+  it('emits the Haptics key on the boot INI path so the bit is set from launch', () => {
+    expect(serializeToIni({ ...DEFAULT_SETTINGS, haptics: settings() })).toContain('Haptics = 1');
+    expect(serializeToIni({ ...DEFAULT_SETTINGS, haptics: settings({ enabled: false }) })).toContain('Haptics = 0');
+  });
+
+  it('JS service drops every event when the master toggle is off', () => {
+    updateHapticSettings(settings({ enabled: false }));
+    fireAll();
+    handleDeath();
+    handleSpinAttack();
+    handleEnvironmental(EnvironmentalEvent.MIRROR_WARP);
+    expect(calls).toBe(0);
+  });
+});
+
+describe('haptics granular gates — each blocks only its own category', () => {
+  it('sword swing', () => {
+    updateHapticSettings(settings({ swordSwing: false }));
+    handleHapticEvent(HapticEventType.SWORD_SWING, 0);
+    handleSpinAttack(); // spin-attack release rides the same toggle
+    expect(calls).toBe(0);
+    updateHapticSettings(settings({ swordSwing: true }));
+    handleHapticEvent(HapticEventType.SWORD_SWING, 0);
+    expect(calls).toBe(1);
+  });
+
+  it('sword hit enemy', () => {
+    updateHapticSettings(settings({ swordHitEnemy: false }));
+    handleHapticEvent(HapticEventType.SWORD_HIT_ENEMY, 8);
+    expect(calls).toBe(0);
+    updateHapticSettings(settings({ swordHitEnemy: true }));
+    handleHapticEvent(HapticEventType.SWORD_HIT_ENEMY, 8);
+    expect(calls).toBe(1);
+  });
+
+  it('sword clink', () => {
+    updateHapticSettings(settings({ swordClink: false }));
+    handleHapticEvent(HapticEventType.SWORD_CLINK, 0);
+    expect(calls).toBe(0);
+    updateHapticSettings(settings({ swordClink: true }));
+    handleHapticEvent(HapticEventType.SWORD_CLINK, 0);
+    expect(calls).toBe(1);
+  });
+
+  it('damage taken (incl. death)', () => {
+    updateHapticSettings(settings({ damageTaken: false }));
+    handleHapticEvent(HapticEventType.DAMAGE_TAKEN, 8);
+    handleDeath(); // death rides the same toggle
+    expect(calls).toBe(0);
+    updateHapticSettings(settings({ damageTaken: true }));
+    handleHapticEvent(HapticEventType.DAMAGE_TAKEN, 8);
+    expect(calls).toBe(1);
+  });
+
+  it('item use (incl. hookshot-wall + boomerang-catch)', () => {
+    updateHapticSettings(settings({ itemUse: false }));
+    handleHapticEvent(HapticEventType.ITEM_USED, 1 /* BOMBS */);
+    handleHapticEvent(HapticEventType.HOOKSHOT_WALL, 0);
+    handleHapticEvent(HapticEventType.BOOMERANG_CATCH, 0);
+    expect(calls).toBe(0);
+    updateHapticSettings(settings({ itemUse: true }));
+    handleHapticEvent(HapticEventType.ITEM_USED, 1 /* BOMBS */);
+    expect(calls).toBe(1);
+  });
+
+  it('dash vibration', () => {
+    updateHapticSettings(settings({ dashVibration: false }));
+    handleDashPulse();
+    expect(calls).toBe(0);
+    updateHapticSettings(settings({ dashVibration: true }));
+    resetDashState(); // clear the inter-pulse throttle
+    handleDashPulse();
+    expect(calls).toBe(1);
+  });
+
+  it('environmental effects', () => {
+    updateHapticSettings(settings({ environmentalEffects: false }));
+    handleHapticEvent(HapticEventType.ENVIRONMENTAL, EnvironmentalEvent.BOMB_EXPLODE);
+    handleEnvironmental(EnvironmentalEvent.MIRROR_WARP); // polling path rides the same toggle
+    expect(calls).toBe(0);
+    updateHapticSettings(settings({ environmentalEffects: true }));
+    handleHapticEvent(HapticEventType.ENVIRONMENTAL, EnvironmentalEvent.BOMB_EXPLODE);
+    expect(calls).toBe(1);
+  });
+
+  it('an unrelated toggle being off does not block other categories', () => {
+    // Only sword-swing off; everything else must still pass.
+    updateHapticSettings(settings({ swordSwing: false }));
+    fireAll(); // sword-swing is one of the 7 fired; the other 6 should ring
+    expect(calls).toBe(6);
+  });
+});

--- a/tests/input/vibration-shaping.test.ts
+++ b/tests/input/vibration-shaping.test.ts
@@ -1,0 +1,24 @@
+/* @layer tests @kind test */
+import { describe, it, expect } from 'vitest';
+import { findControllerById } from '@shared/input/register-all';
+
+// Per-controller strength shaping compensates for how each pad's rumble tech feels. Xbox
+// dual-rumble is linear and soft at low magnitudes, so it boosts; Switch HD-rumble buckets
+// already feel strong, so it stays identity. Shaping only touches magnitude, never duration.
+
+describe('per-controller vibration shaping', () => {
+  it('Xbox boosts low/mid magnitudes onto a floor and clamps at 1', () => {
+    const xbox = findControllerById('xbox')!;
+    expect(xbox.shapeVibration(0)).toBe(0);
+    expect(xbox.shapeVibration(0.35)).toBeCloseTo(0.5975, 4); // faint sword swing → punchy
+    expect(xbox.shapeVibration(0.35)).toBeGreaterThan(0.35);
+    expect(xbox.shapeVibration(1)).toBe(1); // 0.3 + 0.85 = 1.15, clamped
+    expect(xbox.shapeVibration(0.5)).toBeGreaterThan(xbox.shapeVibration(0.2)); // monotonic
+  });
+
+  it('Switch Pro 2 leaves intensity untouched', () => {
+    const spc2 = findControllerById('switch-pro-2')!;
+    expect(spc2.shapeVibration(0.35)).toBe(0.35);
+    expect(spc2.shapeVibration(1)).toBe(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@shared': resolve(__dirname, 'shared'),
+      '@app': resolve(__dirname, 'apps/web/src'),
     },
   },
 });


### PR DESCRIPTION
Fixes a controller driving the game when it shouldn't: input now only comes from devices that are actually in the active profile's map, so a connected but unassigned pad is ignored. Adds PageUp/PageDown to cycle the active profile (rebindable in Shortcuts & Functions) with an Active marker in the profile list, and a Haptics box in the Devices panel where you drag a controller in to enable rumble (supported pads default on).