### PR TITLE
Controller-disconnect overlay: real shortcut glyphs, startup check, on-canvas profile switcher

### DIFF
--- a/apps/web/src/lib/input/binding-display.ts
+++ b/apps/web/src/lib/input/binding-display.ts
@@ -1,0 +1,62 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Binding display — resolves an InputBinding to a human label and an icon URL.
+ * Shared by BindingRow (controls editor), the save-state hints, InputGlyph, and
+ * the controller overlays so icon/label rendering has a single source of truth.
+ */
+
+import type { InputBinding, ButtonIcon, KeyboardBinding } from '@shared/types/controls';
+import { getButtonIconUrl, keyCodeToIconId } from './button-icons';
+
+const formatKeyCode = (code: string): string => {
+  if (code.startsWith('Key')) return code.slice(3);
+  if (code.startsWith('Digit')) return code.slice(5);
+  const map: Record<string, string> = {
+    ArrowUp: 'Arrow Up', ArrowDown: 'Arrow Down', ArrowLeft: 'Arrow Left', ArrowRight: 'Arrow Right',
+    ShiftLeft: 'L.Shift', ShiftRight: 'R.Shift',
+    ControlLeft: 'L.Ctrl', ControlRight: 'R.Ctrl',
+    AltLeft: 'L.Alt', AltRight: 'R.Alt',
+    Enter: 'Enter', Space: 'Space', Backspace: 'Bksp',
+    Tab: 'Tab', Escape: 'Esc', CapsLock: 'Caps',
+    PageUp: 'Page Up', PageDown: 'Page Down',
+  };
+  return map[code] ?? code;
+};
+
+const formatKeyBinding = (b: KeyboardBinding): string => {
+  const parts: string[] = [];
+  if (b.modifiers?.ctrl) parts.push('Ctrl');
+  if (b.modifiers?.shift) parts.push('Shift');
+  if (b.modifiers?.alt) parts.push('Alt');
+  parts.push(b.label ?? formatKeyCode(b.code));
+  return parts.join(' + ');
+};
+
+const getBindingLabel = (binding: InputBinding, icon?: ButtonIcon | null): string => {
+  if (binding.type === 'none') return '—';
+  if (icon?.label) return icon.label;
+  switch (binding.type) {
+    case 'keyboard':
+      return formatKeyBinding(binding);
+    case 'gamepad-button':
+      return binding.label ?? `Button ${binding.index}`;
+    case 'gamepad-axis':
+      return binding.label ?? `Axis ${binding.axisIndex}${binding.direction}`;
+  }
+};
+
+const getBindingIconUrl = (binding: InputBinding, icon?: ButtonIcon | null): string | null => {
+  if (binding.type === 'none') return null;
+  if (icon?.path) return icon.path;
+  if (icon?.key) {
+    const url = getButtonIconUrl(icon.key);
+    if (url) return url;
+  }
+  if (binding.type === 'keyboard') {
+    const iconId = keyCodeToIconId(binding.code);
+    if (iconId) return getButtonIconUrl(iconId);
+  }
+  return null;
+};
+
+export { formatKeyCode, formatKeyBinding, getBindingLabel, getBindingIconUrl };

--- a/apps/web/src/lib/input/input-manager-events.ts
+++ b/apps/web/src/lib/input/input-manager-events.ts
@@ -4,7 +4,19 @@ import { markActivated, updateActivationState } from './device-detector';
 import { resolveGamepadVidPid } from './gamepad-vid-pid';
 import { computeBitmask, snapshotGamepads } from './polling-engine';
 import { allowedDevices } from './profile-devices';
+import { webHidReader } from './hid-reader';
 import type { InputManager } from './input-manager';
+
+/** Fresh set of connected pad "vid:pid" keys — HID (node-hid) + Gamepad API. */
+const connectedGamepadKeys = (m: InputManager): Set<string> => {
+  const keys = new Set(webHidReader.getConnectedDeviceKeys());
+  for (const gp of navigator.getGamepads()) {
+    if (!gp || !gp.connected) continue;
+    const vp = m.gamepadVidPid.get(gp.index);
+    if (vp) keys.add(`${vp.vid}:${vp.pid}`);
+  }
+  return keys;
+};
 
 const isTextInput = (target: EventTarget | null): boolean => {
   if (!target) return false;
@@ -87,14 +99,14 @@ const gamepadConnected = (m: InputManager, e: GamepadEvent): void => {
   markActivated(e.gamepad.index);
   updateActivationState();
   resolveGamepad(m, e.gamepad);
+  m.pauseManager.resumeIfPresent(m.activeProfile, connectedGamepadKeys(m));
   m.refreshDevices();
-  m.pauseManager.autoResume();
 };
 
 const gamepadDisconnected = (m: InputManager): void => {
   updateActivationState();
+  m.pauseManager.checkControllerDisconnect(m.activeProfile, connectedGamepadKeys(m), m.devices);
   m.refreshDevices();
-  m.pauseManager.checkControllerDisconnect(m.activeProfile, m.devices);
 };
 
 const pollFrame = (m: InputManager): void => {
@@ -137,4 +149,4 @@ const pollFrame = (m: InputManager): void => {
   m.animFrameId = requestAnimationFrame(m.pollLoop);
 };
 
-export { isTextInput, rebuildMaps, guardKeys, keyDown, keyUp, resolveGamepad, gamepadConnected, gamepadDisconnected, pollFrame };
+export { isTextInput, rebuildMaps, guardKeys, keyDown, keyUp, resolveGamepad, gamepadConnected, gamepadDisconnected, pollFrame, connectedGamepadKeys };

--- a/apps/web/src/lib/input/input-manager-lifecycle.ts
+++ b/apps/web/src/lib/input/input-manager-lifecycle.ts
@@ -8,7 +8,7 @@ import { webHidReader } from './hid-reader';
 import type { WebHidInputState, DeviceStickCalibration } from './hid-reader';
 import { profileFromPreset } from './profile-utils';
 import { initController, resetController } from './controller-lifecycle';
-import { resolveGamepad } from './input-manager-events';
+import { resolveGamepad, connectedGamepadKeys } from './input-manager-events';
 import type { InputManager } from './input-manager';
 
 // One-time hint when a controller can't be opened on Linux (missing udev rules).
@@ -53,15 +53,16 @@ const startInput = (m: InputManager): void => {
     m.hidStates.set(state.deviceKey, { buttons: state.buttons, axes: state.axes });
     m.currentHidStates.set(state.deviceKey, state);
     m.hidStatesDirty = true;
-    m.pauseManager.autoResume();
+    // A mapped pad sending data again means it's back — resume (gated to the profile).
+    if (m.pauseManager.isPaused) m.resumeIfControllerPresent();
   });
   m.hidDisconnectUnsub = webHidReader.onDisconnect((_deviceKey) => {
     m.hidStates.delete(_deviceKey);
     m.currentHidStates.delete(_deviceKey);
     m.hidStatesDirty = true;
     m.rawDispatcher.removeDevice(_deviceKey);
+    m.pauseManager.checkControllerDisconnect(m.activeProfile, connectedGamepadKeys(m), m.devices);
     m.refreshDevices();
-    m.pauseManager.checkControllerDisconnect(m.activeProfile, m.devices);
   });
 
   m.ipcReportUnsub = controllersStore.onHidReport((deviceKey, vendorId, productId, data) => {
@@ -82,6 +83,7 @@ const startInput = (m: InputManager): void => {
   m.ipcDeviceOpenedUnsub = controllersStore.onHidDeviceOpened((info) => {
     webHidReader.markDeviceOpened(info.deviceKey, info.product);
     initController(info.deviceKey, info.vendorId, info.productId, m.activeControllers);
+    if (m.pauseManager.isPaused) m.resumeIfControllerPresent();
   });
 
   controllersStore.getOpenHidKeys().then(keys => {
@@ -91,7 +93,12 @@ const startInput = (m: InputManager): void => {
   }).catch((e: unknown) => console.warn('[input] failed to read open HID keys', e));
 
   m.refreshDevices();
-  m.devicePollId = setInterval(() => m.refreshDevices(), 2000);
+  m.devicePollId = setInterval(() => {
+    m.refreshDevices();
+    // Safety net for a reconnect that fired no event — resume only, never re-pause,
+    // so a manual resume of a still-absent controller stays resumed.
+    if (m.pauseManager.isPaused) m.resumeIfControllerPresent();
+  }, 2000);
   m.pollLoop();
 };
 

--- a/apps/web/src/lib/input/input-manager-profiles.ts
+++ b/apps/web/src/lib/input/input-manager-profiles.ts
@@ -38,6 +38,9 @@ const cycleActiveProfile = (m: InputManager, direction: 1 | -1): void => {
   for (const fn of m.activeProfileListeners) {
     try { fn(next); } catch { /* ignore */ }
   }
+  // The mapped device set just changed — pause if the new profile's controller is
+  // absent, or resume if it's now present.
+  m.reevaluateControllerPresence();
 };
 
 export { wireProfileActions, setProfiles, subscribeActiveProfile, cycleActiveProfile };

--- a/apps/web/src/lib/input/input-manager.ts
+++ b/apps/web/src/lib/input/input-manager.ts
@@ -28,7 +28,7 @@ import type { GamepadSnapshot } from './polling-engine';
 import type { HidDeviceInfo } from './gamepad-vid-pid';
 import type { ControllerEntry } from './controller-lifecycle';
 import { startInput, stopInput, refreshDevicesImpl } from './input-manager-lifecycle';
-import { rebuildMaps, guardKeys, keyDown, keyUp, gamepadConnected, gamepadDisconnected, pollFrame } from './input-manager-events';
+import { rebuildMaps, guardKeys, keyDown, keyUp, gamepadConnected, gamepadDisconnected, pollFrame, connectedGamepadKeys } from './input-manager-events';
 import { wireProfileActions, setProfiles as setProfilesImpl, subscribeActiveProfile, cycleActiveProfile as cycleActiveProfileImpl } from './input-manager-profiles';
 import type { AllowedDevices } from './profile-devices';
 import type { ActiveProfileListener, DeviceChangeListener, InputStateListener } from './input-manager-types';
@@ -138,6 +138,10 @@ class InputManager {
     return this.activeProfile;
   }
 
+  getProfiles(): InputProfile[] {
+    return this.profiles;
+  }
+
   setProfiles(profiles: InputProfile[]): void {
     setProfilesImpl(this, profiles);
   }
@@ -173,6 +177,21 @@ class InputManager {
 
   isPaused(): boolean {
     return this.pauseManager.isPaused;
+  }
+
+  /** Pause if a device the active profile maps is missing (disconnect / startup / state-load). */
+  checkControllerPresence(): void {
+    this.pauseManager.checkControllerDisconnect(this.activeProfile, connectedGamepadKeys(this), this.devices);
+  }
+
+  /** Resume a disconnect-pause once all the active profile's mapped devices are back. */
+  resumeIfControllerPresent(): void {
+    this.pauseManager.resumeIfPresent(this.activeProfile, connectedGamepadKeys(this));
+  }
+
+  /** Re-check presence after the active profile changes (pause or resume as needed). */
+  reevaluateControllerPresence(): void {
+    this.pauseManager.reevaluateForProfile(this.activeProfile, connectedGamepadKeys(this), this.devices);
   }
 
   resume(): void {

--- a/apps/web/src/lib/input/pause-manager.ts
+++ b/apps/web/src/lib/input/pause-manager.ts
@@ -7,8 +7,20 @@
 
 import type { DetectedDevice } from '@shared/types/controls';
 import type { InputProfile } from '@shared/types/controls';
+import { allowedDevices } from './profile-devices';
 
 type PauseListener = (paused: boolean, controllerName: string) => void;
+
+const padVidPid = (v: string): string => v.toLowerCase().padStart(4, '0');
+
+/** Human-readable name for a mapped device key, for the disconnect overlay. */
+const deviceNameForKey = (profile: InputProfile, devices: DetectedDevice[], key: string): string => {
+  const match = devices.find(d => d.vendorId && d.productId && `${padVidPid(d.vendorId)}:${padVidPid(d.productId)}` === key);
+  if (match) return match.displayName;
+  const assigned = profile.assignedDevice;
+  if (assigned && `${padVidPid(assigned.vendorId)}:${padVidPid(assigned.productId)}` === key) return assigned.displayName;
+  return 'Controller';
+};
 
 class PauseManager {
   private paused = false;
@@ -58,29 +70,56 @@ class PauseManager {
   }
 
   /**
-   * Check if the assigned controller is still connected; pause if not.
+   * Pause if any device the active profile's map references is no longer connected.
+   * `connectedKeys` is the fresh set of "vid:pid" for currently-connected pads (HID
+   * + Gamepad API) — passed in rather than read from the device cache, which lags a
+   * disconnect by a refresh cycle. `devices` is used only to name the missing pad.
    */
-  checkControllerDisconnect(profile: InputProfile | null, devices: DetectedDevice[]): void {
-    if (this.paused) return;
-    const assigned = profile?.assignedDevice;
-    if (assigned && assigned.deviceFamily !== 'keyboard') {
-      const stillConnected = devices.some(
-        d => d.vendorId === assigned.vendorId && d.productId === assigned.productId && d.connected
-      );
-      if (!stillConnected) {
-        this.paused = true;
-        this.pausedControllerName = assigned.displayName;
-        this.onPause?.(true);
-        this.notify(true, assigned.displayName);
-      }
+  checkControllerDisconnect(profile: InputProfile | null, connectedKeys: Set<string>, devices: DetectedDevice[]): void {
+    if (this.paused || !profile) return;
+    const { gamepadKeys } = allowedDevices(profile);
+    for (const key of gamepadKeys) {
+      if (connectedKeys.has(key)) continue;
+      const name = deviceNameForKey(profile, devices, key);
+      this.paused = true;
+      this.pausedControllerName = name;
+      this.onPause?.(true);
+      this.notify(true, name);
+      return;
     }
   }
 
   /**
-   * Auto-resume if paused due to controller disconnect (not manual).
+   * Resume from a disconnect pause only once EVERY device the active profile maps is
+   * connected again. Gating on the mapped set means an unrelated controller can't
+   * dismiss the overlay — only the right one reconnecting (or being activated) does.
+   * Never touches a manual pause.
    */
-  autoResume(): void {
-    if (this.paused && this.pausedControllerName !== 'Manual pause') {
+  resumeIfPresent(profile: InputProfile | null, connectedKeys: Set<string>): void {
+    if (!this.paused || this.pausedControllerName === 'Manual pause' || !profile) return;
+    const { gamepadKeys } = allowedDevices(profile);
+    for (const key of gamepadKeys) {
+      if (!connectedKeys.has(key)) return; // still missing at least one mapped pad
+    }
+    this.resume();
+  }
+
+  /**
+   * Re-evaluate after the ACTIVE PROFILE changes — the mapped device set is now
+   * different, so pause (or re-name the pause) if the new profile's controller is
+   * missing, or resume if it's present. Leaves a manual pause untouched.
+   */
+  reevaluateForProfile(profile: InputProfile | null, connectedKeys: Set<string>, devices: DetectedDevice[]): void {
+    if (!profile || this.pausedControllerName === 'Manual pause') return;
+    const { gamepadKeys } = allowedDevices(profile);
+    const missing = [...gamepadKeys].find(key => !connectedKeys.has(key));
+    if (missing) {
+      const name = deviceNameForKey(profile, devices, missing);
+      this.paused = true;
+      this.pausedControllerName = name;
+      this.onPause?.(true);
+      this.notify(true, name);
+    } else if (this.paused) {
       this.resume();
     }
   }

--- a/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.css
+++ b/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.css
@@ -13,6 +13,16 @@
   flex-shrink: 0;
 }
 
+.input-glyph--sm .input-glyph__icon {
+  width: 18px;
+  height: 18px;
+}
+
+.input-glyph__plain {
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
 .input-glyph__key {
   display: inline-block;
   background: var(--c-bg);

--- a/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.css
+++ b/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.css
@@ -1,0 +1,32 @@
+/* @layer renderer-components @kind style */
+.input-glyph {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  vertical-align: middle;
+}
+
+.input-glyph__icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.input-glyph__key {
+  display: inline-block;
+  background: var(--c-bg);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-sm);
+  padding: var(--space-xs) var(--space-sm);
+  font-family: monospace;
+  font-size: var(--text-sm);
+  color: var(--c-gold);
+  white-space: nowrap;
+}
+
+.input-glyph__label {
+  font-size: var(--text-sm);
+  color: var(--c-text-dim);
+  white-space: nowrap;
+}

--- a/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.tsx
+++ b/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.tsx
@@ -1,8 +1,9 @@
 /* @layer renderer-components @kind component */
 /**
- * InputGlyph — presentational badge for a single input binding: its icon (keyboard
- * key or controller button) with an optional text label. Resolves icon + label via
- * the shared binding-display helpers. Bare/presentational — no data or stores.
+ * InputGlyph — presentational badge for a single input: the icon (keyboard key or
+ * controller button) with an optional text label. Accepts either a full InputBinding
+ * (resolved via the shared binding-display helpers) or a raw button-icon id. Bare/
+ * presentational — no data or stores.
  */
 
 import { Box } from '../../../../design-system/primitives/Box';
@@ -10,26 +11,47 @@ import { Text } from '../../../../design-system/primitives/Text';
 import { Image } from '../../../../design-system/primitives/Image';
 import type { InputBinding, ButtonIcon } from '@shared/types/controls';
 import { getBindingLabel, getBindingIconUrl } from '@app/lib/input/binding-display';
+import { getButtonIconUrl } from '@app/lib/input/button-icons';
 import './InputGlyph.css';
 
 interface InputGlyphProps {
-  binding: InputBinding;
+  binding?: InputBinding;
+  iconId?: string | null;
+  label?: string;
   icon?: ButtonIcon | null;
   showLabel?: boolean;
+  size?: 'sm' | 'md';
+  /** Fallback rendering when there's no icon: a keycap ('key') or plain text ('plain'). */
+  fallbackVariant?: 'key' | 'plain';
+  fallbackClassName?: string;
   className?: string;
 }
 
+const resolve = (props: InputGlyphProps): { iconUrl: string | null; label: string } => {
+  if (props.binding) {
+    return {
+      iconUrl: getBindingIconUrl(props.binding, props.icon ?? null),
+      label: getBindingLabel(props.binding, props.icon ?? null),
+    };
+  }
+  return {
+    iconUrl: props.iconId ? getButtonIconUrl(props.iconId) : null,
+    label: props.label ?? '',
+  };
+};
+
 const InputGlyph = (props: InputGlyphProps) => {
-  const { binding, icon = null, showLabel = true, className = '' } = props;
-  const label = getBindingLabel(binding, icon);
-  const iconUrl = getBindingIconUrl(binding, icon);
+  const { showLabel = true, size = 'md', fallbackVariant = 'key', fallbackClassName = '', className = '' } = props;
+  const { iconUrl, label } = resolve(props);
 
   return (
-    <Box className={`input-glyph ${className}`}>
+    <Box className={`input-glyph input-glyph--${size} ${className}`}>
       {iconUrl ? (
         <Image src={iconUrl} alt={label} className="input-glyph__icon" />
+      ) : fallbackVariant === 'plain' ? (
+        <Text className={`input-glyph__plain ${fallbackClassName}`}>{label}</Text>
       ) : (
-        <Text as="kbd" className="input-glyph__key">{label}</Text>
+        <Text as="kbd" className={`input-glyph__key ${fallbackClassName}`}>{label}</Text>
       )}
       {showLabel && iconUrl && <Text className="input-glyph__label">{label}</Text>}
     </Box>

--- a/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.tsx
+++ b/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.tsx
@@ -1,0 +1,40 @@
+/* @layer renderer-components @kind component */
+/**
+ * InputGlyph — presentational badge for a single input binding: its icon (keyboard
+ * key or controller button) with an optional text label. Resolves icon + label via
+ * the shared binding-display helpers. Bare/presentational — no data or stores.
+ */
+
+import { Box } from '../../../../design-system/primitives/Box';
+import { Text } from '../../../../design-system/primitives/Text';
+import { Image } from '../../../../design-system/primitives/Image';
+import type { InputBinding, ButtonIcon } from '@shared/types/controls';
+import { getBindingLabel, getBindingIconUrl } from '@app/lib/input/binding-display';
+import './InputGlyph.css';
+
+interface InputGlyphProps {
+  binding: InputBinding;
+  icon?: ButtonIcon | null;
+  showLabel?: boolean;
+  className?: string;
+}
+
+const InputGlyph = (props: InputGlyphProps) => {
+  const { binding, icon = null, showLabel = true, className = '' } = props;
+  const label = getBindingLabel(binding, icon);
+  const iconUrl = getBindingIconUrl(binding, icon);
+
+  return (
+    <Box className={`input-glyph ${className}`}>
+      {iconUrl ? (
+        <Image src={iconUrl} alt={label} className="input-glyph__icon" />
+      ) : (
+        <Text as="kbd" className="input-glyph__key">{label}</Text>
+      )}
+      {showLabel && iconUrl && <Text className="input-glyph__label">{label}</Text>}
+    </Box>
+  );
+};
+
+export { InputGlyph };
+export type { InputGlyphProps };

--- a/apps/web/src/ui/domains/app/compounds/InputGlyph/index.ts
+++ b/apps/web/src/ui/domains/app/compounds/InputGlyph/index.ts
@@ -1,0 +1,3 @@
+/* @layer renderer-components @kind barrel */
+export { InputGlyph } from './InputGlyph';
+export type { InputGlyphProps } from './InputGlyph';

--- a/apps/web/src/ui/domains/app/views/GameLayer/GameLayer.tsx
+++ b/apps/web/src/ui/domains/app/views/GameLayer/GameLayer.tsx
@@ -12,6 +12,9 @@ import { useCanvasFit } from '../../../../../hooks/useCanvasFit';
 import { useShadowEditorStore } from '../../../../../stores/shadow-editor-store';
 import { useExclusiveInsetsStore } from '../../../../../stores/exclusive-insets-store';
 import { ControllerDisconnectOverlay } from './sub-components/ControllerDisconnectOverlay';
+import { ProfileSwitcherOverlay } from './sub-components/ProfileSwitcherOverlay';
+import { useControllerOverlay } from './behavior/useControllerOverlay';
+import { useProfileSwitcher } from './behavior/useProfileSwitcher';
 import { NavigationOverlay } from './sub-components/navigation-overlay';
 import { ShadowEditorOverlay } from './sub-components/ShadowEditorOverlay';
 import { ShadowEditorPanel } from './sub-components/ShadowEditorPanel';
@@ -120,24 +123,16 @@ const GameLayer = (props: GameLayerProps) => {
     return unsub;
   }, [status]);
 
-  // Double-click canvas to resume from pause
+  // On game start, verify the profile's mapped controller is actually present.
+  // Delay so HID enumeration / gamepad activation has a moment to populate.
   useEffect(() => {
     if (status !== 'running') return;
+    const id = setTimeout(() => getInputManager().checkControllerPresence(), 800);
+    return () => clearTimeout(id);
+  }, [status]);
 
-    const handleDblClick = () => {
-      const inputMgr = getInputManager();
-      if (inputMgr.isPaused()) {
-        inputMgr.resume();
-      }
-    };
-
-    const canvas = canvasRef.current;
-    canvas?.addEventListener('dblclick', handleDblClick);
-
-    return () => {
-      canvas?.removeEventListener('dblclick', handleDblClick);
-    };
-  }, [status, canvasKey]);
+  const overlay = useControllerOverlay(controllerPaused);
+  const profileSwitcher = useProfileSwitcher(status === 'running');
 
   return (
     <Box
@@ -185,7 +180,14 @@ const GameLayer = (props: GameLayerProps) => {
       />
 
       {controllerPaused && status === 'running' && disconnectedName && disconnectedName !== 'Manual pause' && (
-        <ControllerDisconnectOverlay controllerName={disconnectedName} />
+        <ControllerDisconnectOverlay
+          controllerName={disconnectedName}
+          pauseMapping={overlay.pauseMapping}
+          prevMapping={overlay.prevMapping}
+          nextMapping={overlay.nextMapping}
+          canSwitchProfile={overlay.canSwitchProfile}
+          onResume={overlay.onResume}
+        />
       )}
       {controllerPaused && status === 'running' && (!disconnectedName || disconnectedName === 'Manual pause') && (
         <Box className="game-layer__pause-overlay">
@@ -194,6 +196,15 @@ const GameLayer = (props: GameLayerProps) => {
             <Box className="game-layer__pause-bar" />
           </Box>
         </Box>
+      )}
+      {status === 'running' && (
+        <ProfileSwitcherOverlay
+          open={profileSwitcher.open}
+          profiles={profileSwitcher.profiles}
+          activeId={profileSwitcher.activeId}
+          prevMapping={profileSwitcher.prevMapping}
+          nextMapping={profileSwitcher.nextMapping}
+        />
       )}
       {status === 'running' && <NavigationOverlay width={fitSize.width} height={fitSize.height} gameRunning={status === 'running'} />}
       {status === 'running' && <ShadowEditorOverlay width={fitSize.width} height={fitSize.height} gameRunning={status === 'running'} />}

--- a/apps/web/src/ui/domains/app/views/GameLayer/behavior/useControllerOverlay.ts
+++ b/apps/web/src/ui/domains/app/views/GameLayer/behavior/useControllerOverlay.ts
@@ -1,0 +1,30 @@
+/* @layer renderer-components @kind hook */
+/**
+ * useControllerOverlay — resolves the data the disconnect overlay needs: the bound
+ * resume (pause) shortcut, the profile prev/next shortcuts, whether more than one
+ * profile exists (to offer switching), and a manual-resume handler.
+ * Recomputed when `paused` flips so it reflects the current bindings/profiles.
+ */
+
+import { useMemo } from 'react';
+import { getInputManager } from '../../../../../../lib/game';
+import type { FunctionAction, FunctionMapping } from '@shared/types/controls';
+
+const findMapping = (mappings: FunctionMapping[], action: FunctionAction): FunctionMapping | null =>
+  mappings.find(m => m.action === action && m.binding.type !== 'none') ?? null;
+
+const useControllerOverlay = (paused: boolean) => {
+  return useMemo(() => {
+    const mgr = getInputManager();
+    const mappings = mgr.getFunctionMappings();
+    return {
+      pauseMapping: findMapping(mappings, 'pause'),
+      prevMapping: findMapping(mappings, 'profile-prev'),
+      nextMapping: findMapping(mappings, 'profile-next'),
+      canSwitchProfile: mgr.getProfiles().length > 1,
+      onResume: () => mgr.resume(),
+    };
+  }, [paused]);
+};
+
+export { useControllerOverlay };

--- a/apps/web/src/ui/domains/app/views/GameLayer/behavior/useProfileSwitcher.ts
+++ b/apps/web/src/ui/domains/app/views/GameLayer/behavior/useProfileSwitcher.ts
@@ -1,0 +1,47 @@
+/* @layer renderer-components @kind hook */
+/**
+ * useProfileSwitcher — drives the on-canvas profile switcher drawer. Opens when the
+ * active profile is cycled (the profile-next/prev shortcuts fire onActiveProfileChange),
+ * tracks the active id, and auto-hides after a short idle. No-op with a single profile
+ * (cycling can't change anything, so it never fires).
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { getInputManager } from '../../../../../../lib/game';
+import type { FunctionAction, FunctionMapping, InputProfile } from '@shared/types/controls';
+
+const AUTO_HIDE_MS = 1600;
+
+const findMapping = (mappings: FunctionMapping[], action: FunctionAction): FunctionMapping | null =>
+  mappings.find(m => m.action === action && m.binding.type !== 'none') ?? null;
+
+const useProfileSwitcher = (isRunning: boolean) => {
+  const [open, setOpen] = useState(false);
+  const [profiles, setProfiles] = useState<InputProfile[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isRunning) return undefined;
+    const mgr = getInputManager();
+    const unsub = mgr.onActiveProfileChange((profile) => {
+      setProfiles(mgr.getProfiles());
+      setActiveId(profile.id);
+      setOpen(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setOpen(false), AUTO_HIDE_MS);
+    });
+    return () => { unsub(); clearTimeout(timerRef.current); };
+  }, [isRunning]);
+
+  const mappings = getInputManager().getFunctionMappings();
+  return {
+    open,
+    profiles,
+    activeId,
+    prevMapping: findMapping(mappings, 'profile-prev'),
+    nextMapping: findMapping(mappings, 'profile-next'),
+  };
+};
+
+export { useProfileSwitcher };

--- a/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ControllerDisconnectOverlay.css
+++ b/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ControllerDisconnectOverlay.css
@@ -48,29 +48,17 @@
   font-size: var(--text-base);
   color: var(--c-text-dim);
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
 }
 
 .controller-disconnect-overlay__actions p {
-  margin: 0 0 var(--space-sm);
-}
-
-.controller-disconnect-overlay__actions ul {
   margin: 0;
-  padding-left: var(--space-lg);
-  list-style: disc;
 }
 
-.controller-disconnect-overlay__actions li {
-  margin-bottom: var(--space-xs);
-}
-
-.controller-disconnect-overlay__actions kbd {
-  display: inline-block;
-  background: var(--c-bg);
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  padding: var(--space-xs) var(--space-sm);
-  font-family: monospace;
-  font-size: var(--text-sm);
-  color: var(--c-gold);
+.controller-disconnect-overlay__option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
 }

--- a/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ControllerDisconnectOverlay.tsx
+++ b/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ControllerDisconnectOverlay.tsx
@@ -1,38 +1,64 @@
 /* @layer renderer-components @kind component */
 /**
- * ControllerDisconnectOverlay — shown when the active controller disconnects
- * during gameplay. Blocks input and shows resume instructions.
+ * ControllerDisconnectOverlay — shown when a device the active profile maps
+ * disconnects (or is missing at startup). Blocks input and shows how to recover,
+ * with the actual bound shortcuts rendered as icons. Double-click resumes.
  */
 
 import { Box } from '../../../../../design-system/primitives/Box';
 import { Text } from '../../../../../design-system/primitives/Text';
+import { InputGlyph } from '../../../compounds/InputGlyph';
+import { resolveFunctionMappingIcon } from '../../../../../../lib/game';
+import type { FunctionMapping } from '@shared/types/controls';
 import './ControllerDisconnectOverlay.css';
 
 interface ControllerDisconnectOverlayProps {
   controllerName: string;
+  pauseMapping: FunctionMapping | null;
+  prevMapping: FunctionMapping | null;
+  nextMapping: FunctionMapping | null;
+  canSwitchProfile: boolean;
+  onResume: () => void;
 }
 
+const glyph = (m: FunctionMapping) => (
+  <InputGlyph binding={m.binding} icon={m.icon ?? resolveFunctionMappingIcon(m)} showLabel={false} />
+);
+
 const ControllerDisconnectOverlay = (props: ControllerDisconnectOverlayProps) => {
-  const { controllerName } = props;
+  const { controllerName, pauseMapping, prevMapping, nextMapping, canSwitchProfile, onResume } = props;
+  const showResume = pauseMapping != null && pauseMapping.binding.type !== 'none';
+  const showSwitch = canSwitchProfile && prevMapping != null && nextMapping != null;
+
   return (
-    <Box className="controller-disconnect-overlay">
+    <Box className="controller-disconnect-overlay" onDoubleClick={onResume}>
       <Box className="controller-disconnect-overlay__card">
         <Box className="controller-disconnect-overlay__icon">🎮</Box>
         <Text as="h2" className="controller-disconnect-overlay__title">Controller Disconnected</Text>
         <Text as="p" className="controller-disconnect-overlay__message">
-          <Text as="strong">{controllerName}</Text> has been disconnected.
+          <Text as="strong">{controllerName}</Text> is not connected.
         </Text>
         <Box className="controller-disconnect-overlay__actions">
-          <Text as="p">Reconnect the controller, or:</Text>
-          <Box as="ul">
-            <Text as="li">Double-click the game canvas to resume</Text>
-            <Text as="li">Press <Text as="kbd">F10</Text> to resume</Text>
-            <Text as="li">Use another registered controller</Text>
+          <Text as="p">Reconnect it to continue, or:</Text>
+          <Box className="controller-disconnect-overlay__option">
+            <Text>Double-click here to resume</Text>
           </Box>
+          {showResume && (
+            <Box className="controller-disconnect-overlay__option">
+              {glyph(pauseMapping)}
+              <Text>Resume</Text>
+            </Box>
+          )}
+          {showSwitch && (
+            <Box className="controller-disconnect-overlay__option">
+              {glyph(prevMapping)}{glyph(nextMapping)}
+              <Text>Switch input profile</Text>
+            </Box>
+          )}
         </Box>
       </Box>
     </Box>
   );
-}
+};
 
 export { ControllerDisconnectOverlay };

--- a/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ProfileSwitcherOverlay.css
+++ b/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ProfileSwitcherOverlay.css
@@ -1,0 +1,77 @@
+/* @layer renderer-components @kind style */
+.profile-switcher {
+  position: absolute;
+  left: var(--space-lg);
+  top: 50%;
+  transform: translate(calc(-100% - var(--space-lg)), -50%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-width: 200px;
+  max-width: 260px;
+  padding: var(--space-md);
+  background: var(--c-scrim);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+  z-index: var(--z-panel);
+}
+
+.profile-switcher--open {
+  transform: translate(0, -50%);
+  opacity: 1;
+}
+
+.profile-switcher__title {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--c-text-dim);
+}
+
+.profile-switcher__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.profile-switcher__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--r-md);
+  border-left: 2px solid transparent;
+  color: var(--c-text-dim);
+}
+
+.profile-switcher__item--active {
+  background: var(--c-gold-soft);
+  border-left-color: var(--c-gold);
+  color: var(--c-text);
+}
+
+.profile-switcher__item-icon {
+  font-size: var(--text-lg);
+  flex-shrink: 0;
+}
+
+.profile-switcher__item-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-switcher__hint {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding-top: var(--space-xs);
+  border-top: 1px solid var(--c-border);
+  color: var(--c-text-dim);
+  font-size: var(--text-xs);
+}

--- a/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ProfileSwitcherOverlay.tsx
+++ b/apps/web/src/ui/domains/app/views/GameLayer/sub-components/ProfileSwitcherOverlay.tsx
@@ -1,0 +1,53 @@
+/* @layer renderer-components @kind component */
+/**
+ * ProfileSwitcherOverlay — transient drawer on the left of the game canvas that
+ * appears while cycling input profiles (PageUp/PageDown by default). Lists the
+ * profiles with the active one highlighted; auto-hides. Presentational.
+ */
+
+import { Box } from '../../../../../design-system/primitives/Box';
+import { Text } from '../../../../../design-system/primitives/Text';
+import { InputGlyph } from '../../../compounds/InputGlyph';
+import { resolveFunctionMappingIcon } from '../../../../../../lib/game';
+import type { FunctionMapping, InputProfile } from '@shared/types/controls';
+import './ProfileSwitcherOverlay.css';
+
+interface ProfileSwitcherOverlayProps {
+  open: boolean;
+  profiles: InputProfile[];
+  activeId: string | null;
+  prevMapping: FunctionMapping | null;
+  nextMapping: FunctionMapping | null;
+}
+
+const hintGlyph = (m: FunctionMapping | null) =>
+  m ? <InputGlyph binding={m.binding} icon={m.icon ?? resolveFunctionMappingIcon(m)} showLabel={false} /> : null;
+
+const ProfileSwitcherOverlay = (props: ProfileSwitcherOverlayProps) => {
+  const { open, profiles, activeId, prevMapping, nextMapping } = props;
+
+  return (
+    <Box className={`profile-switcher ${open ? 'profile-switcher--open' : ''}`}>
+      <Text className="profile-switcher__title">Input Profile</Text>
+      <Box className="profile-switcher__list">
+        {profiles.map((p) => (
+          <Box
+            key={p.id}
+            className={`profile-switcher__item ${p.id === activeId ? 'profile-switcher__item--active' : ''}`}
+          >
+            <Text className="profile-switcher__item-icon">{p.deviceType === 'keyboard' ? '⌨️' : '🎮'}</Text>
+            <Text className="profile-switcher__item-name">{p.name}</Text>
+          </Box>
+        ))}
+      </Box>
+      {(prevMapping || nextMapping) && (
+        <Box className="profile-switcher__hint">
+          {hintGlyph(prevMapping)}{hintGlyph(nextMapping)}
+          <Text className="profile-switcher__hint-label">Switch</Text>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export { ProfileSwitcherOverlay };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/BindingRow.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/BindingRow.tsx
@@ -9,8 +9,8 @@ import { Box } from '../../../../../../design-system/primitives/Box';
 import { Button } from '../../../../../../design-system/primitives/Button';
 import { Text } from '../../../../../../design-system/primitives/Text';
 import { Image } from '../../../../../../design-system/primitives/Image';
-import type { InputBinding, ButtonIcon, KeyboardBinding } from '@shared/types/controls';
-import { getButtonIconUrl, keyCodeToIconId } from '@app/lib/input/button-icons';
+import type { InputBinding, ButtonIcon } from '@shared/types/controls';
+import { getBindingLabel, getBindingIconUrl } from '@app/lib/input/binding-display';
 import './BindingRow.css';
 
 interface BindingRowProps {
@@ -21,56 +21,6 @@ interface BindingRowProps {
   bindingIcon?: ButtonIcon | null;
   onRebind: () => void;
   onClear?: () => void;
-}
-
-const formatKeyCode = (code: string): string => {
-  if (code.startsWith('Key')) return code.slice(3);
-  if (code.startsWith('Digit')) return code.slice(5);
-  const map: Record<string, string> = {
-    ArrowUp: 'Arrow Up', ArrowDown: 'Arrow Down', ArrowLeft: 'Arrow Left', ArrowRight: 'Arrow Right',
-    ShiftLeft: 'L.Shift', ShiftRight: 'R.Shift',
-    ControlLeft: 'L.Ctrl', ControlRight: 'R.Ctrl',
-    AltLeft: 'L.Alt', AltRight: 'R.Alt',
-    Enter: 'Enter', Space: 'Space', Backspace: 'Bksp',
-    Tab: 'Tab', Escape: 'Esc', CapsLock: 'Caps',
-  };
-  return map[code] ?? code;
-};
-
-const formatKeyBinding = (b: KeyboardBinding): string => {
-  const parts: string[] = [];
-  if (b.modifiers?.ctrl) parts.push('Ctrl');
-  if (b.modifiers?.shift) parts.push('Shift');
-  if (b.modifiers?.alt) parts.push('Alt');
-  parts.push(b.label ?? formatKeyCode(b.code));
-  return parts.join(' + ');
-};
-
-const getBindingLabel = (binding: InputBinding, icon?: ButtonIcon | null): string => {
-  if (binding.type === 'none') return '—';
-  if (icon?.label) return icon.label;
-  switch (binding.type) {
-    case 'keyboard':
-      return formatKeyBinding(binding);
-    case 'gamepad-button':
-      return binding.label ?? `Button ${binding.index}`;
-    case 'gamepad-axis':
-      return binding.label ?? `Axis ${binding.axisIndex}${binding.direction}`;
-  }
-}
-
-const getBindingIconUrl = (binding: InputBinding, icon?: ButtonIcon | null): string | null => {
-  if (binding.type === 'none') return null;
-  if (icon?.path) return icon.path;
-  if (icon?.key) {
-    const url = getButtonIconUrl(icon.key);
-    if (url) return url;
-  }
-  if (binding.type === 'keyboard') {
-    const iconId = keyCodeToIconId(binding.code);
-    if (iconId) return getButtonIconUrl(iconId);
-  }
-  return null;
 }
 
 const BindingRow = (props: BindingRowProps) => {
@@ -126,4 +76,4 @@ const BindingRow = (props: BindingRowProps) => {
   );
 }
 
-export { BindingRow, getBindingIconUrl, getBindingLabel };
+export { BindingRow };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/index.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/controls/index.ts
@@ -1,6 +1,6 @@
 /* @layer renderer-components @kind barrel */
 export { AssignedDeviceCard } from './AssignedControllerCard';
 export { BindingListener } from './BindingListener';
-export { BindingRow, getBindingIconUrl, getBindingLabel } from './BindingRow';
+export { BindingRow } from './BindingRow';
 export { DeviceCard } from './DeviceCard';
 export { InputProfileList } from './InputProfileList';

--- a/apps/web/src/ui/domains/app/views/SaveStateOverlay/SaveStateOverlay.tsx
+++ b/apps/web/src/ui/domains/app/views/SaveStateOverlay/SaveStateOverlay.tsx
@@ -4,8 +4,8 @@ import { saveState, loadState, getActiveProfileId } from '../../../../../lib/gam
 import { SaveSlot } from '../../compounds/SaveSlot';
 import { Box } from '../../../../design-system/primitives/Box';
 import { Text } from '../../../../design-system/primitives/Text';
-import { Image } from '../../../../design-system/primitives/Image';
 import { ProgressRing } from '../../../../design-system/primitives/ProgressRing';
+import { InputGlyph } from '../../compounds/InputGlyph';
 import { log } from '../../../../../lib/log-bus';
 import * as savesStore from '@app/lib/storage/saves-store';
 import type { SlotHint } from './behavior/useEnhancedSaveSlot';
@@ -162,11 +162,14 @@ const SaveStateOverlay = (props: SaveStateOverlayProps) => {
             {hints?.map((hint) => (
               <Box key={hint.action} className={`save-overlay__hint save-overlay__hint--${hint.action}`}>
                 <Box className="save-overlay__hint-icon-wrap">
-                  {hint.iconUrl ? (
-                    <Image src={hint.iconUrl} alt={hint.keyLabel} className="save-overlay__hint-icon" />
-                  ) : (
-                    <Text className="save-overlay__hint-key-text">{hint.keyLabel}</Text>
-                  )}
+                  <InputGlyph
+                    binding={hint.binding}
+                    icon={hint.icon}
+                    showLabel={false}
+                    size="sm"
+                    fallbackVariant="plain"
+                    fallbackClassName="save-overlay__hint-key-text"
+                  />
                   {(hint.action === 'hold-save' || hint.action === 'holding-save') && (
                     <ProgressRing
                       className="save-overlay__hint-ring"

--- a/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.helpers.ts
+++ b/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.helpers.ts
@@ -6,10 +6,10 @@
  */
 
 import { getInputManager, resolveFunctionMappingIcon } from '../../../../../../lib/game';
-import type { FunctionAction, FunctionMapping } from '@shared/types/controls';
-import { getBindingLabel, getBindingIconUrl } from '@app/lib/input/binding-display';
-import { keyCodeToIconId, getButtonIconUrl } from '@app/lib/input/button-icons';
+import type { FunctionMapping, InputBinding, ButtonIcon } from '@shared/types/controls';
 import type { SlotHint } from './enhanced-save-slot.types';
+
+type BindingInfo = { binding: InputBinding; icon: ButtonIcon | null };
 
 const withPauseGuard = async (action: () => Promise<boolean>): Promise<boolean> => {
   const inputMgr = getInputManager();
@@ -26,51 +26,33 @@ const withPauseGuard = async (action: () => Promise<boolean>): Promise<boolean> 
   return result;
 };
 
-const getSlotBinding = (mappings: FunctionMapping[], slot: number): { label: string; iconUrl: string | null } => {
-  const loadAction = `load-state-${slot + 1}` as FunctionAction;
-  const loadMapping = mappings.find(m => m.action === loadAction && m.binding.type !== 'none');
-  if (loadMapping) {
-    const icon = loadMapping.icon ?? resolveFunctionMappingIcon(loadMapping);
-    return {
-      label: getBindingLabel(loadMapping.binding, icon),
-      iconUrl: getBindingIconUrl(loadMapping.binding, icon),
-    };
-  }
-  const saveAction = `save-state-${slot + 1}` as FunctionAction;
-  const saveMapping = mappings.find(m => m.action === saveAction && m.binding.type !== 'none');
-  if (saveMapping) {
-    const icon = saveMapping.icon ?? resolveFunctionMappingIcon(saveMapping);
-    return {
-      label: getBindingLabel(saveMapping.binding, icon),
-      iconUrl: getBindingIconUrl(saveMapping.binding, icon),
-    };
-  }
-  return { label: `Slot ${slot + 1}`, iconUrl: null };
+const bindingInfo = (m: FunctionMapping): BindingInfo => ({
+  binding: m.binding,
+  icon: m.icon ?? resolveFunctionMappingIcon(m),
+});
+
+const getSlotBinding = (mappings: FunctionMapping[], slot: number): BindingInfo => {
+  const loadMapping = mappings.find(m => m.action === `load-state-${slot + 1}` && m.binding.type !== 'none');
+  if (loadMapping) return bindingInfo(loadMapping);
+  const saveMapping = mappings.find(m => m.action === `save-state-${slot + 1}` && m.binding.type !== 'none');
+  if (saveMapping) return bindingInfo(saveMapping);
+  return { binding: { type: 'none' }, icon: null };
 };
 
-const getEscBinding = (): { label: string; iconUrl: string | null } => {
-  const iconId = keyCodeToIconId('Escape');
-  return {
-    label: 'Esc',
-    iconUrl: iconId ? getButtonIconUrl(iconId) : null,
-  };
-};
+const getEscBinding = (): BindingInfo => ({ binding: { type: 'keyboard', code: 'Escape' }, icon: null });
 
 const buildIdleHints = (mappings: FunctionMapping[], slot: number): SlotHint[] => {
   const slotInfo = getSlotBinding(mappings, slot);
   const escInfo = getEscBinding();
   return [
-    { action: 'tap-load', keyLabel: slotInfo.label, iconUrl: slotInfo.iconUrl },
-    { action: 'hold-save', keyLabel: slotInfo.label, iconUrl: slotInfo.iconUrl },
-    { action: 'esc-cancel', keyLabel: escInfo.label, iconUrl: escInfo.iconUrl },
+    { action: 'tap-load', ...slotInfo },
+    { action: 'hold-save', ...slotInfo },
+    { action: 'esc-cancel', ...escInfo },
   ];
 };
 
 const buildHoldingHints = (mappings: FunctionMapping[], slot: number): SlotHint[] => {
-  const slotInfo = getSlotBinding(mappings, slot);
-  return [
-    { action: 'holding-save', keyLabel: slotInfo.label, iconUrl: slotInfo.iconUrl },
-  ];
+  return [{ action: 'holding-save', ...getSlotBinding(mappings, slot) }];
 };
 
 export { withPauseGuard, getSlotBinding, getEscBinding, buildIdleHints, buildHoldingHints };

--- a/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.helpers.ts
+++ b/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.helpers.ts
@@ -7,7 +7,7 @@
 
 import { getInputManager, resolveFunctionMappingIcon } from '../../../../../../lib/game';
 import type { FunctionAction, FunctionMapping } from '@shared/types/controls';
-import { getBindingLabel, getBindingIconUrl } from '../../ProfileHub/sub-components/controls/BindingRow';
+import { getBindingLabel, getBindingIconUrl } from '@app/lib/input/binding-display';
 import { keyCodeToIconId, getButtonIconUrl } from '@app/lib/input/button-icons';
 import type { SlotHint } from './enhanced-save-slot.types';
 

--- a/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.types.ts
+++ b/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.types.ts
@@ -2,6 +2,7 @@
 /**
  * Types and constants for the enhanced save slot state machine.
  */
+import type { InputBinding, ButtonIcon } from '@shared/types/controls';
 
 /** Time in ms below which a second press is considered a "tap" → LOAD */
 const TAP_THRESHOLD_MS = 180;
@@ -10,8 +11,8 @@ type HintAction = 'tap-load' | 'hold-save' | 'esc-cancel' | 'holding-save';
 
 interface SlotHint {
   action: HintAction;
-  keyLabel: string;
-  iconUrl: string | null;
+  binding: InputBinding;
+  icon: ButtonIcon | null;
 }
 
 interface EnhancedSaveSlotState {

--- a/tests/input/pause-disconnect.test.ts
+++ b/tests/input/pause-disconnect.test.ts
@@ -1,0 +1,124 @@
+/* @layer test @kind test */
+/**
+ * Disconnect pause — the game pauses the moment ANY device in the active profile's
+ * map goes missing from the connected set, not just the single assigned device.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { InputProfile, ButtonMapping, DetectedDevice, AssignedDevice } from '@shared/types/controls';
+import { PauseManager } from '@app/lib/input/pause-manager';
+
+const padBinding = (vid: string, pid: string, index: number): ButtonMapping => ({
+  snesButton: 'A', binding: { type: 'gamepad-button', index }, icon: null, sourceVid: vid, sourcePid: pid,
+});
+
+const assigned = (vid: string, pid: string, name: string): AssignedDevice => ({
+  vendorId: vid, productId: pid, displayName: name, deviceFamily: 'xbox', presetId: null,
+});
+
+const profile = (mappings: ButtonMapping[], assignedDevice: AssignedDevice | null): InputProfile => ({
+  id: 'p', name: 'P', deviceType: 'gamepad', deviceFamily: 'xbox',
+  mappings, isDefault: false, assignedDevice, createdAt: 0, modifiedAt: 0,
+});
+
+const device = (vid: string, pid: string, name: string): DetectedDevice => ({
+  id: `hid-${vid}-${pid}`, type: 'gamepad', rawId: name, vendorId: vid, productId: pid,
+  deviceFamily: 'generic', displayName: name, presetId: null, connected: false,
+  activated: false, stale: false, brandLogoKey: null, inputApi: 'hid',
+});
+
+const makePM = () => {
+  const pm = new PauseManager();
+  const events: { paused: boolean; name: string }[] = [];
+  pm.onPause = () => {};
+  pm.subscribe((paused, name) => events.push({ paused, name }));
+  return { pm, events };
+};
+
+describe('PauseManager.checkControllerDisconnect', () => {
+  it('pauses when a mapped device is missing, naming it', () => {
+    const { pm, events } = makePM();
+    const p = profile([padBinding('045e', '02ff', 0)], assigned('057e', '2009', 'Switch Pro'));
+    const connected = new Set(['045e:02ff']); // the Switch (057e:2009) is gone
+    pm.checkControllerDisconnect(p, connected, [device('057e', '2009', 'Switch Pro')]);
+    expect(pm.isPaused).toBe(true);
+    expect(events.at(-1)).toEqual({ paused: true, name: 'Switch Pro' });
+  });
+
+  it('does not pause while every mapped device is still connected', () => {
+    const { pm } = makePM();
+    const p = profile([padBinding('045e', '02ff', 0)], assigned('057e', '2009', 'Switch Pro'));
+    pm.checkControllerDisconnect(p, new Set(['045e:02ff', '057e:2009']), []);
+    expect(pm.isPaused).toBe(false);
+  });
+
+  it('ignores a keyboard-only profile (nothing to disconnect)', () => {
+    const { pm } = makePM();
+    const p = profile([{ snesButton: 'A', binding: { type: 'keyboard', code: 'KeyZ' }, icon: null }], null);
+    pm.checkControllerDisconnect(p, new Set(), []);
+    expect(pm.isPaused).toBe(false);
+  });
+
+  it('is a no-op when already paused', () => {
+    const { pm, events } = makePM();
+    pm.togglePause(); // manual pause
+    const before = events.length;
+    pm.checkControllerDisconnect(profile([padBinding('045e', '02ff', 0)], null), new Set(), []);
+    expect(events.length).toBe(before);
+  });
+});
+
+describe('PauseManager.resumeIfPresent', () => {
+  const p = () => profile([padBinding('045e', '02ff', 0)], assigned('057e', '2009', 'Switch Pro'));
+
+  it('resumes once every mapped device is reconnected', () => {
+    const { pm, events } = makePM();
+    pm.checkControllerDisconnect(p(), new Set(['045e:02ff']), [device('057e', '2009', 'Switch Pro')]);
+    expect(pm.isPaused).toBe(true);
+    pm.resumeIfPresent(p(), new Set(['045e:02ff', '057e:2009']));
+    expect(pm.isPaused).toBe(false);
+    expect(events.at(-1)).toEqual({ paused: false, name: '' });
+  });
+
+  it('does not resume while a mapped device is still missing (a wrong controller connects)', () => {
+    const { pm } = makePM();
+    pm.checkControllerDisconnect(p(), new Set(), [device('057e', '2009', 'Switch Pro')]);
+    pm.resumeIfPresent(p(), new Set(['1234:5678'])); // unrelated pad
+    expect(pm.isPaused).toBe(true);
+  });
+
+  it('never auto-resumes a manual pause', () => {
+    const { pm } = makePM();
+    pm.togglePause();
+    pm.resumeIfPresent(profile([padBinding('045e', '02ff', 0)], null), new Set(['045e:02ff']));
+    expect(pm.isPaused).toBe(true);
+  });
+});
+
+describe('PauseManager.reevaluateForProfile (profile switch)', () => {
+  it('pauses when the newly-selected profile\'s controller is absent', () => {
+    const { pm, events } = makePM();
+    const p = profile([padBinding('057e', '2009', 0)], assigned('057e', '2009', 'Switch Pro'));
+    pm.reevaluateForProfile(p, new Set(['1234:5678']), [device('057e', '2009', 'Switch Pro')]);
+    expect(pm.isPaused).toBe(true);
+    expect(events.at(-1)).toEqual({ paused: true, name: 'Switch Pro' });
+  });
+
+  it('resumes when switching to a profile whose controller is present', () => {
+    const { pm } = makePM();
+    const gone = profile([padBinding('045e', '02ff', 0)], assigned('057e', '2009', 'Switch Pro'));
+    pm.checkControllerDisconnect(gone, new Set(), [device('057e', '2009', 'Switch Pro')]);
+    expect(pm.isPaused).toBe(true);
+    const kbd = profile([{ snesButton: 'A', binding: { type: 'keyboard', code: 'KeyZ' }, icon: null }], null);
+    pm.reevaluateForProfile(kbd, new Set(), []); // keyboard profile has no mapped pads
+    expect(pm.isPaused).toBe(false);
+  });
+
+  it('leaves a manual pause alone', () => {
+    const { pm } = makePM();
+    pm.togglePause();
+    pm.reevaluateForProfile(profile([padBinding('045e', '02ff', 0)], null), new Set(), []);
+    expect(pm.isPaused).toBe(true);
+    expect(pm.controllerName).toBe('Manual pause');
+  });
+});


### PR DESCRIPTION
Pauses and shows the overlay the moment a device the active profile maps is missing — now at game start too, not only on a live unplug — and gates resume to the mapped device so an unrelated controller can't dismiss it. Switching profiles re-checks presence. The overlay shows the actual bound Resume and profile-switch shortcuts as icons (no more hardcoded F10), double-click resumes (was broken — the overlay was eating the event), and it offers profile switching only when more than one profile exists. Adds a reusable InputGlyph component with shared binding-display helpers (BindingRow and the save-state hints now use it), plus an on-canvas profile-switcher drawer driven by the PageUp/PageDown shortcuts.