### PR TITLE
Open a profile's folder from the hub

### DIFF
--- a/apps/desktop/electron/storage/ipc-handlers.ts
+++ b/apps/desktop/electron/storage/ipc-handlers.ts
@@ -27,6 +27,10 @@ const DOMAINS: { domain: DataDomain; label: string; dir: string }[] = [
   { domain: 'assets', label: 'Assets', dir: 'assets' },
 ];
 
+// Strips anything outside [A-Za-z0-9_-] so an id can never contain a path
+// separator, '..', or a drive letter.
+const sanitizeId = (id: string): string => id.replace(/[^A-Za-z0-9_-]/g, '_');
+
 const dirBytes = async (dir: string): Promise<number> => {
   let total = 0;
   let entries;
@@ -52,6 +56,11 @@ const getLocation = (): DataLocation => ({
 const registerStorageHandlers = (): void => {
   handle('storage:getLocation', () => getLocation());
   handle('storage:reveal', async () => { await shell.openPath(getUserDataPath()); });
+  handle('storage:revealProfile', async (_e, profileId) => {
+    const dir = getUserDataPath('profiles', sanitizeId(profileId));
+    const error = await shell.openPath(dir);
+    return error ? { success: false, error } : { success: true };
+  });
   handle('storage:getSummary', async (): Promise<StorageSummary> => {
     const domains: DomainUsage[] = [];
     for (const { domain, label, dir } of DOMAINS) {

--- a/apps/web/src/platform/hosts/capacitor/storage.ts
+++ b/apps/web/src/platform/hosts/capacitor/storage.ts
@@ -49,6 +49,7 @@ const getLocation = async (): Promise<DataLocation> => {
 const createCapacitorStorage = (): StoragePort => ({
   getLocation,
   reveal: async () => {},
+  revealProfile: async () => false,
   spritesBaseUrl: async (romFile) => {
     const stem = romFile.replace(/\.(sfc|smc)$/i, '');
     try {

--- a/apps/web/src/platform/hosts/electron-factory.ts
+++ b/apps/web/src/platform/hosts/electron-factory.ts
@@ -39,6 +39,7 @@ const createWindowControls = (): WindowControlsPort => ({
 const createStorage = (): StoragePort => ({
   getLocation: () => window.api.getDataLocation(),
   reveal: () => window.api.revealDataFolder(),
+  revealProfile: async (profileId) => (await window.api.revealProfileFolder(profileId)).success,
   getSummary: () => window.api.getStorageSummary(),
   spritesBaseUrl: async (romFile) => window.api.getSpritesBaseUrl(romFile),
 });

--- a/apps/web/src/platform/hosts/web-factory.ts
+++ b/apps/web/src/platform/hosts/web-factory.ts
@@ -50,6 +50,7 @@ const EMPTY_SUMMARY: StorageSummary = {
 const createStorage = (): StoragePort => ({
   getLocation: async () => EMPTY_SUMMARY.location,
   reveal: async () => {},
+  revealProfile: async () => false,
   getSummary: async () => EMPTY_SUMMARY,
   spritesBaseUrl: async () => '',
 });

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/HomeTab.css
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/HomeTab.css
@@ -38,6 +38,12 @@
   font-weight: var(--weight-medium);
 }
 
+/* Sits in the info-card row, so it matches the cards' height instead of the
+   button's own intrinsic one. */
+.home-tab__folder-btn {
+  align-self: stretch;
+}
+
 /* Two-column layout — collapses to one column when there isn't room for two. */
 .home-tab__columns {
   display: grid;

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/HomeTab.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/HomeTab.tsx
@@ -1,6 +1,10 @@
 /* @layer renderer-components @kind component */
+import { useCallback } from 'react';
+import { usePlatform } from '@app/platform';
+import { log } from '@app/lib/log-bus';
 import { HeroSaveCard } from '../../../compounds/HeroSaveCard';
 import { Box } from '../../../../../design-system/primitives/Box';
+import { Button } from '../../../../../design-system/primitives/Button';
 import { Text } from '../../../../../design-system/primitives/Text';
 import { formatRelativeTime } from './home-tab/home-tab-helpers';
 import { useHomeTabSaves } from './home-tab/useHomeTabSaves';
@@ -16,6 +20,16 @@ const HomeTab = (props: HomeTabProps) => {
   const { profileId, romFile, isGameRunning, onStartGame, lastPlayed, created, windowMode } = props;
   const saves = useHomeTabSaves({ profileId, isGameRunning, onStartGame });
   const { heroSave, normalScreenshots, busyNormal, handleLoadNormal } = saves;
+  const { storage, capabilities } = usePlatform();
+
+  const handleOpenFolder = useCallback(async () => {
+    try {
+      const opened = await storage.revealProfile(profileId);
+      if (!opened) log.app('Could not open the profile folder', 'warn');
+    } catch (e: unknown) {
+      log.app(`Could not open the profile folder: ${e instanceof Error ? e.message : e}`, 'error');
+    }
+  }, [storage, profileId]);
 
   return (
     <Box className="home-tab">
@@ -38,6 +52,18 @@ const HomeTab = (props: HomeTabProps) => {
             <Text className="home-tab__info-label">Window</Text>
             <Text className="home-tab__info-value" style={CAPITALIZE}>{windowMode}</Text>
           </Box>
+        )}
+        {capabilities.revealDataFolder && (
+          <Button
+            variant="secondary"
+            size="sm"
+            className="home-tab__folder-btn"
+            icon="📂"
+            onClick={() => void handleOpenFolder()}
+            title="Open this profile's folder in the system file manager"
+          >
+            Open profile folder
+          </Button>
         )}
       </Box>
 

--- a/shared/ipc/invoke-contract.ts
+++ b/shared/ipc/invoke-contract.ts
@@ -25,6 +25,7 @@ interface InvokeContract {
   // Storage — data location, reveal in OS file manager, per-domain usage summary
   'storage:getLocation': () => Promise<DataLocation>;
   'storage:reveal': () => Promise<void>;
+  'storage:revealProfile': (profileId: string) => Promise<Result>;
   'storage:getSummary': () => Promise<StorageSummary>;
 
   // Generic file store — POSIX paths relative to the Data root

--- a/shared/ipc/maps.ts
+++ b/shared/ipc/maps.ts
@@ -14,6 +14,7 @@ const INVOKE_MAP = {
   getUserDataPath: 'app:getUserDataPath',
   getDataLocation: 'storage:getLocation',
   revealDataFolder: 'storage:reveal',
+  revealProfileFolder: 'storage:revealProfile',
   getStorageSummary: 'storage:getSummary',
   fileReadBytes: 'file:readBytes',
   fileReadText: 'file:readText',

--- a/shared/platform/ports/storage.ts
+++ b/shared/platform/ports/storage.ts
@@ -29,6 +29,9 @@ interface StorageSummary {
 interface StoragePort {
   getLocation: () => Promise<DataLocation>;
   reveal: () => Promise<void>; // no-op when !canReveal
+  // One profile's folder. Resolves false when the host can't reveal (!canReveal) or
+  // the folder couldn't be opened, so a caller can tell the user instead of no-op'ing.
+  revealProfile: (profileId: string) => Promise<boolean>;
   getSummary: () => Promise<StorageSummary>;
   // Base URL for a ROM's extracted sprites (app-sprite:// on Electron,
   // Capacitor.convertFileSrc on mobile); ends with '/'. Empty when unavailable.


### PR DESCRIPTION
The profile hub's Home tab now has an "Open profile folder" button next to the info cards, so you can get at a profile's saves and config without hunting for the AppData path.

* The path is resolved in the main process from the existing userData strategy, so Windows, macOS and Linux all land in the right place, and a named instance opens its own folder rather than the default one.
* New `storage:revealProfile` channel on the StoragePort. Web and mobile answer false, and the button isn't rendered there, since there's no file manager to reveal into.
* The channel returns what `shell.openPath` said instead of dropping it, and the renderer logs a failure, so this can't silently do nothing.
* Profile ids are sanitized before being joined onto the profiles dir, same as the simulator log handler does with run ids.

Verified over IPC on the built app: a bogus id comes back `{"success":false,"error":"Failed to open path"}` and a real one opens the folder.