### PR TITLE
Fix the crystal layout in the widescreen pause screen

### DIFF
--- a/apps/web/src/ui/domains/hud/composites/PauseCrystalIcon/PauseCrystalIcon.tsx
+++ b/apps/web/src/ui/domains/hud/composites/PauseCrystalIcon/PauseCrystalIcon.tsx
@@ -1,7 +1,8 @@
 /* @layer renderer-hud @kind component */
 /**
  * PauseCrystalIcon — renders a single crystal (empty or filled).
- * Crystals are 16×16 (2×2 tiles).
+ * A crystal is 16×8: two tiles side by side, one tile tall. Drawing it square
+ * stretches the sprite to double height.
  */
 import { HudImage } from '../../primitives/HudImage';
 
@@ -12,14 +13,15 @@ interface PauseCrystalIconProps {
 }
 
 const PauseCrystalIcon = ({ filled, scale, spritesBase }: PauseCrystalIconProps) => {
-  const size = 16 * scale;
+  const width = 16 * scale;
+  const height = 8 * scale;
   const src = `${spritesBase}pause-crystal-${filled ? 'filled' : 'empty'}.png`;
 
   return (
     <HudImage
       src={src}
-      width={size}
-      height={size}
+      width={width}
+      height={height}
       style={{ display: 'block', imageRendering: 'pixelated' }}
     />
   );

--- a/apps/web/src/ui/domains/hud/compounds/PauseProgressPanel/PauseProgressPanel.tsx
+++ b/apps/web/src/ui/domains/hud/compounds/PauseProgressPanel/PauseProgressPanel.tsx
@@ -4,7 +4,7 @@
  *
  * Game layout: tiles (21,11)→(30,19) = 10×9 tiles
  * - Pendants: 3 icons (green top-center, blue bottom-left, red bottom-right)
- * - Crystals: 7 icons in a diamond pattern
+ * - Crystals: 7 icons in 2-3-2 rows, the middle row offset half a slot
  *
  * link_which_pendants bits: 0=Power(red), 1=Wisdom(blue), 2=Courage(green)
  * link_has_crystals bits: 0-6 for each crystal
@@ -31,14 +31,19 @@ const PauseProgressPanel = ({ pendants, crystals, showCrystals, scale, spritesBa
   const innerRows = 7;
 
   if (showCrystals) {
-    // Crystal layout: 7 crystals in specific positions
-    // Row 1 (y=2): positions 2,4 (2 crystals)
-    // Row 2 (y=4): positions 0,2,4,6 (4 crystals) — but game uses diamond
-    // Actual game: row0: c2,c4 | row1: c0,c2,c4,c6 | adjusted to fit
+    // Crystal slots, in tiles from the inner (inside-border) top-left corner. Each
+    // crystal is 2 tiles wide and 1 tall, so the rows sit 2 tiles apart and the
+    // middle row of 3 is inset one tile, giving the 2-3-2 arrangement:
+    //
+    //     . .        cols 2,4
+    //    . . .       cols 1,3,5
+    //     . .        cols 2,4
+    //
+    // Index order is the crystal bit order, so slot N shows bit N.
     const crystalPositions = [
-      { x: 2, y: 1 }, { x: 4, y: 1 },    // top row
-      { x: 0, y: 3 }, { x: 2, y: 3 }, { x: 4, y: 3 }, { x: 6, y: 3 }, // middle row
-      { x: 3, y: 5 },                       // bottom
+      { x: 2, y: 2 }, { x: 4, y: 2 },
+      { x: 1, y: 4 }, { x: 3, y: 4 }, { x: 5, y: 4 },
+      { x: 2, y: 6 }, { x: 4, y: 6 },
     ];
 
     return (
@@ -51,7 +56,7 @@ const PauseProgressPanel = ({ pendants, crystals, showCrystals, scale, spritesBa
           <HudBox key={idx} style={{
             position: 'absolute',
             left: pos.x * tile,
-            top: (pos.y + 1) * tile,
+            top: pos.y * tile,
           }}>
             <PauseCrystalIcon
               filled={!!(crystals & (1 << idx))}


### PR DESCRIPTION
Two things were off in the crystal panel, both coming from the same wrong assumption about the sprite.

- The seven slots were placed two, four, one from a guess. The game lays them out two, three, two with the middle row inset one tile, so the positions now come straight from the tile grid it draws.
- The crystal sprite is two tiles side by side, sixteen by eight, but the icon drew it in a square box and stretched it to double height. The pendants beside it really are two by two, which is probably where the assumption came from.

Verified against the game's own pause screen on the state tyreek shared, by capturing that state twice with our overlay switched on and off. The crystals land on the same tile in both.

Fixes #36
