### PR TITLE
Optional vsync and pixel-perfect scaling

### DIFF
--- a/apps/web/src/App/PageRouter.tsx
+++ b/apps/web/src/App/PageRouter.tsx
@@ -43,6 +43,7 @@ interface PageRouterProps {
     handleDisplayPerfChange: (enabled: boolean) => void;
     handleEdgeEffectChange: (enabled: boolean) => void;
     handleShadowCastingChange: (enabled: boolean) => void;
+    handlePixelPerfectChange: (enabled: boolean) => void;
   };
   audio: {
     handleMasterVolumeChange: (volume: number) => void;
@@ -146,6 +147,7 @@ const PageRouter = (props: PageRouterProps) => {
             onDisplayPerfChange={display.handleDisplayPerfChange}
             onEdgeEffectChange={display.handleEdgeEffectChange}
             onShadowCastingChange={display.handleShadowCastingChange}
+            onPixelPerfectChange={display.handlePixelPerfectChange}
             onSaveSlotSettingsChange={saveState.handleSaveSlotSettingsChange}
             masterVolumeOverride={audio.muteOverride}
             activeTab={profileHubTab}

--- a/apps/web/src/App/behavior/useDisplaySettings.ts
+++ b/apps/web/src/App/behavior/useDisplaySettings.ts
@@ -15,6 +15,7 @@ const useDisplaySettings = (params: { isGameRunning: boolean }) => {
   const [showFps, setShowFps] = useState(false);
   const [overworldEdgeEffect, setOverworldEdgeEffect] = useState(true);
   const [postProcessingShadows, setPostProcessingShadows] = useState(false);
+  const [pixelPerfect, setPixelPerfect] = useState(false);
 
   const handleWindowModeChange = useCallback((mode: GameSettings['windowMode']) => {
     setWindowMode(mode);
@@ -35,6 +36,10 @@ const useDisplaySettings = (params: { isGameRunning: boolean }) => {
 
   const handleShadowCastingChange = useCallback((enabled: boolean) => {
     setPostProcessingShadows(enabled);
+  }, []);
+
+  const handlePixelPerfectChange = useCallback((enabled: boolean) => {
+    setPixelPerfect(enabled);
   }, []);
 
   // Track fullscreen state for aspect ratio lock
@@ -87,6 +92,7 @@ const useDisplaySettings = (params: { isGameRunning: boolean }) => {
     overworldEdgeEffect: boolean;
     postProcessingShadows: boolean;
     startFullscreen: boolean;
+    pixelPerfect: boolean;
   }) => {
     setWindowMode(settings.windowMode);
     setViewportConstraint(settings.viewportConstraint);
@@ -94,6 +100,7 @@ const useDisplaySettings = (params: { isGameRunning: boolean }) => {
     setShowFps(settings.displayPerfInTitle);
     setOverworldEdgeEffect(settings.overworldEdgeEffect);
     setPostProcessingShadows(settings.postProcessingShadows);
+    setPixelPerfect(settings.pixelPerfect);
     if (settings.startFullscreen) {
       win.setFullscreen(true);
     }
@@ -107,11 +114,13 @@ const useDisplaySettings = (params: { isGameRunning: boolean }) => {
     showFps,
     overworldEdgeEffect,
     postProcessingShadows,
+    pixelPerfect,
     handleWindowModeChange,
     handleConstraintSettingsChange,
     handleDisplayPerfChange,
     handleEdgeEffectChange,
     handleShadowCastingChange,
+    handlePixelPerfectChange,
     initFromSettings,
   };
 };

--- a/apps/web/src/hooks/useCanvasFit.ts
+++ b/apps/web/src/hooks/useCanvasFit.ts
@@ -6,8 +6,53 @@ interface FitSize {
   height: number;
 }
 
-const useCanvasFit = (containerRef: RefObject<HTMLElement | null>, bufW: number, bufH: number, stretch = false): FitSize => {
+interface CanvasFitParams {
+  containerRef: RefObject<HTMLElement | null>;
+  /** Canvas backing-store size. Twice the source resolution — the core presents at 2x. */
+  bufW: number;
+  bufH: number;
+  /** Fill the container outright, ignoring the source proportions. */
+  stretch?: boolean;
+  /** Snap to a whole number of source pixels so none of them come out a different size. */
+  pixelPerfect?: boolean;
+}
+
+/** The backing store is 2x the source resolution, so a source pixel is this many buffer pixels. */
+const BUFFER_OVERSAMPLE = 2;
+
+const getPixelRatio = (): number => {
+  return window.devicePixelRatio || 1;
+};
+
+/**
+ * Largest whole-source-pixel size that still fits.
+ *
+ * Measured in device pixels, not CSS pixels: at 125% or 150% display scaling a size that looks
+ * like a clean multiple in CSS units lands on a fractional number of real pixels, and the uneven
+ * pixel sizes this is meant to remove come straight back. Returns a CSS size for layout.
+ */
+const fitWholePixels = (containerW: number, containerH: number, bufW: number, bufH: number): FitSize => {
+  const dpr = getPixelRatio();
+  const sourceW = bufW / BUFFER_OVERSAMPLE;
+  const sourceH = bufH / BUFFER_OVERSAMPLE;
+
+  // Whole device pixels per source pixel. Never below 1 — a container too small for even 1:1 gets
+  // the smallest honest size and overflows rather than collapsing to nothing.
+  const scale = Math.max(1, Math.floor(Math.min((containerW * dpr) / sourceW, (containerH * dpr) / sourceH)));
+
+  return { width: (sourceW * scale) / dpr, height: (sourceH * scale) / dpr };
+};
+
+/** Largest size preserving the source proportions, filling one axis exactly. */
+const fitProportional = (containerW: number, containerH: number, bufW: number, bufH: number): FitSize => {
+  const scale = Math.min(containerW / bufW, containerH / bufH);
+  return { width: Math.floor(bufW * scale), height: Math.floor(bufH * scale) };
+};
+
+const useCanvasFit = (params: CanvasFitParams): FitSize => {
+  const { containerRef, bufW, bufH, stretch = false, pixelPerfect = false } = params;
   const [size, setSize] = useState<FitSize>({ width: bufW, height: bufH });
+  const [pixelRatio, setPixelRatio] = useState(getPixelRatio);
 
   const compute = useCallback(() => {
     const el = containerRef.current;
@@ -24,12 +69,10 @@ const useCanvasFit = (containerRef: RefObject<HTMLElement | null>, bufW: number,
 
     if (!bufW || !bufH) return;
 
-    const scale = Math.min(containerW / bufW, containerH / bufH);
-    setSize({
-      width: Math.floor(bufW * scale),
-      height: Math.floor(bufH * scale),
-    });
-  }, [containerRef, bufW, bufH, stretch]);
+    setSize(pixelPerfect
+      ? fitWholePixels(containerW, containerH, bufW, bufH)
+      : fitProportional(containerW, containerH, bufW, bufH));
+  }, [containerRef, bufW, bufH, stretch, pixelPerfect]);
 
   useEffect(() => {
     compute();
@@ -40,8 +83,24 @@ const useCanvasFit = (containerRef: RefObject<HTMLElement | null>, bufW: number,
     return () => ro.disconnect();
   }, [compute]);
 
+  // Dragging the window to a monitor with different display scaling changes how many real pixels a
+  // CSS pixel is worth without changing the container's CSS size, so the resize observer above never
+  // fires — this media query does. Re-armed on each change, because a query only ever matches the
+  // ratio it was built with. Nothing but pixel-perfect mode depends on the ratio, so nothing else
+  // pays for the listener.
+  useEffect(() => {
+    if (!pixelPerfect) return;
+    const query = window.matchMedia(`(resolution: ${pixelRatio}dppx)`);
+    const onChange = () => {
+      setPixelRatio(getPixelRatio());
+      compute();
+    };
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, [compute, pixelPerfect, pixelRatio]);
+
   return size;
 };
 
 export { useCanvasFit };
-export type { FitSize };
+export type { CanvasFitParams, FitSize };

--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -15,7 +15,7 @@ export type { MsuTrackData, AutoSaveConfig } from './lifecycle';
 export { saveState, loadState, loadNamedState, loadStateRef, captureStateBuffer, loadStateFromBuffer } from './save-states';
 export { fulfillFrameCapture } from './capture-frame';
 export { setItemOverride, clearItemOverrides } from './randomizer';
-export { pushLiveSettings, reassertBackdropBlack, reassertHudHidden, reassertPauseHidden, reassertVolumes, reassertLiveFlagsAfterLoad, reassertFeatureFlags, primeLiveSettings, LIVE_SETTINGS } from './live-settings';
+export { pushLiveSettings, reassertBackdropBlack, reassertVsync, reassertHudHidden, reassertPauseHidden, reassertVolumes, reassertLiveFlagsAfterLoad, reassertFeatureFlags, primeLiveSettings, LIVE_SETTINGS } from './live-settings';
 export { initMasterVolume, setMasterVolume, suspendAudio, resumeAudio } from './audio-volume';
 export { getFps } from './fps';
 export {

--- a/apps/web/src/lib/game/live-settings-keys.ts
+++ b/apps/web/src/lib/game/live-settings-keys.ts
@@ -42,6 +42,10 @@ const LIVE_SETTINGS: ReadonlySet<keyof GameSettings> = new Set([
   // Window settings (Electron-managed, no WASM restart needed)
   'windowMode',
   'viewportConstraint',
+  // Canvas fit is recomputed from a React prop — no WASM restart needed
+  'pixelPerfect',
+  // Frame pacing (swapped via WasmSetVsync — the main loop's schedule can change mid-run)
+  'vsync',
   // Audio volume (Web Audio gain, no restart needed)
   'masterVolume',
   // Sub-volumes (WASM DSP-level, no restart needed)

--- a/apps/web/src/lib/game/live-settings.ts
+++ b/apps/web/src/lib/game/live-settings.ts
@@ -23,6 +23,9 @@ import { LIVE_SETTINGS } from './live-settings-keys';
 
 // Track the last-pushed forceBackdropBlack value so we can re-assert after state loads
 let lastBackdropBlack = false;
+// Frame pacing mode. The core boots on the timer schedule and has no INI key for this, so the
+// startup re-assert is what actually applies the profile's choice — not just a post-load repair.
+let lastVsync = false;
 // Track the last-pushed hudHidden value so we can re-assert after state loads
 let lastHudHidden = false;
 // Track the last-pushed pauseHidden value so we can re-assert after state loads
@@ -80,6 +83,12 @@ const pushLiveSettings = (settings: GameSettings): boolean => {
       mod.ccall('WasmSetForceBackdropBlack', null, ['number'], [settings.forceBackdropBlack ? 1 : 0]);
     } catch { /* WASM not rebuilt yet */ }
 
+    // Frame pacing (guard: function may not exist in older WASM builds)
+    try {
+      lastVsync = !!settings.vsync;
+      mod.ccall('WasmSetVsync', null, ['number'], [settings.vsync ? 1 : 0]);
+    } catch { /* WASM not rebuilt yet */ }
+
     // Hide native gameplay HUD when enhanced overlay is active
     try {
       const hideHud = settings.hudMode === 'enhanced' && settings.hudEnhancedParts.includes('main');
@@ -115,6 +124,8 @@ const tryVoidCcall = (fn: string, value: number): void => {
 
 const reassertBackdropBlack = (): void => tryVoidCcall('WasmSetForceBackdropBlack', lastBackdropBlack ? 1 : 0);
 
+const reassertVsync = (): void => tryVoidCcall('WasmSetVsync', lastVsync ? 1 : 0);
+
 const reassertHudHidden = (): void => tryVoidCcall('WasmSetHudHidden', lastHudHidden ? 1 : 0);
 
 const reassertPauseHidden = (): void => tryVoidCcall('WasmSetPauseHidden', lastPauseHidden ? 1 : 0);
@@ -130,6 +141,7 @@ const reassertVolumes = (): void => {
 /** Re-assert every live flag after a save-state load clobbers WRAM. */
 const reassertLiveFlagsAfterLoad = (): void => {
   reassertBackdropBlack();
+  reassertVsync();
   reassertHudHidden();
   reassertPauseHidden();
   reassertVolumes();
@@ -154,6 +166,7 @@ const primeLiveSettings = (settings: GameSettings): void => {
   // the features word even before the user changes a setting to trigger a full pushLiveSettings.
   lastSettings = settings;
   lastBackdropBlack = !!settings.forceBackdropBlack;
+  lastVsync = !!settings.vsync;
   const hideHud = settings.hudMode === 'enhanced' && settings.hudEnhancedParts.includes('main');
   lastHudHidden = hideHud;
   const hidePause = settings.hudMode === 'enhanced' && settings.hudEnhancedParts.includes('pause');
@@ -163,4 +176,4 @@ const primeLiveSettings = (settings: GameSettings): void => {
   lastSfxVol = settings.sfxMuted ? 0 : Math.round(settings.sfxVolume * 1.28);
 };
 
-export { LIVE_SETTINGS, pushLiveSettings, reassertBackdropBlack, reassertHudHidden, reassertPauseHidden, reassertVolumes, reassertLiveFlagsAfterLoad, reassertFeatureFlags, primeLiveSettings };
+export { LIVE_SETTINGS, pushLiveSettings, reassertBackdropBlack, reassertVsync, reassertHudHidden, reassertPauseHidden, reassertVolumes, reassertLiveFlagsAfterLoad, reassertFeatureFlags, primeLiveSettings };

--- a/apps/web/src/lib/game/settings.ts
+++ b/apps/web/src/lib/game/settings.ts
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS: GameSettings = {
   saveOnQuit: true,
   displayPerfInTitle: false,
   disableFrameDelay: false,
+  vsync: false,
 
   // Aspect Ratio & Display
   extendedRendering: false,
@@ -46,6 +47,7 @@ const DEFAULT_SETTINGS: GameSettings = {
   windowMode: 'default',
   startFullscreen: false,
   viewportConstraint: 'none',
+  pixelPerfect: false,
 
   // Mobile display
   renderIntoNotch: true,
@@ -182,7 +184,7 @@ WindowScale = ${settings.windowScale}
 NewRenderer = ${boolToIni(settings.newRenderer)}
 EnhancedMode7 = ${boolToIni(settings.enhancedMode7)}
 NoSpriteLimits = ${boolToIni(settings.noSpriteLimits)}
-LinearFiltering = ${boolToIni(settings.linearFiltering)}
+LinearFiltering = ${boolToIni(settings.linearFiltering && !settings.pixelPerfect)}
 OutputMethod = ${settings.outputMethod}
 DimFlashes = ${boolToIni(settings.dimFlashes)}
 ${settings.linkSprite ? 'LinkGraphics = /link_sprite.zspr\n' : ''}

--- a/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
+++ b/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
@@ -63,6 +63,7 @@ const AppMain = () => {
         overworldEdgeEffect: data.settings.overworldEdgeEffect,
         postProcessingShadows: data.settings.postProcessingShadows,
         startFullscreen: data.settings.startFullscreen,
+        pixelPerfect: data.settings.pixelPerfect,
       });
       audio.initFromSettings(data.settings.masterVolume);
       saveState.initFromSettings(data.settings.enhancedSaveSlotShortcut, data.settings.saveHoldDuration);
@@ -152,6 +153,7 @@ const AppMain = () => {
           profileId={profileMgmt.activeProfile?.id}
           stretch={display.viewportConstraint !== 'none'}
           edgeEffect={display.overworldEdgeEffect}
+          pixelPerfect={display.pixelPerfect}
           shadowCasting={display.postProcessingShadows}
         />
 

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/settings-sections.ts
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/settings-sections.ts
@@ -9,7 +9,7 @@ const SETTINGS_SECTIONS: Array<{ title: string; keys: Array<{ key: string; label
     keys: [
       { key: 'autosave', label: 'Autosave' },
       { key: 'displayPerfInTitle', label: 'FPS Counter' },
-      { key: 'disableFrameDelay', label: 'Disable Frame Delay' },
+      { key: 'vsync', label: 'V-Sync' },
     ],
   },
   {
@@ -23,6 +23,7 @@ const SETTINGS_SECTIONS: Array<{ title: string; keys: Array<{ key: string; label
       { key: 'windowMode', label: 'Window Mode', format: (v) => String(v ?? 'default') },
       { key: 'startFullscreen', label: 'Start Fullscreen' },
       { key: 'viewportConstraint', label: 'Viewport Constraint', format: (v) => String(v ?? 'none') },
+      { key: 'pixelPerfect', label: 'Pixel Perfect' },
     ],
   },
   {

--- a/apps/web/src/ui/domains/app/views/GameLayer/GameLayer.tsx
+++ b/apps/web/src/ui/domains/app/views/GameLayer/GameLayer.tsx
@@ -26,7 +26,7 @@ import './GameLayer.css';
 import type { GameLayerProps } from './GameLayer.type';
 
 const GameLayer = (props: GameLayerProps) => {
-  const { assetData, configIni, profileId, stretch, edgeEffect = true, shadowCasting = false } = props;
+  const { assetData, configIni, profileId, stretch, pixelPerfect = false, edgeEffect = true, shadowCasting = false } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const fxCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -50,7 +50,7 @@ const GameLayer = (props: GameLayerProps) => {
   const exclusiveInsets = useExclusiveInsetsStore((s) => s.insets);
 
   // Compute fitted size using shared hook (same formula for canvas + overlay)
-  const fitSize = useCanvasFit(containerRef, bufSize.w, bufSize.h, stretch);
+  const fitSize = useCanvasFit({ containerRef, bufW: bufSize.w, bufH: bufSize.h, stretch, pixelPerfect });
 
   // Apply fitted size to canvases (they need direct DOM style manipulation).
   // Depends on `status` because SDL/Emscripten removes inline styles during

--- a/apps/web/src/ui/domains/app/views/GameLayer/GameLayer.type.ts
+++ b/apps/web/src/ui/domains/app/views/GameLayer/GameLayer.type.ts
@@ -4,6 +4,7 @@ interface GameLayerProps {
   configIni?: string;
   profileId?: string;
   stretch?: boolean;
+  pixelPerfect?: boolean;
   edgeEffect?: boolean;
   shadowCasting?: boolean;
 }

--- a/apps/web/src/ui/domains/app/views/ProfileHub/ProfileHub.type.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/ProfileHub.type.ts
@@ -27,6 +27,7 @@ interface ProfileHubProps {
   onDisplayPerfChange?: (enabled: boolean) => void;
   onSaveSlotSettingsChange?: (enhanced: boolean, holdDuration: number) => void;
   onEdgeEffectChange?: (enabled: boolean) => void;
+  onPixelPerfectChange?: (enabled: boolean) => void;
   onShadowCastingChange?: (enabled: boolean) => void;
   masterVolumeOverride?: { volume: number; version: number } | null;
   activeTab?: ProfileHubTab;

--- a/apps/web/src/ui/domains/app/views/ProfileHub/behavior/apply-settings-effects.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/behavior/apply-settings-effects.ts
@@ -41,7 +41,7 @@ const syncHudStore = (s: GameSettings): void => {
 
 type ParentCallbacks = Pick<ProfileHubProps,
   'onWindowModeChange' | 'onConstraintSettingsChange' | 'onMasterVolumeChange' | 'onDisplayPerfChange'
-  | 'onSaveSlotSettingsChange' | 'onEdgeEffectChange' | 'onShadowCastingChange'
+  | 'onSaveSlotSettingsChange' | 'onEdgeEffectChange' | 'onShadowCastingChange' | 'onPixelPerfectChange'
 >;
 
 interface SettingsEffectDeps extends ParentCallbacks {
@@ -57,7 +57,7 @@ const applySettingsSideEffects = (patch: Partial<GameSettings>, next: GameSettin
   const {
     profileId, isGameRunning, changedKeys, restartToastShownRef, setToasts, setFullscreen,
     onWindowModeChange, onConstraintSettingsChange, onMasterVolumeChange, onDisplayPerfChange,
-    onSaveSlotSettingsChange, onEdgeEffectChange, onShadowCastingChange,
+    onSaveSlotSettingsChange, onEdgeEffectChange, onShadowCastingChange, onPixelPerfectChange,
   } = deps;
 
   // Persist asynchronously; surface failures so settings never silently fail to save.
@@ -110,6 +110,11 @@ const applySettingsSideEffects = (patch: Partial<GameSettings>, next: GameSettin
   // Notify parent of shadow casting toggle
   if ('postProcessingShadows' in patch) {
     onShadowCastingChange?.(next.postProcessingShadows);
+  }
+
+  // Notify parent of pixel-perfect toggle (drives the canvas fit)
+  if ('pixelPerfect' in patch) {
+    onPixelPerfectChange?.(next.pixelPerfect);
   }
 
   // Swap the player sprite sheet in the running core so the choice shows without a restart.

--- a/apps/web/src/ui/domains/app/views/ProfileHub/behavior/useProfileSettings.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/behavior/useProfileSettings.ts
@@ -16,7 +16,7 @@ const useProfileSettings = (props: ProfileHubProps) => {
   const {
     profile, isGameRunning, masterVolumeOverride,
     onWindowModeChange, onConstraintSettingsChange, onMasterVolumeChange, onDisplayPerfChange,
-    onSaveSlotSettingsChange, onEdgeEffectChange, onShadowCastingChange,
+    onSaveSlotSettingsChange, onEdgeEffectChange, onShadowCastingChange, onPixelPerfectChange,
   } = props;
 
   const { window: win } = usePlatform();
@@ -80,7 +80,7 @@ const useProfileSettings = (props: ProfileHubProps) => {
         profileId: profile.id, isGameRunning, changedKeys, restartToastShownRef, setToasts,
         setFullscreen: win.setFullscreen,
         onWindowModeChange, onConstraintSettingsChange, onMasterVolumeChange, onDisplayPerfChange,
-        onSaveSlotSettingsChange, onEdgeEffectChange, onShadowCastingChange,
+        onSaveSlotSettingsChange, onEdgeEffectChange, onShadowCastingChange, onPixelPerfectChange,
       });
       return next;
     });
@@ -108,6 +108,7 @@ const useProfileSettings = (props: ProfileHubProps) => {
           onDisplayPerfChange?.(merged.displayPerfInTitle);
           onEdgeEffectChange?.(merged.overworldEdgeEffect);
           onShadowCastingChange?.(merged.postProcessingShadows);
+          onPixelPerfectChange?.(merged.pixelPerfect);
           getInputManager().setFunctionMappings(merged.functionMappings ?? DEFAULT_FUNCTION_MAPPINGS);
           // Always attempt to push — if module isn't running yet, it's a no-op.
           pushLiveSettings(merged);

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/GraphicsSettings.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/GraphicsSettings.tsx
@@ -25,6 +25,12 @@ const APPEARANCE_SECTION: Section = {
 
 const SECTIONS: Section[] = [RENDERING_SECTION, ENHANCEMENTS_SECTION, APPEARANCE_SECTION];
 
+// Pixel Perfect promises whole, identical source pixels — bilinear interpolation would break that
+// upstream of everything else, so the core is handed LinearFiltering off and the control follows suit.
+const isDisabled = (key: string, settings: GameSettings): boolean => {
+  return key === 'linearFiltering' && settings.pixelPerfect;
+};
+
 const renderControl = (key: string, settings: GameSettings, onChange: (patch: Partial<GameSettings>) => void): ReactNode | null => {
   if (key !== 'linkSprite') return null;
   return <PlayerSpriteSelector value={settings.linkSprite} onChange={(v) => onChange({ linkSprite: v })} />;
@@ -32,7 +38,7 @@ const renderControl = (key: string, settings: GameSettings, onChange: (patch: Pa
 
 const GraphicsSettings = (props: GraphicsSettingsProps) => {
   const { settings, onChange } = props;
-  return <SettingsLayout sections={SECTIONS} settings={settings} onChange={onChange} renderControl={renderControl} />;
+  return <SettingsLayout sections={SECTIONS} settings={settings} onChange={onChange} renderControl={renderControl} isDisabled={isDisabled} />;
 };
 
 export { GraphicsSettings };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/SettingsView.constants.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/SettingsView.constants.ts
@@ -1,20 +1,25 @@
 /* @layer renderer-components @kind data */
-import type { Section } from '../../../compounds/SettingsLayout';
+import type { GameSettings } from '@shared/types/settings';
+import type { Section, SettingItem } from '../../../compounds/SettingsLayout';
 
-const WINDOW_SECTION: Section = {
-  id: 'window',
-  title: 'Window',
-  subsections: [
-    {
-      id: 'window-mode',
-      title: 'Mode',
-      items: [
-        { key: 'windowMode', label: 'Window Mode', description: 'Window display mode', keywords: 'borderless windowed default' },
-        { key: 'startFullscreen', label: 'Start in Fullscreen', description: 'Automatically enter fullscreen when the game starts', keywords: 'fullscreen launch start' },
-        { key: 'viewportConstraint', label: 'Viewport', description: 'Controls how the game canvas relates to the window', keywords: 'ratio lock constrain aspect black bars stretch fill fit viewport' },
-      ],
-    },
-  ],
+const PIXEL_PERFECT_ITEM: SettingItem = {
+  key: 'pixelPerfect',
+  label: 'Pixel Perfect',
+  description: 'Scale the picture by whole source pixels only, so every pixel is exactly the same size. Removes the shimmer on fences, walls and other straight edges while scrolling, at the cost of slightly wider black borders. Turns Linear Filtering off while active.',
+  keywords: 'pixel perfect integer scale scaling sharp crisp shimmer wobble ripple tearing nearest',
+};
+
+/** Pixel Perfect only has meaning under Letterbox — Fit/Stretch bypass the fit math entirely. */
+const buildWindowSection = (s: GameSettings): Section => {
+  const items: SettingItem[] = [
+    { key: 'windowMode', label: 'Window Mode', description: 'Window display mode', keywords: 'borderless windowed default' },
+    { key: 'startFullscreen', label: 'Start in Fullscreen', description: 'Automatically enter fullscreen when the game starts', keywords: 'fullscreen launch start' },
+    { key: 'viewportConstraint', label: 'Viewport', description: 'Controls how the game canvas relates to the window', keywords: 'ratio lock constrain aspect black bars stretch fill fit viewport' },
+  ];
+
+  if (s.viewportConstraint === 'none') items.push(PIXEL_PERFECT_ITEM);
+
+  return { id: 'window', title: 'Window', subsections: [{ id: 'window-mode', title: 'Mode', items }] };
 };
 
 const PERFORMANCE_SECTION: Section = {
@@ -26,7 +31,7 @@ const PERFORMANCE_SECTION: Section = {
       title: 'Options',
       items: [
         { key: 'displayPerfInTitle', label: 'Show FPS', description: 'Display the current frames per second in the title bar while the game is running', keywords: 'fps performance frame rate counter' },
-        { key: 'disableFrameDelay', label: 'Disable Frame Delay', description: 'Remove the per-frame sleep used for timing — improves performance and reduces input lag on 60 Hz displays where V-Sync handles the pacing', keywords: 'frame delay vsync performance input lag 60hz' },
+        { key: 'vsync', label: 'V-Sync', description: 'Pace the game against your display’s refresh rate instead of an internal timer. Smooths scrolling on 60 Hz displays where the two clocks would otherwise drift apart. Game speed stays correct on any refresh rate.', keywords: 'vsync v-sync tearing judder stutter frame pacing refresh rate smooth scrolling 60hz' },
       ],
     },
   ],
@@ -91,4 +96,4 @@ const MOBILE_SECTION: Section = {
   subsections: [{ id: 'mobile-display', title: 'Display', items: [NOTCH_ITEM] }],
 };
 
-export { WINDOW_SECTION, PERFORMANCE_SECTION, RENDERING_SECTION, ENHANCEMENTS_SECTION, MOBILE_SECTION };
+export { buildWindowSection, PERFORMANCE_SECTION, RENDERING_SECTION, ENHANCEMENTS_SECTION, MOBILE_SECTION };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/SystemSettings.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/SystemSettings.tsx
@@ -4,7 +4,7 @@ import { type ReactNode } from 'react';
 import type { GameSettings } from '@shared/types/settings';
 import { SettingsLayout, type Section } from '../../../compounds/SettingsLayout';
 import { SegmentedControl } from '../../../../../design-system/primitives/SegmentedControl';
-import { WINDOW_SECTION, PERFORMANCE_SECTION } from './SettingsView.constants';
+import { buildWindowSection, PERFORMANCE_SECTION } from './SettingsView.constants';
 import { SAVE_SECTION } from './gameplay-settings-sections';
 import { renderControl as renderSaveControl, isDisabled } from './gameplay-settings-controls';
 
@@ -24,7 +24,8 @@ const WINDOW_MODE_OPTIONS = [
   { value: 'borderless', label: 'Borderless' },
 ];
 
-const SECTIONS: Section[] = [WINDOW_SECTION, PERFORMANCE_SECTION, SAVE_SECTION];
+// Window is built per-render: the Pixel Perfect item only appears under the Letterbox viewport.
+const buildSections = (s: GameSettings): Section[] => [buildWindowSection(s), PERFORMANCE_SECTION, SAVE_SECTION];
 
 const renderControl = (key: string, settings: GameSettings, onChange: (patch: Partial<GameSettings>) => void): ReactNode | null => {
   if (key === 'windowMode') {
@@ -55,7 +56,7 @@ const SystemSettings = (props: SystemSettingsProps) => {
   const { settings, onChange } = props;
   return (
     <SettingsLayout
-      sections={SECTIONS}
+      sections={buildSections(settings)}
       settings={settings}
       onChange={onChange}
       renderControl={renderControl}

--- a/core/wasm-build/build.mjs
+++ b/core/wasm-build/build.mjs
@@ -50,7 +50,7 @@ const hookSrcs = [
 ].map((f) => h(`${f}.c`));
 
 // Our Emscripten entry points (replace the native main.c). Resolved from this dir.
-const emMain = ['emscripten_main.c', 'emscripten_sdl.c', 'emscripten_api.c', 'emscripten_io.c'].map((f) => join(here, f));
+const emMain = ['emscripten_main.c', 'emscripten_sdl.c', 'emscripten_api.c', 'emscripten_io.c', 'emscripten_pacing.c'].map((f) => join(here, f));
 
 const cflags = [
   '-O2', '-g2',

--- a/core/wasm-build/emscripten_api.c
+++ b/core/wasm-build/emscripten_api.c
@@ -116,6 +116,18 @@ void WasmSetDisplayPerf(int enable) {
   g_config.display_perf_title = enable;
 }
 
+// Swap the frame loop between the display's vertical blank and the fixed timer. Live-safe: the
+// profile pushes the current choice at startup and again whenever the setting changes.
+EMSCRIPTEN_KEEPALIVE
+void WasmSetVsync(int enable) {
+  SetVsyncMode(enable != 0);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int WasmGetVsync(void) {
+  return g_vsync ? 1 : 0;
+}
+
 // ---------------------------------------------------------------------------
 // Volume — masters the SDL audio mixer + per-channel DSP volumes
 // ---------------------------------------------------------------------------

--- a/core/wasm-build/emscripten_internal.h
+++ b/core/wasm-build/emscripten_internal.h
@@ -24,6 +24,18 @@ extern bool g_js_input_mode;
 // ── FPS (defined in emscripten_main.c) ──
 extern int g_curr_fps;
 
+// ── Frame pacing (defined in emscripten_pacing.c) ──
+// Nominal NTSC frame time. The game step is gated on this so a display-synced loop
+// advances at the right speed no matter what the refresh rate is.
+#define FRAME_INTERVAL_MS (1000.0 / 60.0988)
+// True while the loop is display-synced (rAF); false for the timer schedule.
+extern bool g_vsync;
+// Milliseconds of game time owed. Only consulted in vsync mode.
+extern double g_frame_accumulator;
+extern double g_last_frame_time;
+void SetVsyncMode(bool enable);
+int StepsOwedThisTick(void);
+
 // ── Audio (defined in emscripten_main.c) ──
 extern uint8 *g_audiobuffer, *g_audiobuffer_cur, *g_audiobuffer_end;
 extern int g_frames_per_block;

--- a/core/wasm-build/emscripten_main.c
+++ b/core/wasm-build/emscripten_main.c
@@ -3,7 +3,8 @@
 // Provides SDL2 init, the emscripten_set_main_loop frame callback, and main().
 // The SDL renderer/audio/input handlers live in emscripten_sdl.c; asset
 // loading + save/load + input setters in emscripten_io.c; the JS-facing
-// settings/command/clean-frame exports in emscripten_api.c. Shared engine
+// settings/command/clean-frame exports in emscripten_api.c; the loop's
+// schedule and per-tick step budget in emscripten_pacing.c. Shared engine
 // state is declared in emscripten_internal.h and DEFINED here.
 
 #include <stdio.h>
@@ -116,6 +117,11 @@ static void MainFrameCallback(void) {
 
   if (g_paused) return;
 
+  // A tick that owes nothing leaves the canvas holding the previous frame (the context is created
+  // with preserveDrawingBuffer), so there is nothing to redraw and no reason to burn a draw on it.
+  int steps = StepsOwedThisTick();
+  if (steps == 0) return;
+
   // FPS measurement: count frames per wall-clock second using emscripten_get_now()
   // (SDL_GetPerformanceCounter returns uint64 ms, losing sub-ms precision which
   //  causes division-by-zero in per-frame timing on fast draws)
@@ -138,8 +144,12 @@ static void MainFrameCallback(void) {
     g_curr_fps = 0;
   }
 
+  // More than one step only happens when the display refreshes slower than the game runs; the
+  // intermediate states are simulated but never drawn, which keeps real-time speed without
+  // rendering frames nobody sees.
   int inputs = g_input1_state;
-  ZeldaRunFrame(inputs);
+  for (int i = 0; i < steps; i++)
+    ZeldaRunFrame(inputs);
 
   // Draw
   int render_scale = PpuGetCurrentRenderScale(g_zenv.ppu, g_ppu_render_flags);
@@ -305,10 +315,12 @@ int main(int argc, char **argv) {
 
   printf("zelda3 WASM initialized. Starting main loop.\n");
 
-  // Run at 60 FPS. Using fps=0 (rAF) can cause timing issues because the
-  // browser may call the callback at the display's refresh rate which can
-  // exceed 60Hz on high-refresh displays, making the game run too fast.
-  // The SNES runs at ~60.098 FPS (NTSC); 60 is close enough.
+  // Start on the timer schedule (fps > 0), which is what this build has always used. A non-zero fps
+  // makes Emscripten drive the loop from setTimeout rather than the display's vertical blank; that
+  // keeps the game at ~60 FPS on any monitor, at the cost of drifting against the display's own
+  // clock. SetVsyncMode() swaps to the vblank-driven schedule when the profile asks for it — the
+  // accumulator in StepsOwedThisTick is what keeps the speed correct there, since rAF fires at
+  // whatever the panel runs at. The bridge pushes the profile's choice right after startup.
   emscripten_set_main_loop(MainFrameCallback, 60, 1);
 
   // Cleanup (unreachable with simulate_infinite_loop=1, but good practice)

--- a/core/wasm-build/emscripten_pacing.c
+++ b/core/wasm-build/emscripten_pacing.c
@@ -1,0 +1,70 @@
+/* @layer core-wasm-build @kind native */
+// Frame pacing for the WASM build — decides how the main loop is scheduled and, when it is driven
+// by the display, how many game steps a given tick actually owes. Split out of emscripten_main.c;
+// the loop body itself stays there and just asks StepsOwedThisTick() what to do.
+//
+// Two schedules exist:
+//   timer  — Emscripten drives the loop from setTimeout at a fixed ~60 Hz. This is what the build
+//            has always done. It free-runs against the display's own clock, so on a 60 Hz panel the
+//            two beat and a frame is periodically shown twice or dropped; in smooth scrolling that
+//            reads as a stutter. High-refresh and variable-refresh displays mostly hide it, which
+//            is why it goes unnoticed on some machines and not others.
+//   vsync  — the loop is driven by the display's vertical blank instead. Presentation lines up with
+//            the panel, but the tick rate is now whatever the panel runs at, so the accumulator
+//            below is what keeps the game itself at the right speed.
+
+#include <emscripten.h>
+
+#include "src/types.h"
+
+#include "emscripten_internal.h"
+
+bool g_vsync = false;
+double g_frame_accumulator = 0.0;
+double g_last_frame_time = 0.0;
+
+// Never advance more than this per tick. A display slower than the game legitimately owes two steps,
+// but a long stall (window hidden, load hitch) must not cash in as a burst of fast-forward.
+#define MAX_STEPS_PER_TICK 2
+
+// Swap schedules. Safe to call at any time — the accumulator is rearmed so the first tick after a
+// switch can't see a stale timestamp and claim a huge delta.
+void SetVsyncMode(bool enable) {
+  g_vsync = enable;
+  g_frame_accumulator = 0.0;
+  g_last_frame_time = 0.0;
+  if (enable)
+    emscripten_set_main_loop_timing(EM_TIMING_RAF, 1);
+  else
+    emscripten_set_main_loop_timing(EM_TIMING_SETTIMEOUT, (int)(1000 / 60));
+}
+
+// How many game steps this tick owes. Always 1 on the timer schedule — there, the schedule is the
+// clock. On the display schedule the elapsed time decides: usually 0 on a 144 Hz panel, 1 on 60 Hz,
+// 2 on 30 Hz. Returning 0 means the tick draws nothing and the previous frame simply stays up.
+int StepsOwedThisTick(void) {
+  if (!g_vsync)
+    return 1;
+
+  double now = emscripten_get_now();
+  if (g_last_frame_time == 0.0) {
+    // First tick after start or a mode switch — run one step and start measuring from here.
+    g_last_frame_time = now;
+    return 1;
+  }
+
+  g_frame_accumulator += now - g_last_frame_time;
+  g_last_frame_time = now;
+
+  // Drop anything owed past the catch-up ceiling, so a stall is absorbed rather than replayed.
+  double ceiling = FRAME_INTERVAL_MS * MAX_STEPS_PER_TICK;
+  if (g_frame_accumulator > ceiling)
+    g_frame_accumulator = ceiling;
+
+  int steps = 0;
+  while (g_frame_accumulator >= FRAME_INTERVAL_MS && steps < MAX_STEPS_PER_TICK) {
+    g_frame_accumulator -= FRAME_INTERVAL_MS;
+    steps++;
+  }
+  return steps;
+}

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -23,7 +23,13 @@ interface GameSettings {
   autoSaveMaxEntries: number; // 1-20, default 5
   saveOnQuit: boolean;
   displayPerfInTitle: boolean;
+  // Legacy: only read by the native SDL main loop, which is not part of the WASM build — kept so
+  // existing profiles and the INI round-trip unchanged. Superseded by `vsync` below.
   disableFrameDelay: boolean;
+  // Drive the core's frame loop from the display's vertical blank (requestAnimationFrame) instead of
+  // a free-running timer, and gate the game step on a 60.0988 Hz accumulator so the speed stays right
+  // on any refresh rate. Off = the timer pacing the app has always used. Live-togglable.
+  vsync: boolean;
 
   // ─── Aspect Ratio & Display ───
   // Master gate — off: the engine always runs 4:3 vanilla and no sub-settings appear in the UI.
@@ -79,6 +85,11 @@ interface GameSettings {
   windowMode: 'default' | 'borderless';
   startFullscreen: boolean;
   viewportConstraint: 'none' | 'fit' | 'fill';
+  // Snap the canvas to a whole number of source pixels, measured in DEVICE pixels so display scaling
+  // can't reintroduce uneven pixel sizes. Trades a little image size for a scroll that never shimmers.
+  // Renderer-only (not serialized to the INI). Only meaningful when viewportConstraint is 'none' —
+  // the other modes bypass the fit math entirely. Forces linearFiltering off while enabled.
+  pixelPerfect: boolean;
 
   // ─── Mobile display ───
   // true (default): render under the camera cutout (full-bleed). false: keep UI +


### PR DESCRIPTION
Someone on the discord reported screen tearing in kakariko village. Digging into it, real scanline tearing almost certainly isn't coming from us (we never disable Chromium's gpu vsync), but two things in our pipeline do produce artifacts that read as tearing while scrolling, and both are fixable. This adds a toggle for each, defaulting to off so current behaviour is untouched.

* The frame loop was scheduled by a free-running timer at ~60Hz, independent of the display's own clock, so on a 60Hz panel the two beat and a frame periodically shows twice or gets skipped. V-Sync drives the loop from the vertical blank instead, with an accumulator gating the game step at 60.0988Hz so the speed stays correct on any refresh rate. It toggles live, so it can be flipped mid-scroll to compare.
* The canvas was scaled by a fractional amount, so source pixels landed on 4 or 5 screen pixels and which ones got 5 changed as the view scrolled. That's a ripple across straight edges, and kakariko is all fences and roof lines. Pixel Perfect snaps to whole source pixels, measured in device pixels so windows display scaling at 125/150% can't sneak the problem back in.
* Pixel Perfect forces linear filtering off while it's on, otherwise the 256 to 512 upscale is already blurred before anything downstream can help.
* Dropped the Disable Frame Delay setting from the UI. It's only read by the native SDL loop, which isn't part of the wasm build, so it never did anything here. Field and INI key kept for compat.

Verified: typecheck, eslint and analyze all clean, wasm rebuilds with the new exports present, unit tests pass, app boots. The scaling math was checked numerically rather than by eye, including the scaled-display cases where css size comes out fractional but device pixels land exact.

Not verified: the actual in-game A/B, since that needs a real rom and profile. That part is yours.