### PR TITLE
Fix the desert boss being invisible in widescreen

### DIFF
--- a/core/zelda3/src/sprite.h
+++ b/core/zelda3/src/sprite.h
@@ -66,6 +66,26 @@ static inline void OamSetY(OamEnt *oam, uint16 y) {
   }
 }
 
+// Mirror of OamSetX for draw routines that keep only the LOW BYTE of a sprite's world X (per-segment
+// position histories, for instance). Such a caller cannot produce a true absolute screen X, so it must
+// NOT drive the wide-view high-X extension: the stock 9-bit X is the whole coordinate, exactly as
+// SetOamPlain treats it. Handing the low-byte difference to OamSetX instead derives a garbage
+// (int16)x >> 9 and flings the sprite a multiple of 512px off-screen.
+static inline void OamSetXLowByte(OamEnt *oam, uint8 x) {
+  oam->x = x;
+  g_oam_x_high[oam - oam_buf] = 0;
+}
+
+// Some draw routines keep only the low byte of a sprite's world Y (per-segment position histories, for
+// instance) and rely on 8-bit wrap to place anything above the camera: a screen-Y of -8 arrives as 0xf8.
+// OamSetY needs a SIGNED screen-Y to build the 9-bit form a tall view reads, so map that wrap band back
+// to negative first. 0xf0..0xff is the stock visible-above-top window ([-16,-1]); 0xe0..0xef really is
+// below a 224-line screen, so it must stay positive.
+static inline uint16 OamWrappedScreenY(int y) {
+  uint8 v = (uint8)y;
+  return (uint16)(v >= 0xf0 ? (int)v - 256 : (int)v);
+}
+
 // Wide screens: the stock OAM X is 9-bit (oam->x + the high bit in bytewise_extended_oam below), which
 // caps the view at 512px. When a wide view is configured (g_oam_wide_budget != 0) also carry the SIGNED X
 // bits ABOVE the 9th in g_oam_x_high[slot] = (int16)x >> 9, so the PPU can place the sprite at its true

--- a/core/zelda3/src/sprite_main.c
+++ b/core/zelda3/src/sprite_main.c
@@ -3584,9 +3584,9 @@ void Lanmola_Draw(int k) {  // 85a64a
   do {
     int j = r2 + k * 64;
     r2 = r2 - 8 & 63;
-    OamSetX(oam, moldorm_x_lo[j] - BG2HOFS_copy2);
+    OamSetXLowByte(oam, moldorm_x_lo[j] - BG2HOFS_copy2);
     if (!sign8(beamos_x_hi[j]))
-      oam->y = moldorm_y_lo[j] - beamos_x_hi[j] - BG2VOFS_copy2;
+      OamSetY(oam, OamWrappedScreenY(moldorm_y_lo[j] - beamos_x_hi[j] - BG2VOFS_copy2));
     j = beamos_y_hi[j];
     if (n != 7 || i != 0) {
       oam->charnum = (n == i) ? kLanmola_Draw_Char1[j] : 0xc6;
@@ -3601,9 +3601,9 @@ void Lanmola_Draw(int k) {  // 85a64a
   do {
     int j = r5 + k * 64;
     r5 = r5 - 8 & 63;
-    OamSetX(oam, moldorm_x_lo[j] - BG2HOFS_copy2);
+    OamSetXLowByte(oam, moldorm_x_lo[j] - BG2HOFS_copy2);
     if (!sign8(beamos_x_hi[j]))
-      oam->y = moldorm_y_lo[j] + 10 - BG2VOFS_copy2;
+      OamSetY(oam, OamWrappedScreenY(moldorm_y_lo[j] + 10 - BG2VOFS_copy2));
     oam->charnum = 0x6c;
     oam->flags = 0x34;
     bytewise_extended_oam[oam - oam_buf] = 2;


### PR DESCRIPTION
The three worms in the second dungeon never drew with widescreen on. Closes #38.

* `OamSetX` derives the X bits above the stock 9 as `(int16)x >> 9`, which needs a true full-precision screen X
* the boss stores only the low byte of each segment's world X, so those upper bits were garbage and became a 512px offset
* added `OamSetXLowByte` for that case: stock 9-bit X, high byte zeroed, same as `SetOamPlain` already did
* routed the two raw `oam->y` writes through `OamSetY` too, so a segment above the screen top folds negative under tall rendering

Verified on the reporter's save state: segments, sand ring and mound all draw.