### PR TITLE
Apply custom player sprites live so their palette reaches the screen

### DIFF
--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -10,6 +10,7 @@ export type { DoorBoundaryTile, DungeonMapPosition, FallHole, LiveSpriteInfo, Ov
 export type { SimChestRaw, SimSpriteRaw, SimDoorRaw, SimDoorDirection, SimFlagSnapshot } from './wasm-bridge';
 export { startGame, resetGame } from './lifecycle';
 export { setMsuData, setAutoSaveConfig, setLinkSpriteData } from './lifecycle';
+export { applyPlayerSprite, clearPlayerSprite } from './player-sprite';
 export type { MsuTrackData, AutoSaveConfig } from './lifecycle';
 export { saveState, loadState, loadNamedState, loadStateRef, captureStateBuffer, loadStateFromBuffer } from './save-states';
 export { fulfillFrameCapture } from './capture-frame';

--- a/apps/web/src/lib/game/live-settings-keys.ts
+++ b/apps/web/src/lib/game/live-settings-keys.ts
@@ -75,6 +75,8 @@ const LIVE_SETTINGS: ReadonlySet<keyof GameSettings> = new Set([
   'hudPauseHighlight',
   // Haptics (JS-only, no WASM restart needed)
   'haptics',
+  // Player sprite sheet (swapped in place via WasmApplyPlayerSpriteFile)
+  'linkSprite',
 ]);
 
 export { LIVE_SETTINGS };

--- a/apps/web/src/lib/game/player-sprite.ts
+++ b/apps/web/src/lib/game/player-sprite.ts
@@ -1,0 +1,46 @@
+/* @layer bridge-wasm @kind logic */
+/**
+ * Live player-sprite swapping. The boot path stages a .zspr through the INI (see boot-files), but a
+ * sheet can also be swapped while the game runs: write it to the same MEMFS path and let the core
+ * re-read it, which overwrites the gfx + palette assets and pushes the new palette straight to CGRAM.
+ * Returns false when no game is running, so callers can fall back to "applies on next boot".
+ */
+import { log } from '../log-bus';
+import { getModule } from './wasm-bridge';
+import { isZspr } from './zspr';
+
+const MEMFS_PATH = '/link_sprite.zspr';
+
+/** Swap the running game's player sheet. False if there's no module or the bytes aren't a ZSPR. */
+const applyPlayerSprite = (bytes: Uint8Array): boolean => {
+  const mod = getModule();
+  if (!mod) return false;
+  if (!isZspr(bytes)) {
+    log.app('[PlayerSprite] Refusing to apply — not a ZSPR sheet');
+    return false;
+  }
+  try {
+    mod.FS.writeFile(MEMFS_PATH, bytes);
+    const ok = mod.ccall('WasmApplyPlayerSpriteFile', 'number', ['string'], [MEMFS_PATH]);
+    if (!ok) log.app('[PlayerSprite] Core rejected the sheet');
+    return !!ok;
+  } catch (err) {
+    log.error(`[PlayerSprite] Live apply failed: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
+};
+
+/** Put the stock sheet back in the running game. False if there's no module. */
+const clearPlayerSprite = (): boolean => {
+  const mod = getModule();
+  if (!mod) return false;
+  try {
+    mod.ccall('WasmClearPlayerSprite', null, [], []);
+    return true;
+  } catch (err) {
+    log.error(`[PlayerSprite] Live restore failed: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
+};
+
+export { applyPlayerSprite, clearPlayerSprite };

--- a/apps/web/src/lib/game/zspr.ts
+++ b/apps/web/src/lib/game/zspr.ts
@@ -35,8 +35,11 @@ const PREVIEW_COLS = 2;
 const PREVIEW_W = PREVIEW_COLS * 8;
 const PREVIEW_H = (PREVIEW_TILES.length / PREVIEW_COLS) * 8;
 
+// A palette block holds 15 colors per outfit, for pixel indices 1–15 — index 0 is transparent and has
+// no stored entry, so entry N-1 is the color for index N. The core lands these the same way: 15 words
+// copied to the sprite palette's second slot onward (Palette_Load_LinkArmorAndGloves).
 const snesColor = (pal: Uint8Array, idx: number): [number, number, number] => {
-  const c = word(pal, idx * 2);
+  const c = word(pal, (idx - 1) * 2);
   return [(c & 31) * 8, ((c >> 5) & 31) * 8, ((c >> 10) & 31) * 8];
 };
 

--- a/apps/web/src/ui/domains/app/views/ProfileHub/behavior/apply-settings-effects.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/behavior/apply-settings-effects.ts
@@ -4,10 +4,24 @@ import type React from 'react';
 import type { GameSettings } from '@shared/types/settings';
 import type { ToastItem } from '../../../../../design-system/primitives/Toast';
 import type { ProfileHubProps } from '../ProfileHub.type';
-import { pushLiveSettings, LIVE_SETTINGS, getInputManager } from '../../../../../../lib/game';
+import { pushLiveSettings, LIVE_SETTINGS, getInputManager, applyPlayerSprite, clearPlayerSprite, setLinkSpriteData } from '../../../../../../lib/game';
 import { useHudSettingsStore } from '../../../../../../stores/hud-settings-store';
 import { DEFAULT_FUNCTION_MAPPINGS } from '@shared/types/controls';
 import { writeConfig } from '../../../../../../lib/storage/profile-store';
+import { readLinkSprite } from '../../../../../../lib/storage/link-sprites-store';
+
+// Apply a sprite choice to the running core and re-stage it for the next boot. Staging matters even
+// when the live swap succeeds: the core re-reads the staged bytes when the game restarts.
+const swapPlayerSprite = async (name: string | null): Promise<void> => {
+  if (!name) {
+    setLinkSpriteData(null);
+    clearPlayerSprite();
+    return;
+  }
+  const bytes = await readLinkSprite(name);
+  setLinkSpriteData(bytes ?? null);
+  if (bytes) applyPlayerSprite(bytes);
+};
 
 const syncHudStore = (s: GameSettings): void => {
   useHudSettingsStore.getState().setHudSettings({
@@ -96,6 +110,11 @@ const applySettingsSideEffects = (patch: Partial<GameSettings>, next: GameSettin
   // Notify parent of shadow casting toggle
   if ('postProcessingShadows' in patch) {
     onShadowCastingChange?.(next.postProcessingShadows);
+  }
+
+  // Swap the player sprite sheet in the running core so the choice shows without a restart.
+  if ('linkSprite' in patch) {
+    void swapPlayerSprite(next.linkSprite);
   }
 
   // Sync HUD settings to store for live rendering

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/PlayerSpriteSelector.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/PlayerSpriteSelector.tsx
@@ -38,7 +38,7 @@ const PlayerSpriteSelector = (props: PlayerSpriteSelectorProps) => {
     <Box className="player-sprite-selector">
       <Text className="player-sprite-selector__title">Player Sprite</Text>
       <Text className="player-sprite-selector__hint">
-        Manage sprites in Data Manager › Player Sprites. Applies when the game starts.
+        Manage sprites in Data Manager › Player Sprites. Applies right away.
       </Text>
       <Box className="player-sprite-selector__grid">
         {choices.map((c) => {

--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -39,6 +39,22 @@ uint8 GameHook_GetExtraArmorPct(void);
 // Applies the extra-armor cheat to an incoming damage value (no-op at 0%).
 uint8 GameHook_ApplyExtraArmor(uint8 dmg);
 
+// ─── Custom player sprite sheets (player_sprite.c) ───
+
+// Overwrite the player gfx + armor/gloves palette assets from a ZSPR sheet. |push_live| samples the
+// new palette into the live buffers straight away — pass false before the core is initialized.
+// Returns false (assets untouched) if the sheet is malformed.
+bool PlayerSprite_Apply(const uint8 *data, size_t len, bool push_live);
+
+// Put the stock sheet and palettes back. No-op when no custom sheet is applied.
+void PlayerSprite_Restore(bool push_live);
+
+// True while a custom sheet is applied.
+bool PlayerSprite_HasCustom(void);
+
+// Sample the armor/gloves palette assets into the live palette buffers.
+void PlayerSprite_RefreshPalette(void);
+
 // ─── Haptic Events (haptic_events.c) ───
 
 // Called when the player starts a sword swing animation.

--- a/core/game-hooks/player_sprite.c
+++ b/core/game-hooks/player_sprite.c
@@ -1,0 +1,127 @@
+/* @layer core-game-hooks @kind native */
+// Custom player-character sprite sheets in the community ZSPR format: parse, apply, and revert.
+//
+// A sheet carries 0x7000 bytes of 4bpp tiles plus a palette block (4 outfits x 15 colors, then two
+// glove colors). Applying one overwrites three assets in place. Two things make this more than a
+// memcpy:
+//
+//  * The palette assets are only sampled into the live palette buffers when the game happens to
+//    reload gear palettes, so a swap has to push them itself or the new colors sit unused.
+//  * A save state restores the palette buffers it was recorded with, so a state saved under a
+//    different sheet reinstates that sheet's colors. Callers re-push after a load.
+//
+// The stock assets are snapshotted on first apply so a sheet can be swapped or removed at runtime
+// without rebooting the core.
+#include "game_hooks_internal.h"
+#include <stdlib.h>
+#include "src/load_gfx.h"
+
+enum {
+  kSheetBytes = 0x7000,   // 4bpp player tiles
+  kOutfitBytes = 120,     // 4 outfits x 15 colors x 2 bytes
+  kGloveBytes = 4,        // 2 colors x 2 bytes
+  kArmorAssetBytes = 150, // the stock armor/gloves asset — 5 outfits x 15 colors
+  kHeaderBytes = 27,
+};
+
+static uint8 *g_stock_sheet;
+static uint8 g_stock_outfits[kArmorAssetBytes];
+static uint16 g_stock_gloves[2];
+static bool g_have_stock;
+static bool g_has_custom;
+
+static uint32 ReadWord(const uint8 *b) { return b[0] | (b[1] << 8); }
+static uint32 ReadDword(const uint8 *b) { return b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24); }
+
+// The asset layout is a fixed contract; refuse rather than memcpy past an asset that changed size.
+static bool AssetsHaveExpectedSize(void) {
+  if (kLinkGraphics_SIZE == kSheetBytes && kPalette_ArmorAndGloves_SIZE == kArmorAssetBytes)
+    return true;
+  printf("[PlayerSprite] Unexpected asset sizes (gfx=%u pal=%u) — not applying\n",
+         (unsigned)kLinkGraphics_SIZE, (unsigned)kPalette_ArmorAndGloves_SIZE);
+  return false;
+}
+
+static bool CaptureStock(void) {
+  if (g_have_stock)
+    return true;
+  g_stock_sheet = (uint8 *)malloc(kSheetBytes);
+  if (g_stock_sheet == NULL) {
+    printf("[PlayerSprite] Out of memory capturing stock sheet\n");
+    return false;
+  }
+  memcpy(g_stock_sheet, kLinkGraphics, kSheetBytes);
+  memcpy(g_stock_outfits, kPalette_ArmorAndGloves, kArmorAssetBytes);
+  memcpy(g_stock_gloves, kGlovesColor, kGloveBytes);
+  g_have_stock = true;
+  return true;
+}
+
+// Sample the armor/gloves palette assets into the live palette buffers and flag CGRAM for upload.
+// Safe to call any time after the core is initialized; a no-op visually if nothing changed.
+void PlayerSprite_RefreshPalette(void) {
+  Palette_Load_LinkArmorAndGloves();
+}
+
+bool PlayerSprite_HasCustom(void) {
+  return g_has_custom;
+}
+
+bool PlayerSprite_Apply(const uint8 *data, size_t len, bool push_live) {
+  if (data == NULL || len < kHeaderBytes || memcmp(data, "ZSPR", 4) != 0) {
+    printf("[PlayerSprite] Not a ZSPR sheet\n");
+    return false;
+  }
+  uint32 px_off = ReadDword(data + 9), px_len = ReadWord(data + 13);
+  uint32 pal_off = ReadDword(data + 15), pal_len = ReadWord(data + 19);
+  if (px_len != kSheetBytes ||
+      (uint64)px_off + px_len > len ||
+      (uint64)pal_off + pal_len > len) {
+    printf("[PlayerSprite] Malformed ZSPR header (px=%u+%u pal=%u+%u len=%u)\n",
+           px_off, px_len, pal_off, pal_len, (unsigned)len);
+    return false;
+  }
+  if (!AssetsHaveExpectedSize() || !CaptureStock())
+    return false;
+
+  memcpy(kLinkGraphics, data + px_off, kSheetBytes);
+  // A sheet may ship pixels only; keep the stock colors in that case rather than a partial copy.
+  if (pal_len >= kOutfitBytes)
+    memcpy(kPalette_ArmorAndGloves, data + pal_off, kOutfitBytes);
+  if (pal_len >= kOutfitBytes + kGloveBytes)
+    memcpy(kGlovesColor, data + pal_off + kOutfitBytes, kGloveBytes);
+  g_has_custom = true;
+
+  if (push_live)
+    PlayerSprite_RefreshPalette();
+  return true;
+}
+
+void PlayerSprite_Restore(bool push_live) {
+  if (!g_have_stock || !g_has_custom)
+    return;
+  memcpy(kLinkGraphics, g_stock_sheet, kSheetBytes);
+  memcpy(kPalette_ArmorAndGloves, g_stock_outfits, kArmorAssetBytes);
+  memcpy(kGlovesColor, g_stock_gloves, kGloveBytes);
+  g_has_custom = false;
+  if (push_live)
+    PlayerSprite_RefreshPalette();
+}
+
+// ─── JS-facing exports ───
+// Applying a sheet is file-based (WasmApplyPlayerSpriteFile, emscripten_io.c) so the renderer reuses
+// the MEMFS path it already writes at boot instead of hand-managing a heap buffer.
+
+// Back to the sheet the assets shipped with.
+EMSCRIPTEN_KEEPALIVE
+void WasmClearPlayerSprite(void) {
+  PlayerSprite_Restore(true);
+}
+
+// Re-push the palette assets into the live buffers — used after a save-state load, which restores
+// whatever palette was recorded and would otherwise strand the selected sheet's colors.
+EMSCRIPTEN_KEEPALIVE
+void WasmRefreshPlayerPalette(void) {
+  if (g_has_custom)
+    PlayerSprite_RefreshPalette();
+}

--- a/core/wasm-build/build.mjs
+++ b/core/wasm-build/build.mjs
@@ -46,6 +46,7 @@ const hookSrcs = [
   'game_hooks', 'state_queries', 'state_queries_sprites', 'state_queries_grids',
   'state_queries_tables', 'state_queries_rooms', 'state_queries_room_exits',
   'sim_queries', 'sim_triggers', 'item_overrides', 'check_triggers', 'ui_state', 'cheats', 'haptic_events',
+  'player_sprite',
 ].map((f) => h(`${f}.c`));
 
 // Our Emscripten entry points (replace the native main.c). Resolved from this dir.

--- a/core/wasm-build/emscripten_io.c
+++ b/core/wasm-build/emscripten_io.c
@@ -20,6 +20,7 @@
 #include "src/util.h"
 #include "src/spc_player.h"
 
+#include "game_hooks.h"
 #include "emscripten_internal.h"
 
 // Assets (canonical definitions; declared extern in assets.h)
@@ -121,7 +122,28 @@ void WasmSaveState(int slot) {
 EMSCRIPTEN_KEEPALIVE
 void WasmLoadState(int slot) {
   SaveLoadSlot(kSaveLoad_Load, slot);
+  // A snapshot carries the palette buffers that were live when it was recorded, so a state saved
+  // under a different sheet reinstates that sheet's colors — the selected one would sit unused in
+  // the assets until some in-game event happened to reload gear palettes. Re-push it here.
+  if (PlayerSprite_HasCustom())
+    PlayerSprite_RefreshPalette();
   printf("*** Load state: slot %d\n", slot);
+}
+
+// Swap the player sprite sheet mid-session from a .zspr the renderer wrote to MEMFS. Pushes the new
+// palette live, so the change shows without rebooting the core. Returns 0 and leaves the assets alone
+// if the file is missing or malformed.
+EMSCRIPTEN_KEEPALIVE
+int WasmApplyPlayerSpriteFile(const char *path) {
+  size_t length = 0;
+  uint8 *file = path ? ReadWholeFile(path, &length) : NULL;
+  if (file == NULL) {
+    printf("[PlayerSprite] Could not read %s\n", path ? path : "(null)");
+    return 0;
+  }
+  int ok = PlayerSprite_Apply(file, length, true) ? 1 : 0;
+  free(file);
+  return ok;
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/core/wasm-build/emscripten_main.c
+++ b/core/wasm-build/emscripten_main.c
@@ -32,6 +32,7 @@
 #include "src/features.h"
 #include "src/hud.h"
 
+#include "game_hooks.h"
 #include "emscripten_internal.h"
 
 // ---------------------------------------------------------------------------
@@ -158,22 +159,16 @@ void ChangeWindowScale(int scale_step) {
   // No-op in WASM — browser handles sizing
 }
 
-// Custom Link sprite (.zspr) override — main.c's LoadLinkGraphics isn't linked into the WASM build, so we
-// reimplement the ZSPR load: read the MEMFS path the bridge wrote (LinkGraphics INI key), validate, and copy
-// pixel + palette over the default Link gfx. No-op when unset. Length is checked before reading any offset.
-static void ApplyCustomLinkGraphics(void) {
+// Custom player sprite selected in the profile — main.c's LoadLinkGraphics isn't linked into the WASM
+// build, so read the MEMFS path the bridge wrote (LinkGraphics INI key) and hand it to the sprite
+// module. No-op when unset. The palette isn't pushed live here: the core isn't initialized yet, and
+// the normal startup sequence samples the patched assets on its own.
+static void ApplyConfiguredPlayerSprite(void) {
   size_t length = 0;
   uint8 *file = g_config.link_graphics ? ReadWholeFile(g_config.link_graphics, &length) : NULL;
   if (file == NULL)
     return;
-  if (length >= 27 && memcmp(file, "ZSPR", 4) == 0) {
-    uint32 px_off = DWORD(file[9]), px_len = WORD(file[13]), pal_off = DWORD(file[15]), pal_len = WORD(file[19]);
-    if (px_len == 0x7000 && (uint64)px_off + px_len <= length && (uint64)pal_off + pal_len <= length) {
-      memcpy(kLinkGraphics, file + px_off, 0x7000);
-      if (pal_len >= 120) memcpy(kPalette_ArmorAndGloves, file + pal_off, 120);
-      if (pal_len >= 124) memcpy(kGlovesColor, file + pal_off + 120, 4);
-    }
-  }
+  PlayerSprite_Apply(file, length, false);
   free(file);
 }
 
@@ -189,9 +184,9 @@ int main(int argc, char **argv) {
   // Load game assets
   LoadAssets();
 
-  // Custom Link sprite: if the INI set LinkGraphics (the bridge wrote the .zspr to MEMFS + the key), this
-  // overrides the default Link gfx loaded by LoadAssets. No-op when no sprite is selected (vanilla).
-  ApplyCustomLinkGraphics();
+  // Custom player sprite: if the INI set LinkGraphics (the bridge wrote the .zspr to MEMFS + the key),
+  // this overrides the sheet LoadAssets just read. No-op when no sprite is selected (stock).
+  ApplyConfiguredPlayerSprite();
 
   // Initialize game core (use WASM-safe version to avoid ppu_init signature mismatch)
   WasmZeldaInitialize();


### PR DESCRIPTION
Fixes #31.

Custom sprites were drawing with the stock palette. The sheet overwrote the palette assets at boot, but nothing pushed them into the live buffers, and loading a save state put the old palette back.

- sheet handling moved into its own module
- keeps a copy of the stock assets, so it can swap or revert at runtime
- picking a sprite applies right away now, no restart
- re-pushes the palette after a state load
- fixes picker previews being shifted one color
