### PR TITLE
Give the player its own palette bank so custom sheets stop recoloring villagers

### DIFF
--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -41,19 +41,26 @@ uint8 GameHook_ApplyExtraArmor(uint8 dmg);
 
 // ─── Custom player sprite sheets (player_sprite.c) ───
 
-// Overwrite the player gfx + armor/gloves palette assets from a ZSPR sheet. |push_live| samples the
-// new palette into the live buffers straight away — pass false before the core is initialized.
+// Overwrite the player gfx asset from a ZSPR sheet and take its palette into the PPU's private player
+// bank. |push_live| lands the colors straight away — pass false before the core is initialized.
 // Returns false (assets untouched) if the sheet is malformed.
 bool PlayerSprite_Apply(const uint8 *data, size_t len, bool push_live);
 
-// Put the stock sheet and palettes back. No-op when no custom sheet is applied.
+// Put the stock sheet back and return the player to the shared palette row. No-op when none is applied.
 void PlayerSprite_Restore(bool push_live);
 
 // True while a custom sheet is applied.
 bool PlayerSprite_HasCustom(void);
 
-// Sample the armor/gloves palette assets into the live palette buffers.
+// Reload gear palettes so the player's banked colors are rebuilt for the current armor and gloves.
 void PlayerSprite_RefreshPalette(void);
+
+// The game loaded a gear palette into the shared sprite row; |src| is the outfit it chose inside
+// kPalette_ArmorAndGloves. Mirrors it into the player's private bank when a custom sheet is applied.
+void GameHook_PlayerGearPaletteLoaded(const uint16 *src);
+
+// The gloves color was refreshed on its own, without a full gear reload.
+void GameHook_PlayerGlovesColorUpdated(void);
 
 // ─── Haptic Events (haptic_events.c) ───
 

--- a/core/game-hooks/player_sprite.c
+++ b/core/game-hooks/player_sprite.c
@@ -2,33 +2,41 @@
 // Custom player-character sprite sheets in the community ZSPR format: parse, apply, and revert.
 //
 // A sheet carries 0x7000 bytes of 4bpp tiles plus a palette block (4 outfits x 15 colors, then two
-// glove colors). Applying one overwrites three assets in place. Two things make this more than a
-// memcpy:
+// glove colors). The tiles simply overwrite the player gfx asset. The palette cannot: the gear palette
+// occupies a sprite palette that villagers and followers also draw from, and their art was drawn against
+// the stock outfit colors, so writing a sheet's colors there turns them black or gold to match.
 //
-//  * The palette assets are only sampled into the live palette buffers when the game happens to
-//    reload gear palettes, so a swap has to push them itself or the new colors sit unused.
-//  * A save state restores the palette buffers it was recorded with, so a state saved under a
-//    different sheet reinstates that sheet's colors. Callers re-push after a load.
+// So the palette goes somewhere else. The PPU carries a private 16-color bank past the hardware palette
+// (Ppu.cgram[0x100]) and resolves the player's own pixels against it, leaving the shared row stock. This
+// module owns that bank: it keeps the sheet's outfits, and refreshes the bank whenever the game reloads
+// gear palettes, so armor upgrades, bunny form and the electro palette all track the way they normally do.
 //
-// The stock assets are snapshotted on first apply so a sheet can be swapped or removed at runtime
-// without rebooting the core.
+// The stock gfx is snapshotted on first apply so a sheet can be swapped or removed without rebooting.
 #include "game_hooks_internal.h"
 #include <stdlib.h>
 #include "src/load_gfx.h"
 
 enum {
   kSheetBytes = 0x7000,   // 4bpp player tiles
-  kOutfitBytes = 120,     // 4 outfits x 15 colors x 2 bytes
+  kColorsPerOutfit = 15,  // pixel indices 1-15; index 0 is transparent and has no stored entry
+  kSheetOutfits = 4,      // a ZSPR carries green/blue/red/bunny, but not the electro palette
+  kOutfitBytes = kSheetOutfits * kColorsPerOutfit * 2,
   kGloveBytes = 4,        // 2 colors x 2 bytes
   kArmorAssetBytes = 150, // the stock armor/gloves asset — 5 outfits x 15 colors
   kHeaderBytes = 27,
+  kBankColors = 16,       // the private bank mirrors one full sprite palette
+  kGlovesBankIndex = 13,  // the gloves color lands at 0xFD, i.e. index 13 of the row
 };
 
 static uint8 *g_stock_sheet;
-static uint8 g_stock_outfits[kArmorAssetBytes];
-static uint16 g_stock_gloves[2];
 static bool g_have_stock;
 static bool g_has_custom;
+// The sheet's outfits and glove colors, indexed the way the armor asset is.
+static uint16 g_sheet_outfits[kSheetOutfits * kColorsPerOutfit];
+static uint16 g_sheet_gloves[2];
+static bool g_have_sheet_palette;
+// Which outfit the game last loaded, so a gloves-only update can rebuild the bank without being told again.
+static int g_last_outfit = -1;
 
 static uint32 ReadWord(const uint8 *b) { return b[0] | (b[1] << 8); }
 static uint32 ReadDword(const uint8 *b) { return b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24); }
@@ -51,16 +59,54 @@ static bool CaptureStock(void) {
     return false;
   }
   memcpy(g_stock_sheet, kLinkGraphics, kSheetBytes);
-  memcpy(g_stock_outfits, kPalette_ArmorAndGloves, kArmorAssetBytes);
-  memcpy(g_stock_gloves, kGlovesColor, kGloveBytes);
   g_have_stock = true;
   return true;
 }
 
-// Sample the armor/gloves palette assets into the live palette buffers and flag CGRAM for upload.
-// Safe to call any time after the core is initialized; a no-op visually if nothing changed.
+// Fill the PPU's private bank from the sheet's outfit |outfit|, and switch the player onto it. A no-op
+// before the core is initialized — the first gear-palette load after startup calls back in and lands it.
+static void PushBank(int outfit) {
+  Ppu *ppu = g_zenv.ppu;
+  if (ppu == NULL || !g_have_sheet_palette || outfit < 0 || outfit >= kSheetOutfits)
+    return;
+  const uint16 *src = g_sheet_outfits + outfit * kColorsPerOutfit;
+  ppu->cgram[kPpuPlayerPalBase] = 0;  // index 0 is transparent and never sampled
+  for (int i = 0; i < kColorsPerOutfit; i++)
+    ppu->cgram[kPpuPlayerPalBase + 1 + i] = src[i];
+  if (link_item_gloves)
+    ppu->cgram[kPpuPlayerPalBase + kGlovesBankIndex] = g_sheet_gloves[link_item_gloves - 1];
+  ppu->playerPalActive = true;
+}
+
+// The game just loaded a gear palette into the shared sprite row. |src| points at the outfit it chose
+// inside the armor asset, which is how we know whether it's an outfit the sheet supplies.
+void GameHook_PlayerGearPaletteLoaded(const uint16 *src) {
+  if (!g_has_custom || !g_have_sheet_palette)
+    return;
+  int outfit = (int)(src - kPalette_ArmorAndGloves) / kColorsPerOutfit;
+  g_last_outfit = outfit;
+  // The electro palette is the fifth outfit and no sheet carries it; leave the player on the stock row so
+  // the effect still reads as intended.
+  if (outfit >= kSheetOutfits) {
+    if (g_zenv.ppu != NULL)
+      g_zenv.ppu->playerPalActive = false;
+    return;
+  }
+  PushBank(outfit);
+}
+
+// Gloves can change without a full gear reload, and they recolor one entry of the row.
+void GameHook_PlayerGlovesColorUpdated(void) {
+  if (!g_has_custom || !g_have_sheet_palette || g_last_outfit < 0)
+    return;
+  PushBank(g_last_outfit);
+}
+
+// Kept for callers that want the player's colors re-landed after a save-state load. The bank lives outside
+// the snapshot, so a load cannot disturb it — but link_armor can differ, so rebuild from what's current.
 void PlayerSprite_RefreshPalette(void) {
-  Palette_Load_LinkArmorAndGloves();
+  if (g_has_custom)
+    Palette_Load_LinkArmorAndGloves();
 }
 
 bool PlayerSprite_HasCustom(void) {
@@ -85,11 +131,20 @@ bool PlayerSprite_Apply(const uint8 *data, size_t len, bool push_live) {
     return false;
 
   memcpy(kLinkGraphics, data + px_off, kSheetBytes);
-  // A sheet may ship pixels only; keep the stock colors in that case rather than a partial copy.
-  if (pal_len >= kOutfitBytes)
-    memcpy(kPalette_ArmorAndGloves, data + pal_off, kOutfitBytes);
-  if (pal_len >= kOutfitBytes + kGloveBytes)
-    memcpy(kGlovesColor, data + pal_off + kOutfitBytes, kGloveBytes);
+  // A sheet may ship pixels only; leave the player on the stock row in that case rather than banking a
+  // partial palette.
+  g_have_sheet_palette = false;
+  if (pal_len >= kOutfitBytes) {
+    for (int i = 0; i < kSheetOutfits * kColorsPerOutfit; i++)
+      g_sheet_outfits[i] = (uint16)ReadWord(data + pal_off + i * 2);
+    g_sheet_gloves[0] = kGlovesColor[0];
+    g_sheet_gloves[1] = kGlovesColor[1];
+    if (pal_len >= kOutfitBytes + kGloveBytes) {
+      g_sheet_gloves[0] = (uint16)ReadWord(data + pal_off + kOutfitBytes);
+      g_sheet_gloves[1] = (uint16)ReadWord(data + pal_off + kOutfitBytes + 2);
+    }
+    g_have_sheet_palette = true;
+  }
   g_has_custom = true;
 
   if (push_live)
@@ -101,11 +156,14 @@ void PlayerSprite_Restore(bool push_live) {
   if (!g_have_stock || !g_has_custom)
     return;
   memcpy(kLinkGraphics, g_stock_sheet, kSheetBytes);
-  memcpy(kPalette_ArmorAndGloves, g_stock_outfits, kArmorAssetBytes);
-  memcpy(kGlovesColor, g_stock_gloves, kGloveBytes);
   g_has_custom = false;
+  g_have_sheet_palette = false;
+  g_last_outfit = -1;
+  // Back to the shared row. Nothing to undo there — it held the stock colors the whole time.
+  if (g_zenv.ppu != NULL)
+    g_zenv.ppu->playerPalActive = false;
   if (push_live)
-    PlayerSprite_RefreshPalette();
+    Palette_Load_LinkArmorAndGloves();
 }
 
 // ─── JS-facing exports ───
@@ -118,10 +176,11 @@ void WasmClearPlayerSprite(void) {
   PlayerSprite_Restore(true);
 }
 
-// Re-push the palette assets into the live buffers — used after a save-state load, which restores
-// whatever palette was recorded and would otherwise strand the selected sheet's colors.
+// Re-land the player's colors after a save-state load, which can restore a different armor level than the
+// one the bank was last built for.
 EMSCRIPTEN_KEEPALIVE
 void WasmRefreshPlayerPalette(void) {
   if (g_has_custom)
     PlayerSprite_RefreshPalette();
 }
+

--- a/core/zelda3/snes/ppu.c
+++ b/core/zelda3/snes/ppu.c
@@ -79,6 +79,8 @@ void ppu_reset(Ppu* ppu) {
   ppu->cgramSecondWrite = false;
   ppu->cgramBuffer = 0;
   memset(ppu->oam, 0, sizeof(ppu->oam));
+  memset(ppu->oamIsPlayer, 0, sizeof(ppu->oamIsPlayer));
+  ppu->playerPalActive = false;
   ppu->oamAdr = 0;
   ppu->oamSecondWrite = false;
   ppu->oamBuffer = 0;
@@ -166,7 +168,7 @@ void PpuBeginDrawing(Ppu *ppu, uint8_t *pixels, size_t pitch, uint32_t render_fl
   }
 
   if (PpuGetCurrentRenderScale(ppu, ppu->renderFlags) == 4) {
-    for (int i = 0; i < 256; i++) {
+    for (int i = 0; i < 0x110; i++) {
       uint32 color = ppu->cgram[i];
       ppu->colorMapRgb[i] = ppu->brightnessMult[color & 0x1f] << 16 | ppu->brightnessMult[(color >> 5) & 0x1f] << 8 | ppu->brightnessMult[(color >> 10) & 0x1f];
     }
@@ -660,6 +662,21 @@ static void PpuDrawBackground_2bpp_mosaic(Ppu *ppu, int y, bool sub, uint layer,
 #define SPRITE_PRIO_TO_PRIO(prio, level6) (((prio) * 4 + 2) * 16 + 4 + (level6 ? 2 : 0))
 #define SPRITE_PRIO_TO_PRIO_HI(prio) ((prio) * 4 + 2)
 
+// A z-buffer entry packs a CGRAM index in bits 0-7, the layer type in bits 8-11 and the priority level in
+// bits 12-15. The player's own pixels carry their layer type raised by 8 (sprite 4 -> 12, sprite-without-
+// color-math 6 -> 14), which is free: no layer type above 6 is otherwise used, and priority levels never
+// coincide between backgrounds and sprites, so the raised nibble can never decide an ordering comparison.
+// Masking the nibble with 7 recovers the layer the rest of the pipeline expects.
+#define ZBUF_PLAYER_LAYER_BIT 0x800
+#define ZBUF_LAYER(z) (((z) >> 8) & 7)
+
+// CGRAM entry a z-buffer value resolves to. The player reads its private bank by color index alone, so it
+// keeps the sheet's colors whichever hardware palette its OAM entry happens to name — including palette 0,
+// where the translucency swap parks the player in rooms with a see-through layer.
+static inline uint32 ZbufToCgram(PpuZbufType z) {
+  return (z & ZBUF_PLAYER_LAYER_BIT) ? (kPpuPlayerPalBase | (z & 0xf)) : (z & 0xff);
+}
+
 static void PpuDrawSprites(Ppu *ppu, uint y, uint sub, bool clear_backdrop) {
   int layer = 4;
   if (!IS_SCREEN_ENABLED(ppu, sub, layer))
@@ -851,7 +868,7 @@ static void PpuDrawMode7Upsampled(Ppu *ppu, uint y) {
     for (size_t i = 0; i < draw_width; i++, dst += 16) {
       uint32 pixel = pixels[i] & 0xff;
       if (pixel) {
-        uint32 color = ppu->colorMapRgb[pixel];
+        uint32 color = ppu->colorMapRgb[ZbufToCgram(pixels[i])];
         ((uint32 *)dst)[3] = ((uint32 *)dst)[2] = ((uint32 *)dst)[1] = ((uint32 *)dst)[0] = color;
         ((uint32 *)(dst + pitch * 1))[3] = ((uint32 *)(dst + pitch * 1))[2] = ((uint32 *)(dst + pitch * 1))[1] = ((uint32 *)(dst + pitch * 1))[0] = color;
         ((uint32 *)(dst + pitch * 2))[3] = ((uint32 *)(dst + pitch * 2))[2] = ((uint32 *)(dst + pitch * 2))[1] = ((uint32 *)(dst + pitch * 2))[0] = color;
@@ -976,13 +993,13 @@ static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
       uint32 i = left;
       if (ppu->renderFlags & (kPpuRenderFlags_BlackBG2 | kPpuRenderFlags_BlackBackdrop)) {
         do {
-          uint8 layer = (ppu->bgBuffers[0].data[i] >> 8) & 0xf;
+          uint8 layer = ZBUF_LAYER(ppu->bgBuffers[0].data[i]);
           uint8 cidx = ppu->bgBuffers[0].data[i] & 0xff;
           if ((ppu->renderFlags & kPpuRenderFlags_BlackBG2) ? (layer == 5 || (layer == 1 && cidx >= 112))
                                                             : (layer == 5 && cidx != 0)) {  // BlackBackdrop: gap sentinel only
             dst[0] = 0;
           } else {
-            uint32 color = ppu->cgram[ppu->bgBuffers[0].data[i] & 0xff];
+            uint32 color = ppu->cgram[ZbufToCgram(ppu->bgBuffers[0].data[i])];
             dst[0] = ppu->brightnessMult[color & clip_color_mask] << 16 |
                      ppu->brightnessMult[(color >> 5) & clip_color_mask] << 8 |
                      ppu->brightnessMult[(color >> 10) & clip_color_mask];
@@ -990,7 +1007,7 @@ static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
         } while (dst++, ++i < right);
       } else {
         do {
-          uint32 color = ppu->cgram[ppu->bgBuffers[0].data[i] & 0xff];
+          uint32 color = ppu->cgram[ZbufToCgram(ppu->bgBuffers[0].data[i])];
           dst[0] = ppu->brightnessMult[color & clip_color_mask] << 16 |
                    ppu->brightnessMult[(color >> 5) & clip_color_mask] << 8 |
                    ppu->brightnessMult[(color >> 10) & clip_color_mask];
@@ -1003,13 +1020,13 @@ static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
       // Need to check for each pixel whether to use math or not based on the main screen layer.
       uint32 i = left;
       do {
-        uint8 main_layer = (ppu->bgBuffers[0].data[i] >> 8) & 0xf;
+        uint8 main_layer = ZBUF_LAYER(ppu->bgBuffers[0].data[i]);
         uint8 cidx2 = ppu->bgBuffers[0].data[i] & 0xff;
         if ((ppu->renderFlags & kPpuRenderFlags_BlackBG2) ? (main_layer == 5 || (main_layer == 1 && cidx2 >= 112))
             : ((ppu->renderFlags & kPpuRenderFlags_BlackBackdrop) && main_layer == 5 && cidx2 != 0)) {  // gap sentinel
           dst[0] = 0;
         } else {
-          uint32 color = ppu->cgram[ppu->bgBuffers[0].data[i] & 0xff], color2;
+          uint32 color = ppu->cgram[ZbufToCgram(ppu->bgBuffers[0].data[i])], color2;
           uint32 r = color & clip_color_mask;
           uint32 g = (color >> 5) & clip_color_mask;
           uint32 b = (color >> 10) & clip_color_mask;
@@ -1017,7 +1034,7 @@ static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
           if (math_enabled_cur & (1 << main_layer)) {
             if (math_enabled_cur & 0x100) {  // addSubscreen ?
               if ((ppu->bgBuffers[1].data[i] & 0xff) != 0)
-                color2 = ppu->cgram[ppu->bgBuffers[1].data[i] & 0xff], color_map = half_color_map;
+                color2 = ppu->cgram[ZbufToCgram(ppu->bgBuffers[1].data[i])], color_map = half_color_map;
               else  // Don't halve if ppu->addSubscreen && backdrop
                 color2 = fixed_color;
             } else {
@@ -1202,10 +1219,10 @@ static int ppu_getPixel(Ppu *ppu, int x, int y, bool sub, int *r, int *g, int *b
           );
         }
       } else {
-        // get a pixel from the sprite buffer
+        // get a pixel from the sprite buffer, keeping the player's bank bit so it resolves like the real path
         pixel = 0;
         if ((ppu->objBuffer.data[x + kPpuExtraLeftRight] >> 12) == SPRITE_PRIO_TO_PRIO_HI(curPriority))
-          pixel = ppu->objBuffer.data[x + kPpuExtraLeftRight] & 0xff;
+          pixel = ppu->objBuffer.data[x + kPpuExtraLeftRight] & (0xff | ZBUF_PLAYER_LAYER_BIT);
       }
     }
     if (pixel > 0) {
@@ -1213,11 +1230,11 @@ static int ppu_getPixel(Ppu *ppu, int x, int y, bool sub, int *r, int *g, int *b
       break;
     }
   }
-  uint16_t color = ppu->cgram[pixel & 0xff];
+  uint16_t color = ppu->cgram[ZbufToCgram(pixel)];
   *r = color & 0x1f;
   *g = (color >> 5) & 0x1f;
   *b = (color >> 10) & 0x1f;
-  if (layer == 4 && pixel < 0xc0) layer = 6; // sprites with palette color < 0xc0
+  if (layer == 4 && (pixel & 0xff) < 0xc0) layer = 6; // sprites with palette color < 0xc0
   return layer;
 
 }
@@ -1411,6 +1428,9 @@ static bool ppu_evaluateSprites(Ppu* ppu, int line) {
     int paletteBase = 0x80 + 16 * ((oam1 & 0xe00) >> 9);
     int prio = SPRITE_PRIO_TO_PRIO((oam1 & 0x3000) >> 12, (oam1 & 0x800) == 0);
     PpuZbufType z = paletteBase + (prio << 8);
+    // Mark the player's own body so its pixels resolve against the private bank rather than the shared row.
+    if (ppu->playerPalActive && ppu->oamIsPlayer[index >> 1])
+      z += ZBUF_PLAYER_LAYER_BIT;
     
     for (int col = 0; col < spriteSize; col += 8) {
       if (col + x > -8 - extra_left_right && col + x < 256 + extra_left_right) {

--- a/core/zelda3/snes/ppu.h
+++ b/core/zelda3/snes/ppu.h
@@ -37,6 +37,10 @@ enum {
   // wide/tall view pans across the seam without the wrapping stock tilemap), needing up to two large areas
   // = 2048px = 256 tiles, plus margin.
   kPpuWorldTiles = 320,
+  // First entry of the player's private 16-color palette bank, past the 256 the hardware addresses. The
+  // gear palette shares a sprite row with villagers and followers, so a custom sheet's colors live here
+  // instead and only the player's own pixels resolve against them. See Ppu.cgram.
+  kPpuPlayerPalBase = 0x100,
 };
 
 typedef uint16_t PpuZbufType;
@@ -149,13 +153,24 @@ struct Ppu {
   // g_oam_x_high each frame) so ppu_evaluateSprites can place sprites at their true X across a >512px wide
   // view with no 512 fold — otherwise a sprite and its ±512 alias both draw (the ghost).
   uint8_t oamHighX[128];
+  // Which OAM slots hold the player's own body this frame (synced from g_oam_player). Those pixels read
+  // the private palette bank at cgram[0x100] instead of the hardware palette their OAM entry names, so a
+  // custom sprite sheet can recolor the player without disturbing the row it shares — see kPpuPlayerPal.
+  uint8_t oamIsPlayer[128];
+  // False unless a custom sheet is loaded, in which case the bank above is live. Keeps the stock game
+  // on exactly the path it had before the bank existed.
+  bool playerPalActive;
 
   // store 31 extra entries to remove the need for clamp
   uint8_t brightnessMult[32 + 31];
   uint8_t brightnessMultHalf[32 * 2];
-  uint16_t cgram[0x100];
+  // 0x000-0x0FF is CGRAM as the hardware sees it, and the only part a save state records. kPpuPlayerPalBase
+  // onward is the player's private bank, derived from the loaded sheet and re-pushed whenever gear palettes
+  // reload, so growing this array leaves the snapshot byte-identical.
+  uint16_t cgram[0x110];
   uint8_t mosaicModulo[kPpuXPixels];
-  uint32_t colorMapRgb[256];
+  // Brightness-mapped mirror of cgram for the 4x scale path, player bank included.
+  uint32_t colorMapRgb[0x110];
   PpuPixelPrioBufs bgBuffers[2];
   PpuPixelPrioBufs objBuffer;
   uint16_t vram[0x8000];

--- a/core/zelda3/src/load_gfx.c
+++ b/core/zelda3/src/load_gfx.c
@@ -6,6 +6,7 @@
 #include "player.h"
 #include "sprite.h"
 #include "assets.h"
+#include "game_hooks.h"
 
 // Allow this to be overwritten
 uint16 kGlovesColor[2] = {0x52f6, 0x376};
@@ -2063,6 +2064,7 @@ void Palette_Load_LinkArmorAndGloves() {  // 9bedf9
 void Palette_UpdateGlovesColor() {  // 9bee1b
   if (link_item_gloves)
     main_palette_buffer[0xfd] = aux_palette_buffer[0xfd] = kGlovesColor[link_item_gloves - 1];
+  GameHook_PlayerGlovesColorUpdated();
   flag_update_cgram_in_nmi += 1;
 }
 
@@ -2117,6 +2119,11 @@ void Palette_LoadMultiple(const uint16 *src, int dst, int x_ents, int y_pals) { 
 void Palette_LoadMultiple_Arbitrary(const uint16 *src, int dst, int x_ents) {  // 9bef7b
   memcpy(&aux_palette_buffer[dst >> 1], src, sizeof(uint16) * (x_ents + 1));
   memcpy(&main_palette_buffer[dst >> 1], src, sizeof(uint16) * (x_ents + 1));
+  // Every gear-palette load lands here, whichever outfit it picked. A custom sheet keeps its colors in a
+  // private palette bank rather than this row, which villagers and followers draw from too, so mirror the
+  // load into that bank and the player tracks armor, bunny form and the electro palette the same way.
+  if (dst == kPal_ArmorGloves)
+    GameHook_PlayerGearPaletteLoaded(src);
 }
 
 void Palette_LoadForFileSelect() {  // 9bef96

--- a/core/zelda3/src/player_oam.c
+++ b/core/zelda3/src/player_oam.c
@@ -945,6 +945,7 @@ continue_after_set:
         q = (bank1 & 1) ? q << 4 : q;
         WORD(oam_buf[oam_pos].charnum) = (q & 0xc000) | oam_priority_value | link_palette_bits_of_oam | 4;
         bytewise_extended_oam[oam_pos] = 0;
+        g_oam_player[oam_pos] = 1;
       }
     }
 
@@ -959,6 +960,7 @@ continue_after_set:
       q = (bank2 & 1) ? q << 4 : q;
       WORD(oam_buf[oam_pos].charnum) = (q & 0xc000) | oam_priority_value | link_palette_bits_of_oam | 0x14;
       bytewise_extended_oam[oam_pos] = 0;
+      g_oam_player[oam_pos] = 1;
     }
   }
   SwordResult sr;
@@ -1085,12 +1087,14 @@ continue_after_set:
         WORD(oam_buf[oam_pos].charnum) = td & 0xf000 | oam_priority_value | link_palette_bits_of_oam;
         WORD(oam_buf[oam_pos].x) = oam_x | oam_y << 8;
         bytewise_extended_oam[oam_pos] = 2 + (oam_x >= 0xf8);
+        g_oam_player[oam_pos] = 1;
       }
 
       if ((td << 4 & 0xf000) != 0xf000) {
         WORD(oam_buf[oam_pos+1].charnum) = td << 4 & 0xf000 | oam_priority_value | link_palette_bits_of_oam | 2;
         WORD(oam_buf[oam_pos+1].x) = (uint8)(xcoord) | (ycoord - zcoord + 8) << 8;
         bytewise_extended_oam[oam_pos+1] = 2;
+        g_oam_player[oam_pos+1] = 1;
       }
     }
   }

--- a/core/zelda3/src/types.h
+++ b/core/zelda3/src/types.h
@@ -127,5 +127,10 @@ extern uint8 g_oam_y_high[128];
 // (int16)screenX >> 9) per slot; 0 for any sprite in [-512,511] (so most need nothing). Set by the OAM
 // helpers when wide, synced to the PPU each frame, letting the PPU place a sprite at its true absolute X.
 extern uint8 g_oam_x_high[128];
+// Which OAM slots hold the player's own body this frame. The gear palette lives in a sprite palette that
+// villagers and followers also draw from, so a custom sheet's colors cannot go there without recoloring
+// them. Marked slots read a private palette bank in the PPU instead. Set by the player OAM builder,
+// cleared with the buffer each frame, synced to the PPU alongside the arrays above.
+extern uint8 g_oam_player[128];
 
 #endif  // ZELDA3_TYPES_H_

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -447,6 +447,12 @@ void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
     for (int s = 0; s < 128; s++)
       g_zenv.ppu->oamHighX[s] = g_oam_x_high[s];
   }
+  // Custom sheet: hand over this frame's player slots so the PPU resolves them against the private palette
+  // bank rather than the sprite palette the gear shares with villagers and followers.
+  if (g_zenv.ppu->playerPalActive) {
+    for (int s = 0; s < 128; s++)
+      g_zenv.ppu->oamIsPlayer[s] = g_oam_player[s];
+  }
 
   for (int i = 0; i <= height; i++) {
     if (i == 128 + topBudget && irq_flag) {  // file-select BG3 split fires at content line 128 (shifted down by the top budget)
@@ -504,12 +510,14 @@ uint16 g_oam_tall_budget;
 uint16 g_oam_wide_budget;
 uint8 g_oam_y_high[128];
 uint8 g_oam_x_high[128];  // see types.h — signed high X bits (above the stock 9) for wide views
+uint8 g_oam_player[128];  // see types.h — which slots are the player's own body, for the private palette
 
 static void ClearOamBuffer() {  // 80841e
   for (int i = 0; i < 128; i++) {
     oam_buf[i].y = 0xf0;
     g_oam_y_high[i] = 0;  // reset each frame; OAM helpers set it for tall sprites this frame
     g_oam_x_high[i] = 0;  // reset each frame; OAM helpers set it for wide sprites this frame
+    g_oam_player[i] = 0;  // reset each frame; the player OAM builder marks its own slots
   }
 }
 


### PR DESCRIPTION
A custom sheet was turning the broom villager in Kakariko solid black, because the gear palette is not the player's alone. kPal_ArmorGloves is the same address as kPal_sp7l, so loading it writes all of sprite palette 7, and a number of NPCs draw from that row deliberately. Fixes #40.

- The PPU keeps a private 16-color bank past the hardware palette and resolves the player's own pixels against it, so the shared row stays stock and villagers and followers keep their colors.
- Player pixels are tagged by raising their z-buffer layer nibble by 8. Nothing above 6 is used, and priority levels never coincide between backgrounds and sprites, so the raised nibble can never decide an ordering comparison. Masking with 7 gives the rest of the pipeline the layer it expects.
- The bank lives outside the part of cgram a save state records, so snapshots are byte-identical and existing saves keep loading.
- It refreshes off the gear palette load itself, so armor upgrades, bunny form and gloves track the way they always did. The electro palette has no sheet equivalent, so the player falls back to the shared row there.
- The sheet no longer touches kPalette_ArmorAndGloves at all, which is what upstream does and what caused this.

Verified on the reported screen: the shared row holds the stock greens again while the player's bank holds the sheet's colors.