### PR TITLE
Make InputGlyph the shared input-icon primitive; adopt in save-state hints

### DIFF
--- a/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.css
+++ b/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.css
@@ -13,6 +13,16 @@
   flex-shrink: 0;
 }
 
+.input-glyph--sm .input-glyph__icon {
+  width: 18px;
+  height: 18px;
+}
+
+.input-glyph__plain {
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
 .input-glyph__key {
   display: inline-block;
   background: var(--c-bg);

--- a/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.tsx
+++ b/apps/web/src/ui/domains/app/compounds/InputGlyph/InputGlyph.tsx
@@ -1,8 +1,9 @@
 /* @layer renderer-components @kind component */
 /**
- * InputGlyph — presentational badge for a single input binding: its icon (keyboard
- * key or controller button) with an optional text label. Resolves icon + label via
- * the shared binding-display helpers. Bare/presentational — no data or stores.
+ * InputGlyph — presentational badge for a single input: the icon (keyboard key or
+ * controller button) with an optional text label. Accepts either a full InputBinding
+ * (resolved via the shared binding-display helpers) or a raw button-icon id. Bare/
+ * presentational — no data or stores.
  */
 
 import { Box } from '../../../../design-system/primitives/Box';
@@ -10,26 +11,47 @@ import { Text } from '../../../../design-system/primitives/Text';
 import { Image } from '../../../../design-system/primitives/Image';
 import type { InputBinding, ButtonIcon } from '@shared/types/controls';
 import { getBindingLabel, getBindingIconUrl } from '@app/lib/input/binding-display';
+import { getButtonIconUrl } from '@app/lib/input/button-icons';
 import './InputGlyph.css';
 
 interface InputGlyphProps {
-  binding: InputBinding;
+  binding?: InputBinding;
+  iconId?: string | null;
+  label?: string;
   icon?: ButtonIcon | null;
   showLabel?: boolean;
+  size?: 'sm' | 'md';
+  /** Fallback rendering when there's no icon: a keycap ('key') or plain text ('plain'). */
+  fallbackVariant?: 'key' | 'plain';
+  fallbackClassName?: string;
   className?: string;
 }
 
+const resolve = (props: InputGlyphProps): { iconUrl: string | null; label: string } => {
+  if (props.binding) {
+    return {
+      iconUrl: getBindingIconUrl(props.binding, props.icon ?? null),
+      label: getBindingLabel(props.binding, props.icon ?? null),
+    };
+  }
+  return {
+    iconUrl: props.iconId ? getButtonIconUrl(props.iconId) : null,
+    label: props.label ?? '',
+  };
+};
+
 const InputGlyph = (props: InputGlyphProps) => {
-  const { binding, icon = null, showLabel = true, className = '' } = props;
-  const label = getBindingLabel(binding, icon);
-  const iconUrl = getBindingIconUrl(binding, icon);
+  const { showLabel = true, size = 'md', fallbackVariant = 'key', fallbackClassName = '', className = '' } = props;
+  const { iconUrl, label } = resolve(props);
 
   return (
-    <Box className={`input-glyph ${className}`}>
+    <Box className={`input-glyph input-glyph--${size} ${className}`}>
       {iconUrl ? (
         <Image src={iconUrl} alt={label} className="input-glyph__icon" />
+      ) : fallbackVariant === 'plain' ? (
+        <Text className={`input-glyph__plain ${fallbackClassName}`}>{label}</Text>
       ) : (
-        <Text as="kbd" className="input-glyph__key">{label}</Text>
+        <Text as="kbd" className={`input-glyph__key ${fallbackClassName}`}>{label}</Text>
       )}
       {showLabel && iconUrl && <Text className="input-glyph__label">{label}</Text>}
     </Box>

--- a/apps/web/src/ui/domains/app/views/SaveStateOverlay/SaveStateOverlay.tsx
+++ b/apps/web/src/ui/domains/app/views/SaveStateOverlay/SaveStateOverlay.tsx
@@ -4,8 +4,8 @@ import { saveState, loadState, getActiveProfileId } from '../../../../../lib/gam
 import { SaveSlot } from '../../compounds/SaveSlot';
 import { Box } from '../../../../design-system/primitives/Box';
 import { Text } from '../../../../design-system/primitives/Text';
-import { Image } from '../../../../design-system/primitives/Image';
 import { ProgressRing } from '../../../../design-system/primitives/ProgressRing';
+import { InputGlyph } from '../../compounds/InputGlyph';
 import { log } from '../../../../../lib/log-bus';
 import * as savesStore from '@app/lib/storage/saves-store';
 import type { SlotHint } from './behavior/useEnhancedSaveSlot';
@@ -162,11 +162,14 @@ const SaveStateOverlay = (props: SaveStateOverlayProps) => {
             {hints?.map((hint) => (
               <Box key={hint.action} className={`save-overlay__hint save-overlay__hint--${hint.action}`}>
                 <Box className="save-overlay__hint-icon-wrap">
-                  {hint.iconUrl ? (
-                    <Image src={hint.iconUrl} alt={hint.keyLabel} className="save-overlay__hint-icon" />
-                  ) : (
-                    <Text className="save-overlay__hint-key-text">{hint.keyLabel}</Text>
-                  )}
+                  <InputGlyph
+                    binding={hint.binding}
+                    icon={hint.icon}
+                    showLabel={false}
+                    size="sm"
+                    fallbackVariant="plain"
+                    fallbackClassName="save-overlay__hint-key-text"
+                  />
                   {(hint.action === 'hold-save' || hint.action === 'holding-save') && (
                     <ProgressRing
                       className="save-overlay__hint-ring"

--- a/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.helpers.ts
+++ b/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.helpers.ts
@@ -6,10 +6,10 @@
  */
 
 import { getInputManager, resolveFunctionMappingIcon } from '../../../../../../lib/game';
-import type { FunctionAction, FunctionMapping } from '@shared/types/controls';
-import { getBindingLabel, getBindingIconUrl } from '@app/lib/input/binding-display';
-import { keyCodeToIconId, getButtonIconUrl } from '@app/lib/input/button-icons';
+import type { FunctionMapping, InputBinding, ButtonIcon } from '@shared/types/controls';
 import type { SlotHint } from './enhanced-save-slot.types';
+
+type BindingInfo = { binding: InputBinding; icon: ButtonIcon | null };
 
 const withPauseGuard = async (action: () => Promise<boolean>): Promise<boolean> => {
   const inputMgr = getInputManager();
@@ -26,51 +26,33 @@ const withPauseGuard = async (action: () => Promise<boolean>): Promise<boolean> 
   return result;
 };
 
-const getSlotBinding = (mappings: FunctionMapping[], slot: number): { label: string; iconUrl: string | null } => {
-  const loadAction = `load-state-${slot + 1}` as FunctionAction;
-  const loadMapping = mappings.find(m => m.action === loadAction && m.binding.type !== 'none');
-  if (loadMapping) {
-    const icon = loadMapping.icon ?? resolveFunctionMappingIcon(loadMapping);
-    return {
-      label: getBindingLabel(loadMapping.binding, icon),
-      iconUrl: getBindingIconUrl(loadMapping.binding, icon),
-    };
-  }
-  const saveAction = `save-state-${slot + 1}` as FunctionAction;
-  const saveMapping = mappings.find(m => m.action === saveAction && m.binding.type !== 'none');
-  if (saveMapping) {
-    const icon = saveMapping.icon ?? resolveFunctionMappingIcon(saveMapping);
-    return {
-      label: getBindingLabel(saveMapping.binding, icon),
-      iconUrl: getBindingIconUrl(saveMapping.binding, icon),
-    };
-  }
-  return { label: `Slot ${slot + 1}`, iconUrl: null };
+const bindingInfo = (m: FunctionMapping): BindingInfo => ({
+  binding: m.binding,
+  icon: m.icon ?? resolveFunctionMappingIcon(m),
+});
+
+const getSlotBinding = (mappings: FunctionMapping[], slot: number): BindingInfo => {
+  const loadMapping = mappings.find(m => m.action === `load-state-${slot + 1}` && m.binding.type !== 'none');
+  if (loadMapping) return bindingInfo(loadMapping);
+  const saveMapping = mappings.find(m => m.action === `save-state-${slot + 1}` && m.binding.type !== 'none');
+  if (saveMapping) return bindingInfo(saveMapping);
+  return { binding: { type: 'none' }, icon: null };
 };
 
-const getEscBinding = (): { label: string; iconUrl: string | null } => {
-  const iconId = keyCodeToIconId('Escape');
-  return {
-    label: 'Esc',
-    iconUrl: iconId ? getButtonIconUrl(iconId) : null,
-  };
-};
+const getEscBinding = (): BindingInfo => ({ binding: { type: 'keyboard', code: 'Escape' }, icon: null });
 
 const buildIdleHints = (mappings: FunctionMapping[], slot: number): SlotHint[] => {
   const slotInfo = getSlotBinding(mappings, slot);
   const escInfo = getEscBinding();
   return [
-    { action: 'tap-load', keyLabel: slotInfo.label, iconUrl: slotInfo.iconUrl },
-    { action: 'hold-save', keyLabel: slotInfo.label, iconUrl: slotInfo.iconUrl },
-    { action: 'esc-cancel', keyLabel: escInfo.label, iconUrl: escInfo.iconUrl },
+    { action: 'tap-load', ...slotInfo },
+    { action: 'hold-save', ...slotInfo },
+    { action: 'esc-cancel', ...escInfo },
   ];
 };
 
 const buildHoldingHints = (mappings: FunctionMapping[], slot: number): SlotHint[] => {
-  const slotInfo = getSlotBinding(mappings, slot);
-  return [
-    { action: 'holding-save', keyLabel: slotInfo.label, iconUrl: slotInfo.iconUrl },
-  ];
+  return [{ action: 'holding-save', ...getSlotBinding(mappings, slot) }];
 };
 
 export { withPauseGuard, getSlotBinding, getEscBinding, buildIdleHints, buildHoldingHints };

--- a/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.types.ts
+++ b/apps/web/src/ui/domains/app/views/SaveStateOverlay/behavior/enhanced-save-slot.types.ts
@@ -2,6 +2,7 @@
 /**
  * Types and constants for the enhanced save slot state machine.
  */
+import type { InputBinding, ButtonIcon } from '@shared/types/controls';
 
 /** Time in ms below which a second press is considered a "tap" → LOAD */
 const TAP_THRESHOLD_MS = 180;
@@ -10,8 +11,8 @@ type HintAction = 'tap-load' | 'hold-save' | 'esc-cancel' | 'holding-save';
 
 interface SlotHint {
   action: HintAction;
-  keyLabel: string;
-  iconUrl: string | null;
+  binding: InputBinding;
+  icon: ButtonIcon | null;
 }
 
 interface EnhancedSaveSlotState {


### PR DESCRIPTION
Stacked on #23. InputGlyph now takes either an InputBinding or a raw button-icon id, with size and a fallback variant, so it's the single component for rendering a bound input as an icon+label. The save-state hints use it instead of their own icon-or-text block (SlotHint carries the binding + icon; the duplicate resolution in the helpers is gone). Grid-aligned editor rows (BindingRow, the reserved-Esc row) and the InputTester live-device visualizers are left as-is — different layout/concern where InputGlyph would degrade them. Base will retarget to master once #23 merges.