### PR TITLE
Parse the Haptics INI key so controller rumble actually toggles

### DIFF
--- a/core/zelda3/src/config.c
+++ b/core/zelda3/src/config.c
@@ -516,6 +516,8 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
       return ParseBoolBit(value, &g_config.features0, kFeatures0_CameraLockToViewport);
     } else if (StringEqualsNoCase(key, "SmoothTransitions")) {
       return ParseBoolBit(value, &g_config.features0, kFeatures0_SmoothTransitions);
+    } else if (StringEqualsNoCase(key, "Haptics")) {
+      return ParseBoolBit(value, &g_config.features0, kFeatures0_Haptics);
     }
   }
   return false;


### PR DESCRIPTION
The kFeatures0_Haptics feature bit and its GameHook event path are already in the tree, and the JS side writes Haptics = 1/0 into the config, but the C INI parser never read the key — so the bit was never set from config and haptic events stayed gated off. This adds the missing parse next to the other features0 flags. Left out of the earlier controls PR by mistake.