### PR TITLE
Load manual saves by name from the CLI

### DIFF
--- a/apps/desktop/electron/debug/dump-nav-handler.ts
+++ b/apps/desktop/electron/debug/dump-nav-handler.ts
@@ -1,12 +1,14 @@
 /* @layer electron-main @kind logic */
 /**
- * Debug CLI: --dump-nav=N
+ * Debug CLI: --dump-nav=N|NAME
  *
- * Loads save state slot N, dumps navigation widget state (entrances,
- * screen detection, transitions) to debug-output/dump-nav.json, then exits.
+ * Loads a save state — a number is a quick-save slot, a string is a MANUAL
+ * (normal) save's name — dumps navigation widget state (entrances, screen
+ * detection, transitions) to debug-output/dump-nav.json, then exits.
  *
  * Usage:
  *   npx electron dist/electron/main.js --muted --dump-nav=1
+ *   npx electron dist/electron/main.js --muted --dump-nav=test-throne-room
  */
 
 import { app } from 'electron';
@@ -14,10 +16,11 @@ import { join } from 'path';
 import { handle } from '../lib/ipc/handle';
 import { writeFile, mkdir } from 'fs/promises';
 
-const parseDumpNavSlot = (): number | null => {
+const parseDumpNavSlot = (): number | string | null => {
   for (const arg of process.argv) {
-    const match = arg.match(/^--dump-nav=(\d+)$/);
-    if (match) return parseInt(match[1], 10);
+    const match = arg.match(/^--dump-nav=(.+)$/);
+    // All-digits stays a quick-save slot; anything else is a manual-save name.
+    if (match) return /^\d+$/.test(match[1]) ? parseInt(match[1], 10) : match[1];
   }
   return null;
 };

--- a/apps/desktop/electron/test/ipc-handlers.ts
+++ b/apps/desktop/electron/test/ipc-handlers.ts
@@ -7,11 +7,14 @@
  * Test automation IPC handlers.
  *
  * CLI args consumed by the renderer:
- *   --auto-state=N    Load save state slot N after game starts
+ *   --auto-state=N    Load quick-save slot N after game starts
+ *   --auto-state=NAME Load the MANUAL (normal) save called NAME — names are stable
+ *                     and quick-save can never overwrite them, so automation and
+ *                     regression baselines pin to a name instead of a slot index
  *   --screenshot=NAME Capture window to tests/screenshots/{NAME}.png after state load
  *
  * The renderer calls these IPC channels:
- *   test:getArgs       → returns { autoState: number | null, screenshot: string | null }
+ *   test:getArgs       → returns { autoState: number | string | null, screenshot: string | null }
  *   test:screenshot    → captures BrowserWindow to the given path, returns path
  */
 
@@ -20,13 +23,18 @@ import { join } from 'path';
 import { handle } from '../lib/ipc/handle';
 import { writeFile, mkdir } from 'fs/promises';
 
-const parseTestArgs = (): { autoState: number | null; screenshot: string | null } => {
-  let autoState: number | null = null;
+const parseTestArgs = (): { autoState: number | string | null; screenshot: string | null } => {
+  let autoState: number | string | null = null;
   let screenshot: string | null = null;
 
   for (const arg of process.argv) {
-    const stateMatch = arg.match(/^--auto-state=(\d+)$/);
-    if (stateMatch) autoState = parseInt(stateMatch[1], 10);
+    // All-digits stays a quick-save slot (unchanged); anything else is a
+    // manual-save name.
+    const stateMatch = arg.match(/^--auto-state=(.+)$/);
+    if (stateMatch) {
+      const raw = stateMatch[1];
+      autoState = /^\d+$/.test(raw) ? parseInt(raw, 10) : raw;
+    }
 
     const ssMatch = arg.match(/^--screenshot=(.+)$/);
     if (ssMatch) screenshot = ssMatch[1];

--- a/apps/web/src/App/behavior/useAutoTest.ts
+++ b/apps/web/src/App/behavior/useAutoTest.ts
@@ -4,16 +4,17 @@
  * ║  THIS TEST MUST NEVER BE MODIFIED BY THE AI             ║
  * ╚══════════════════════════════════════════════════════════╝
  *
- * Auto-test hook — reacts to CLI args --auto-state=N --screenshot=NAME.
+ * Auto-test hook — reacts to CLI args --auto-state=N|NAME --screenshot=NAME.
  * When present, automatically:
  *   1. Starts the game with the current profile
- *   2. Loads save state slot N
+ *   2. Loads the requested state — a number is a quick-save slot, a string is a
+ *      manual (normal) save's name
  *   3. Waits for rendering to settle
  *   4. Captures a screenshot via the main process
  */
 
 import { useEffect, useRef } from 'react';
-import { subscribeGameState, loadState } from '../../lib/game';
+import { subscribeGameState, loadStateRef } from '../../lib/game';
 import { log } from '../../lib/log-bus';
 
 interface AutoTestDeps {
@@ -55,8 +56,9 @@ const useAutoTest = ({ activeProfile, loadProfileForGame }: AutoTestDeps) => {
 
       // Load save state if requested
       if (args.autoState !== null) {
-        log.app(`[AutoTest] Loading state slot ${args.autoState}...`);
-        await loadState(args.autoState);
+        const kind = typeof args.autoState === 'number' ? 'quick slot' : 'manual save';
+        log.app(`[AutoTest] Loading ${kind} ${args.autoState}...`);
+        await loadStateRef(args.autoState);
         // Wait for a few frames to render
         await new Promise((r) => setTimeout(r, 2000));
       }

--- a/apps/web/src/App/behavior/useDumpNav.ts
+++ b/apps/web/src/App/behavior/useDumpNav.ts
@@ -10,7 +10,7 @@
 import { useEffect, useRef } from 'react';
 import {
   subscribeGameState,
-  loadState,
+  loadStateRef,
   wasmGetViewportInfo,
   wasmGetGameUIState,
   wasmGetExitScreenMap,
@@ -67,11 +67,12 @@ const useDumpNav = ({ activeProfile, loadProfileForGame }: DumpNavDeps) => {
       });
       if (cancelled) return;
 
-      console.log(`[DumpNav] Game running. Loading state slot ${slot}...`);
-      const loadResult = await loadState(slot);
-      console.log(`[DumpNav] loadState(${slot}) returned: ${loadResult}`);
+      const kind = typeof slot === 'number' ? 'quick slot' : 'manual save';
+      console.log(`[DumpNav] Game running. Loading ${kind} ${slot}...`);
+      const loadResult = await loadStateRef(slot);
+      console.log(`[DumpNav] load ${kind} ${slot} returned: ${loadResult}`);
       if (!loadResult) {
-        const dump = { slot, error: `loadState(${slot}) returned false — save state not found or module not ready` };
+        const dump = { slot, error: `loading ${kind} "${slot}" returned false — state not found or module not ready` };
         await window.api.writeDumpNav(dump);
         setTimeout(() => window.close(), 500);
         return;

--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -10,7 +10,7 @@ export type { SimChestRaw, SimSpriteRaw, SimDoorRaw, SimDoorDirection, SimFlagSn
 export { startGame, resetGame } from './lifecycle';
 export { setMsuData, setAutoSaveConfig, setLinkSpriteData } from './lifecycle';
 export type { MsuTrackData, AutoSaveConfig } from './lifecycle';
-export { saveState, loadState, captureStateBuffer, loadStateFromBuffer } from './save-states';
+export { saveState, loadState, loadNamedState, loadStateRef, captureStateBuffer, loadStateFromBuffer } from './save-states';
 export { fulfillFrameCapture } from './capture-frame';
 export { setItemOverride, clearItemOverrides } from './randomizer';
 export { pushLiveSettings, reassertBackdropBlack, reassertHudHidden, reassertPauseHidden, reassertVolumes, reassertLiveFlagsAfterLoad, reassertFeatureFlags, primeLiveSettings, LIVE_SETTINGS } from './live-settings';

--- a/apps/web/src/lib/game/save-states.ts
+++ b/apps/web/src/lib/game/save-states.ts
@@ -102,6 +102,41 @@ const loadState = async (slot: number): Promise<boolean> => {
 };
 
 /**
+ * Load a NORMAL (manual) save by its name rather than a quick-slot number.
+ * Names are stable and quick-save can never overwrite them, so automation and
+ * regression baselines pin to a name instead of a slot index. Matching is
+ * case-insensitive; the newest save wins if two share a name.
+ */
+const loadNamedState = async (name: string): Promise<boolean> => {
+  const profileId = getProfileId();
+  if (!profileId) {
+    log.app('[LoadState] ABORT: no profileId');
+    return false;
+  }
+  const wanted = name.trim().toLowerCase();
+  const saves = await savesStore.listNormalSaves(profileId);
+  const match = saves.find((s) => s.name.toLowerCase() === wanted);
+  if (!match) {
+    log.error(`[LoadState] No manual save named "${name}". Available: ${saves.map((s) => s.name).join(', ') || 'none'}`);
+    return false;
+  }
+  const buffer = await savesStore.loadNormalSave(profileId, match.id);
+  if (!buffer) {
+    log.error(`[LoadState] Manual save "${match.name}" (${match.id}) has no data on disk`);
+    return false;
+  }
+  log.app(`[LoadState] Loading manual save "${match.name}" (${match.id}, ${buffer.byteLength} bytes)`);
+  return loadStateFromBuffer(buffer);
+};
+
+/**
+ * Load whichever the CLI asked for: a number is a quick-save slot, a string is
+ * a manual save's name. One resolver so every automation flag behaves alike.
+ */
+const loadStateRef = (ref: number | string): Promise<boolean> =>
+  typeof ref === 'number' ? loadState(ref) : loadNamedState(ref);
+
+/**
  * Capture the current game state into a temp slot and return its raw bytes.
  * Encapsulates the WASM/MEMFS dance so views never touch the module directly.
  */
@@ -133,4 +168,4 @@ const loadStateFromBuffer = (buffer: ArrayBuffer, slot = 98): boolean => {
   return true;
 };
 
-export { captureStateBuffer, loadState, loadStateFromBuffer, saveState };
+export { captureStateBuffer, loadNamedState, loadState, loadStateFromBuffer, loadStateRef, saveState };

--- a/shared/ipc/invoke-contract.ts
+++ b/shared/ipc/invoke-contract.ts
@@ -158,14 +158,14 @@ interface InvokeContract {
   'navReview:save': (data: unknown) => Promise<void>;
 
   // Test automation
-  'test:getArgs': () => Promise<{ autoState: number | null; screenshot: string | null }>;
+  'test:getArgs': () => Promise<{ autoState: number | string | null; screenshot: string | null }>;
   'test:screenshot': (name: string) => Promise<string>;
 
   // Debug dumps
   'debug:getDumpLayersSlot': () => Promise<number | null>;
   'debug:getHoverTile': () => Promise<{ col: number; row: number } | null>;
   'debug:dumpLayers': (data: unknown) => Promise<string>;
-  'debug:getDumpNavSlot': () => Promise<number | null>;
+  'debug:getDumpNavSlot': () => Promise<number | string | null>;
   'debug:dumpNav': (data: unknown) => Promise<string>;
   'debug:getSimRunConfig': () => Promise<SimRunConfig | null>;
   'debug:writeSimRun': (data: unknown) => Promise<string>;


### PR DESCRIPTION
Automation and the nav-regression baselines pinned to quick-save slot numbers, which rotate — an accidental quick-save silently invalidated a baseline. Manual saves already carry stable names, so the CLI can address those instead.

- `--auto-state` and `--dump-nav` now accept a name as well as a number: all-digits is a quick slot exactly as before, anything else is a manual save's name
- Both flags go through one resolver so they can't drift apart
- Name matching is case-insensitive, and a miss logs the names that do exist

Stacked on #28 because it builds on that branch's game barrel. Verified: the existing run specs still load `--auto-state=0`, and the nav baselines now capture and check by name with identical results.

Note: this touches two files marked never-modify (`test/ipc-handlers.ts`, `useAutoTest.ts`) with the owner's explicit permission — the numeric path is untouched.