### PR TITLE
Report host hardware, monitors and audio in the debug info

### DIFF
--- a/apps/desktop/electron/diagnostics/collect-displays.ts
+++ b/apps/desktop/electron/diagnostics/collect-displays.ts
@@ -1,0 +1,53 @@
+/* @layer electron-main @kind logic */
+/**
+ * Per-monitor readout. Only the main process can see the whole desktop; the
+ * renderer's `window.screen` describes the one display the window sits on, which
+ * is exactly the blind spot when a report says "it's wrong on my second monitor".
+ */
+import { screen } from 'electron';
+import type { Display } from 'electron';
+import type { DisplayDiagnostics } from '@shared/types/diagnostics';
+
+const TOUCH_LABEL: Record<string, string> = {
+  available: 'touch',
+  unavailable: 'none',
+  unknown: 'unknown',
+};
+
+const describeDisplay = (display: Display, primaryId: number): DisplayDiagnostics => ({
+  id: display.id,
+  label: display.label || `display-${display.id}`,
+  primary: display.id === primaryId,
+  internal: display.internal,
+  bounds: { ...display.bounds },
+  nativeSize: {
+    width: Math.round(display.size.width * display.scaleFactor),
+    height: Math.round(display.size.height * display.scaleFactor),
+  },
+  workArea: { ...display.workArea },
+  scaleFactor: display.scaleFactor,
+  rotation: display.rotation,
+  // 0 means "the platform did not report one" rather than a real 0 Hz.
+  refreshHz: display.displayFrequency || null,
+  colorDepth: display.colorDepth,
+  depthPerComponent: display.depthPerComponent,
+  colorSpace: display.colorSpace,
+  monochrome: display.monochrome,
+  touchSupport: TOUCH_LABEL[display.touchSupport] ?? display.touchSupport,
+});
+
+const collectDisplays = (): DisplayDiagnostics[] => {
+  let primaryId = -1;
+  try {
+    primaryId = screen.getPrimaryDisplay().id;
+  } catch {
+    // no display server (headless CI) — every entry just reports primary: false
+  }
+  try {
+    return screen.getAllDisplays().map((display) => describeDisplay(display, primaryId));
+  } catch {
+    return [];
+  }
+};
+
+export { collectDisplays };

--- a/apps/desktop/electron/diagnostics/collect-gpu.ts
+++ b/apps/desktop/electron/diagnostics/collect-gpu.ts
@@ -1,0 +1,71 @@
+/* @layer electron-main @kind logic */
+/**
+ * GPU readout. The renderer can only see the ANGLE string WebGL hands it; the main
+ * process additionally knows the PCI ids, the driver version, which adapter is
+ * active on a hybrid-graphics machine, and which accelerated features Chromium
+ * actually turned on.
+ */
+import { app } from 'electron';
+import type { GpuDevice, GpuDiagnostics } from '@shared/types/diagnostics';
+
+// getGPUInfo resolves an untyped bag whose shape varies by platform and driver;
+// these narrow only the fields reported below.
+interface RawGpuDevice {
+  vendorId?: number;
+  deviceId?: number;
+  driverVendor?: string;
+  driverVersion?: string;
+  deviceString?: string;
+  active?: boolean;
+}
+
+interface RawGpuInfo {
+  gpuDevice?: RawGpuDevice[];
+  auxAttributes?: Record<string, unknown>;
+}
+
+const text = (value: unknown): string | null => (typeof value === 'string' && value ? value : null);
+
+const readGpuInfo = async (): Promise<RawGpuInfo> => {
+  try {
+    return (await app.getGPUInfo('complete')) as RawGpuInfo;
+  } catch {
+    // --disable-gpu, or the info process never reported back
+    return {};
+  }
+};
+
+const readFeatures = (): Record<string, string> => {
+  try {
+    return app.getGPUFeatureStatus() as unknown as Record<string, string>;
+  } catch {
+    return {};
+  }
+};
+
+const toDevice = (raw: RawGpuDevice): GpuDevice => ({
+  vendorId: raw.vendorId ?? 0,
+  deviceId: raw.deviceId ?? 0,
+  vendor: text(raw.driverVendor),
+  device: text(raw.deviceString),
+  driverVersion: text(raw.driverVersion),
+  active: raw.active === true,
+});
+
+const collectGpu = async (): Promise<GpuDiagnostics> => {
+  const info = await readGpuInfo();
+  const aux = info.auxAttributes ?? {};
+  const devices = (info.gpuDevice ?? []).map(toDevice);
+  const features = readFeatures();
+  return {
+    devices,
+    glVendor: text(aux.glVendor),
+    glRenderer: text(aux.glRenderer),
+    glVersion: text(aux.glVersion),
+    driverVersion: text(aux.driverVersion) ?? devices.find((d) => d.active)?.driverVersion ?? null,
+    hardwareAccelerated: features.gpu_compositing === 'enabled',
+    features,
+  };
+};
+
+export { collectGpu };

--- a/apps/desktop/electron/diagnostics/collect-host.ts
+++ b/apps/desktop/electron/diagnostics/collect-host.ts
@@ -1,0 +1,56 @@
+/* @layer electron-main @kind logic */
+/**
+ * OS / CPU / memory side of the host readout. Everything here comes from the
+ * `os` module or the app itself, so it is cheap and synchronous.
+ */
+import { app, powerMonitor } from 'electron';
+import { arch, cpus, freemem, platform, release, totalmem, uptime, version } from 'os';
+import type { CpuDiagnostics, MemoryDiagnostics, OsDiagnostics, RuntimeVersions } from '@shared/types/diagnostics';
+
+const collectCpu = (): CpuDiagnostics => {
+  const cores = cpus();
+  return {
+    model: cores[0]?.model?.trim() || 'unknown',
+    logicalCores: cores.length,
+    speedMhz: cores[0]?.speed ?? 0,
+    arch: arch(),
+  };
+};
+
+const collectMemory = (): MemoryDiagnostics => {
+  // getSystemMemoryInfo is the only source of swap figures and reports kilobytes.
+  // It is unavailable on some sandboxes, so swap degrades to null while total/free
+  // always come from the os module.
+  let swapTotalBytes: number | null = null;
+  let swapFreeBytes: number | null = null;
+  try {
+    const info = process.getSystemMemoryInfo();
+    swapTotalBytes = info.swapTotal * 1024;
+    swapFreeBytes = info.swapFree * 1024;
+  } catch {
+    // no swap reporting on this platform
+  }
+  return { totalBytes: totalmem(), freeBytes: freemem(), swapTotalBytes, swapFreeBytes };
+};
+
+const collectOs = (): OsDiagnostics => ({
+  platform: platform(),
+  version: version(),
+  release: release(),
+  arch: arch(),
+  uptimeSeconds: Math.round(uptime()),
+  locale: app.getLocale(),
+  systemLocale: app.getSystemLocale(),
+  preferredLanguages: app.getPreferredSystemLanguages(),
+  timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  onBattery: powerMonitor.onBatteryPower,
+});
+
+const collectVersions = (): RuntimeVersions => ({
+  node: process.versions.node ?? '—',
+  v8: process.versions.v8 ?? '—',
+  chrome: process.versions.chrome ?? '—',
+  electron: process.versions.electron ?? '—',
+});
+
+export { collectCpu, collectMemory, collectOs, collectVersions };

--- a/apps/desktop/electron/diagnostics/ipc-handlers.ts
+++ b/apps/desktop/electron/diagnostics/ipc-handlers.ts
@@ -1,0 +1,25 @@
+/* @layer electron-main @kind logic */
+/**
+ * Diagnostics IPC: one read-only channel returning the host hardware/OS readout
+ * that backs the About page's debug-info block.
+ */
+import type { SystemDiagnostics } from '@shared/types/diagnostics';
+import { handle } from '../lib/ipc/handle';
+import { collectCpu, collectMemory, collectOs, collectVersions } from './collect-host';
+import { collectDisplays } from './collect-displays';
+import { collectGpu } from './collect-gpu';
+
+const collectSystemDiagnostics = async (): Promise<SystemDiagnostics> => ({
+  os: collectOs(),
+  cpu: collectCpu(),
+  memory: collectMemory(),
+  gpu: await collectGpu(),
+  displays: collectDisplays(),
+  versions: collectVersions(),
+});
+
+const registerDiagnosticsHandlers = (): void => {
+  handle('diagnostics:getSystem', () => collectSystemDiagnostics());
+};
+
+export { registerDiagnosticsHandlers };

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,6 +35,7 @@ import { registerConnectionHandlers } from './connections/ipc-handlers';
 import { registerScreenEditorHandlers } from './screen-editor/ipc-handlers';
 import { registerShadowCastingHandlers } from './shadow-casting';
 import { registerAppHandlers } from './app/ipc-handlers';
+import { registerDiagnosticsHandlers } from './diagnostics/ipc-handlers';
 import { registerWasmHandlers } from './wasm/ipc-handlers';
 import { registerStorageHandlers } from './storage/ipc-handlers';
 import { registerFileHandlers } from './storage/file-handlers';
@@ -68,6 +69,7 @@ const IPC_HANDLERS: Array<{ register: () => void; devOnly?: boolean }> = [
   { register: registerShadowCastingHandlers },
   { register: registerUpdaterHandlers },
   { register: registerAppHandlers },
+  { register: registerDiagnosticsHandlers },
   { register: registerWasmHandlers },
   { register: registerStorageHandlers },
   { register: registerFileHandlers },

--- a/apps/web/src/lib/diagnostics/collect-renderer.ts
+++ b/apps/web/src/lib/diagnostics/collect-renderer.ts
@@ -1,0 +1,21 @@
+/* @layer renderer-lib @kind logic */
+/** Runs every renderer-side probe. The refresh-rate measurement is the only slow
+ *  one (it has to watch real frames), so it runs alongside the audio probe. */
+import type { RendererDiagnostics } from './types';
+import { probeWebgl } from './probe-webgl';
+import { probeAudio } from './probe-audio';
+import { probeDisplay } from './probe-display';
+import { probeDevice } from './probe-device';
+import { probeRefreshRate } from './probe-refresh-rate';
+
+const collectRendererDiagnostics = async (): Promise<RendererDiagnostics> => {
+  const [audio, refreshHz] = await Promise.all([probeAudio(), probeRefreshRate()]);
+  return {
+    webgl: probeWebgl(),
+    audio,
+    display: probeDisplay(refreshHz),
+    device: probeDevice(),
+  };
+};
+
+export { collectRendererDiagnostics };

--- a/apps/web/src/lib/diagnostics/format/debug-text.ts
+++ b/apps/web/src/lib/diagnostics/format/debug-text.ts
@@ -1,0 +1,37 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Assembles the full debug-info block. `system` is null on any host without a main
+ * process (web, mobile) — the host sections simply drop out and the renderer-side
+ * ones still carry the report.
+ */
+import type { SystemDiagnostics } from '@shared/types/diagnostics';
+import type { RendererDiagnostics } from '../types';
+import { renderSections } from './section';
+import { hardwareSection, systemSection } from './host-system';
+import { graphicsSection } from './graphics';
+import { displaysSection, windowSection } from './displays';
+import { audioSection, inputSection, processSection } from './renderer-env';
+
+interface DebugTextInput {
+  /** Leading identity lines (app version, runtime, engine, platform) owned by the caller. */
+  header: string[];
+  system: SystemDiagnostics | null;
+  renderer: RendererDiagnostics;
+  userAgent: string;
+}
+
+const buildDebugText = ({ header, system, renderer, userAgent }: DebugTextInput): string => {
+  const body = renderSections([
+    ...(system ? [systemSection(system), hardwareSection(system)] : []),
+    graphicsSection(system?.gpu ?? null, renderer.webgl),
+    ...(system && system.displays.length > 0 ? [displaysSection(system.displays)] : []),
+    windowSection(renderer.display),
+    audioSection(renderer.audio),
+    inputSection(renderer.device),
+    processSection(renderer.device),
+  ]);
+  return [header.join('\n'), body, `[User agent]\n${userAgent}`].join('\n\n');
+};
+
+export { buildDebugText };
+export type { DebugTextInput };

--- a/apps/web/src/lib/diagnostics/format/displays.ts
+++ b/apps/web/src/lib/diagnostics/format/displays.ts
@@ -1,0 +1,48 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Monitor sections: every attached display from the host, then the one the window
+ * is actually on as the renderer measures it. Both are reported because a mismatch
+ * between them is itself the bug in a multi-monitor or mixed-DPI report.
+ */
+import type { DisplayDiagnostics } from '@shared/types/diagnostics';
+import type { DisplayEnvironment } from '../types';
+import type { DebugSection } from './section';
+import { section } from './section';
+import { orDash, yesNo } from './units';
+
+// Chromium reports the colour space as a braced struct; the braces add nothing
+// once it is inside a parenthesised clause.
+const colorSpace = (raw: string): string => raw.replace(/[{}]/g, '').trim() || '—';
+
+const displayLines = (display: DisplayDiagnostics, index: number): string[] => {
+  const tags = [display.primary && 'primary', display.internal ? 'internal' : 'external', display.monochrome && 'monochrome']
+    .filter(Boolean)
+    .join(', ');
+  return [
+    `${index + 1}. ${display.label} — ${tags}`,
+    `   Native ${display.nativeSize.width}×${display.nativeSize.height}`
+      + ` @ ${display.refreshHz ? `${display.refreshHz} Hz` : 'unreported Hz'}`
+      + ` · scale ${display.scaleFactor}× · rotation ${display.rotation}°`,
+    `   Logical ${display.bounds.width}×${display.bounds.height} at (${display.bounds.x},${display.bounds.y})`
+      + ` · work area ${display.workArea.width}×${display.workArea.height}`,
+    `   Colour ${display.colorDepth}-bit (${display.depthPerComponent} bpc, ${colorSpace(display.colorSpace)})`
+      + ` · touch ${display.touchSupport}`,
+  ];
+};
+
+const displaysSection = (displays: DisplayDiagnostics[]): DebugSection =>
+  section(`Displays (${displays.length})`, displays.flatMap(displayLines));
+
+const windowSection = (display: DisplayEnvironment): DebugSection => section('Window display', [
+  `Screen: ${display.screen.width}×${display.screen.height} logical`
+    + ` (${display.nativeScreen.width}×${display.nativeScreen.height} native) @ ${display.devicePixelRatio}×`,
+  `Available: ${display.screen.availWidth}×${display.screen.availHeight}`
+    + ` · viewport ${display.viewport.width}×${display.viewport.height}`,
+  `Measured frame rate: ${display.refreshHz ? `${display.refreshHz} Hz` : 'not measurable'}`,
+  `Colour: ${display.colorDepth}-bit (pixel depth ${display.pixelDepth})`
+    + ` · gamut ${display.colorGamut} · HDR ${yesNo(display.hdr)}`,
+  `Preferences: ${display.colorScheme} scheme · reduced motion ${yesNo(display.reducedMotion)}`
+    + ` · orientation ${orDash(display.orientation)}`,
+]);
+
+export { displaysSection, windowSection };

--- a/apps/web/src/lib/diagnostics/format/graphics.ts
+++ b/apps/web/src/lib/diagnostics/format/graphics.ts
@@ -1,0 +1,53 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Graphics section. Host adapter facts and the renderer's WebGL view are merged
+ * here because they answer the same question from two sides, and on the web build
+ * only the WebGL half exists.
+ */
+import type { GpuDevice, GpuDiagnostics } from '@shared/types/diagnostics';
+import type { WebglDiagnostics } from '../types';
+import type { DebugSection } from './section';
+import { section } from './section';
+import { hex, orDash, yesNo } from './units';
+
+const adapterLine = (device: GpuDevice): string => {
+  const name = orDash(device.device ?? device.vendor);
+  const ids = `[${hex(device.vendorId)}:${hex(device.deviceId)}]`;
+  const driver = device.driverVersion ? ` driver ${device.driverVersion}` : '';
+  return `Adapter: ${name} ${ids}${driver}${device.active ? ' (active)' : ''}`;
+};
+
+// Chromium reports several shades of on ('enabled', 'enabled_on', 'enabled_readback')
+// and of off; only the off ones matter to a rendering report.
+const disabledFeatures = (features: Record<string, string>): string[] =>
+  Object.entries(features)
+    .filter(([, status]) => !status.startsWith('enabled'))
+    .map(([name, status]) => `${name}=${status}`);
+
+const gpuLines = (gpu: GpuDiagnostics | null): string[] => {
+  if (!gpu) return [];
+  const disabled = disabledFeatures(gpu.features);
+  return [
+    ...gpu.devices.map(adapterLine),
+    gpu.driverVersion ? `Driver: ${gpu.driverVersion}` : '',
+    `Hardware acceleration: ${yesNo(gpu.hardwareAccelerated)}`,
+    gpu.glVendor || gpu.glRenderer ? `GL: ${orDash(gpu.glVendor)} / ${orDash(gpu.glRenderer)}` : '',
+    gpu.glVersion ? `GL version: ${gpu.glVersion}` : '',
+    disabled.length > 0 ? `Not accelerated: ${disabled.join(', ')}` : 'All GPU features enabled',
+  ].filter(Boolean);
+};
+
+const webglLines = (webgl: WebglDiagnostics | null): string[] => {
+  if (!webgl) return ['WebGL: unavailable'];
+  return [
+    `WebGL${webgl.version}: ${webgl.vendor} / ${webgl.renderer}`,
+    `WebGL version: ${webgl.glVersion} · GLSL: ${webgl.shadingLanguage}`,
+    `Limits: max texture ${webgl.maxTextureSize} · max viewport ${webgl.maxViewport}`
+      + ` · max renderbuffer ${webgl.maxRenderBufferSize} · antialias ${yesNo(webgl.antialias)}`,
+  ];
+};
+
+const graphicsSection = (gpu: GpuDiagnostics | null, webgl: WebglDiagnostics | null): DebugSection =>
+  section('Graphics', [...gpuLines(gpu), ...webglLines(webgl)]);
+
+export { graphicsSection };

--- a/apps/web/src/lib/diagnostics/format/host-system.ts
+++ b/apps/web/src/lib/diagnostics/format/host-system.ts
@@ -1,0 +1,23 @@
+/* @layer renderer-lib @kind logic */
+/** OS, CPU and memory sections of the host readout. */
+import type { SystemDiagnostics } from '@shared/types/diagnostics';
+import type { DebugSection } from './section';
+import { section } from './section';
+import { duration, ghz, gib, orDash, yesNo } from './units';
+
+const systemSection = ({ os, versions }: SystemDiagnostics): DebugSection => section('System', [
+  `OS: ${orDash(os.version)} (${orDash(os.release)}) ${os.arch}`,
+  `Uptime: ${duration(os.uptimeSeconds)} · On battery: ${yesNo(os.onBattery)}`,
+  `Locale: ${orDash(os.locale)} (system ${orDash(os.systemLocale)}) · Time zone: ${orDash(os.timeZone)}`,
+  os.preferredLanguages.length > 0 && `Preferred languages: ${os.preferredLanguages.join(', ')}`,
+  `Versions: node ${versions.node} · v8 ${versions.v8} · chromium ${versions.chrome} · electron ${versions.electron}`,
+]);
+
+const hardwareSection = ({ cpu, memory }: SystemDiagnostics): DebugSection => section('CPU & memory', [
+  `CPU: ${cpu.model} — ${cpu.logicalCores} logical cores @ ${ghz(cpu.speedMhz)} (${cpu.arch})`,
+  `RAM: ${gib(memory.totalBytes)} total, ${gib(memory.freeBytes)} free`,
+  memory.swapTotalBytes !== null
+    && `Swap: ${gib(memory.swapTotalBytes)} total, ${gib(memory.swapFreeBytes ?? 0)} free`,
+]);
+
+export { systemSection, hardwareSection };

--- a/apps/web/src/lib/diagnostics/format/renderer-env.ts
+++ b/apps/web/src/lib/diagnostics/format/renderer-env.ts
@@ -1,0 +1,32 @@
+/* @layer renderer-lib @kind logic */
+/** Audio output, connected controllers, and the renderer's own view of the machine
+ *  (which is all there is to report on the web and mobile builds). */
+import type { AudioDiagnostics, DeviceEnvironment } from '../types';
+import type { DebugSection } from './section';
+import { section } from './section';
+import { mib, ms, orDash, yesNo } from './units';
+
+const audioSection = (audio: AudioDiagnostics | null): DebugSection => section('Audio', [
+  audio
+    ? `Output: ${audio.sampleRate} Hz · ${audio.maxChannels} channels · state ${audio.state}`
+    : 'Output: unavailable (no audio context)',
+  audio && `Latency: base ${ms(audio.baseLatencyMs)} · output ${ms(audio.outputLatencyMs)}`,
+]);
+
+const inputSection = ({ gamepads, maxTouchPoints }: DeviceEnvironment): DebugSection => section('Input', [
+  `Gamepads visible to the browser: ${gamepads.length}`,
+  ...gamepads.map((pad, index) => `   ${index + 1}. ${pad}`),
+  `Max touch points: ${maxTouchPoints}`,
+]);
+
+const processSection = (device: DeviceEnvironment): DebugSection => section('Renderer process', [
+  `Logical cores seen by the renderer: ${orDash(device.logicalCores)}`,
+  device.deviceMemoryGb !== null && `Reported device memory: ${device.deviceMemoryGb} GB`,
+  device.jsHeap
+    && `JS heap: ${mib(device.jsHeap.usedBytes)} used / ${mib(device.jsHeap.totalBytes)} allocated`
+      + ` (limit ${mib(device.jsHeap.limitBytes)})`,
+  `Languages: ${device.languages.join(', ') || '—'} · time zone ${orDash(device.timeZone)}`,
+  `Online: ${yesNo(device.online)}`,
+]);
+
+export { audioSection, inputSection, processSection };

--- a/apps/web/src/lib/diagnostics/format/section.ts
+++ b/apps/web/src/lib/diagnostics/format/section.ts
@@ -1,0 +1,27 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * The debug-info block is built as titled sections so a formatter can drop a line
+ * (or a whole section) when the underlying probe returned nothing, without the
+ * caller having to know which parts are optional.
+ */
+
+interface DebugSection {
+  title: string;
+  lines: string[];
+}
+
+type Line = string | null | false | undefined;
+
+const section = (title: string, lines: Line[]): DebugSection => ({
+  title,
+  lines: lines.filter((line): line is string => typeof line === 'string' && line.length > 0),
+});
+
+const renderSections = (sections: DebugSection[]): string =>
+  sections
+    .filter((entry) => entry.lines.length > 0)
+    .map((entry) => [`[${entry.title}]`, ...entry.lines].join('\n'))
+    .join('\n\n');
+
+export { section, renderSections };
+export type { DebugSection, Line };

--- a/apps/web/src/lib/diagnostics/format/units.ts
+++ b/apps/web/src/lib/diagnostics/format/units.ts
@@ -1,0 +1,31 @@
+/* @layer renderer-lib @kind logic */
+/** Formatting helpers for the debug-info block: compact, stable, no locale
+ *  separators (the text gets pasted into reports and diffed by eye). */
+
+const GIB = 1024 ** 3;
+
+const gib = (bytes: number): string => `${(bytes / GIB).toFixed(1)} GiB`;
+
+const mib = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))} MiB`;
+
+const ghz = (mhz: number): string => (mhz > 0 ? `${(mhz / 1000).toFixed(2)} GHz` : 'unknown');
+
+const ms = (value: number | null): string => (value === null ? '—' : `${value.toFixed(1)} ms`);
+
+const duration = (seconds: number): string => {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (days) return `${days}d ${hours}h`;
+  if (hours) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+};
+
+const hex = (value: number): string => `0x${value.toString(16).toUpperCase().padStart(4, '0')}`;
+
+const yesNo = (value: boolean): string => (value ? 'yes' : 'no');
+
+const orDash = (value: string | number | null | undefined): string =>
+  value === null || value === undefined || value === '' ? '—' : String(value);
+
+export { gib, mib, ghz, ms, duration, hex, yesNo, orDash };

--- a/apps/web/src/lib/diagnostics/index.ts
+++ b/apps/web/src/lib/diagnostics/index.ts
@@ -1,0 +1,8 @@
+/* @layer renderer-lib @kind barrel */
+export { collectRendererDiagnostics } from './collect-renderer';
+export { buildDebugText } from './format/debug-text';
+
+export type { DebugTextInput } from './format/debug-text';
+export type {
+  RendererDiagnostics, WebglDiagnostics, AudioDiagnostics, DisplayEnvironment, DeviceEnvironment,
+} from './types';

--- a/apps/web/src/lib/diagnostics/probe-audio.ts
+++ b/apps/web/src/lib/diagnostics/probe-audio.ts
@@ -1,0 +1,35 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Audio-device probe. The core's mixer runs inside the wasm module, so instead of
+ * reaching into it this opens a short-lived context to read the properties the
+ * output device imposes on any context — the sample rate the resampler has to hit
+ * and the buffer latency behind crackle reports.
+ */
+import type { AudioDiagnostics } from './types';
+
+const probeAudio = async (): Promise<AudioDiagnostics | null> => {
+  let context: AudioContext | null = null;
+  try {
+    context = new AudioContext();
+    const outputLatency = context.outputLatency;
+    const info: AudioDiagnostics = {
+      sampleRate: context.sampleRate,
+      baseLatencyMs: Number.isFinite(context.baseLatency) ? context.baseLatency * 1000 : null,
+      // Reported as 0 until the graph has actually run; treat that as unknown.
+      outputLatencyMs: Number.isFinite(outputLatency) && outputLatency > 0 ? outputLatency * 1000 : null,
+      maxChannels: context.destination.maxChannelCount,
+      state: context.state,
+    };
+    return info;
+  } catch {
+    return null;
+  } finally {
+    try {
+      await context?.close();
+    } catch {
+      // already closed, or the context never opened
+    }
+  }
+};
+
+export { probeAudio };

--- a/apps/web/src/lib/diagnostics/probe-device.ts
+++ b/apps/web/src/lib/diagnostics/probe-device.ts
@@ -1,0 +1,49 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Machine-level facts reachable without a main process, plus the controllers the
+ * Gamepad API can see. Gamepad ids carry the vendor/product pair, which is what a
+ * controller-mapping report needs to be actionable.
+ */
+import type { DeviceEnvironment } from './types';
+
+// Both are non-standard Chromium extensions with no lib.dom typings.
+interface ChromiumNavigator extends Navigator {
+  deviceMemory?: number;
+}
+
+interface ChromiumPerformance extends Performance {
+  memory?: { usedJSHeapSize: number; totalJSHeapSize: number; jsHeapSizeLimit: number };
+}
+
+const readJsHeap = (): DeviceEnvironment['jsHeap'] => {
+  const memory = (performance as ChromiumPerformance).memory;
+  if (!memory) return null;
+  return {
+    usedBytes: memory.usedJSHeapSize,
+    totalBytes: memory.totalJSHeapSize,
+    limitBytes: memory.jsHeapSizeLimit,
+  };
+};
+
+const readGamepads = (): string[] => {
+  try {
+    return Array.from(navigator.getGamepads?.() ?? [])
+      .filter((pad): pad is Gamepad => pad !== null)
+      .map((pad) => `${pad.id} (${pad.buttons.length} buttons, ${pad.axes.length} axes, ${pad.mapping || 'no mapping'})`);
+  } catch {
+    return [];
+  }
+};
+
+const probeDevice = (): DeviceEnvironment => ({
+  logicalCores: navigator.hardwareConcurrency || null,
+  deviceMemoryGb: (navigator as ChromiumNavigator).deviceMemory ?? null,
+  jsHeap: readJsHeap(),
+  maxTouchPoints: navigator.maxTouchPoints ?? 0,
+  languages: Array.from(navigator.languages ?? [navigator.language]).filter(Boolean),
+  timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  online: navigator.onLine,
+  gamepads: readGamepads(),
+});
+
+export { probeDevice };

--- a/apps/web/src/lib/diagnostics/probe-display.ts
+++ b/apps/web/src/lib/diagnostics/probe-display.ts
@@ -1,0 +1,46 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * The display the window is currently on, as the renderer sees it. Scale factor and
+ * colour capability decide how the pixel-art scaler behaves, so they matter for any
+ * report about blurry or mis-sized output.
+ */
+import type { DisplayEnvironment } from './types';
+
+const matches = (query: string): boolean => {
+  try {
+    return window.matchMedia(query).matches;
+  } catch {
+    return false;
+  }
+};
+
+const firstMatch = (queries: string[], fallback: string): string =>
+  queries.find((query) => matches(`(${query})`))?.split(':')[1]?.trim() ?? fallback;
+
+const probeDisplay = (refreshHz: number | null): DisplayEnvironment => {
+  const dpr = window.devicePixelRatio;
+  return {
+    screen: {
+      width: window.screen.width,
+      height: window.screen.height,
+      availWidth: window.screen.availWidth,
+      availHeight: window.screen.availHeight,
+    },
+    nativeScreen: {
+      width: Math.round(window.screen.width * dpr),
+      height: Math.round(window.screen.height * dpr),
+    },
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    colorDepth: window.screen.colorDepth,
+    pixelDepth: window.screen.pixelDepth,
+    devicePixelRatio: dpr,
+    orientation: window.screen.orientation?.type ?? null,
+    colorScheme: matches('(prefers-color-scheme: dark)') ? 'dark' : 'light',
+    colorGamut: firstMatch(['color-gamut: rec2020', 'color-gamut: p3', 'color-gamut: srgb'], 'unknown'),
+    hdr: matches('(dynamic-range: high)'),
+    reducedMotion: matches('(prefers-reduced-motion: reduce)'),
+    refreshHz,
+  };
+};
+
+export { probeDisplay };

--- a/apps/web/src/lib/diagnostics/probe-refresh-rate.ts
+++ b/apps/web/src/lib/diagnostics/probe-refresh-rate.ts
@@ -1,0 +1,52 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Measures the compositor's actual frame cadence by timing animation frames. This
+ * is the rate the emulator is being paced against, which can differ from the mode
+ * the monitor reports — a 144 Hz panel driven at 60, or a variable-refresh panel
+ * settling somewhere in between. Uses the median so one hitch cannot skew it.
+ */
+
+const SAMPLE_FRAMES = 12;
+// Generous, because a background or occluded window has its frames throttled hard
+// and the probe should give up cleanly rather than hold the copy button hostage.
+const TIMEOUT_MS = 2500;
+// A gap this large means the tab was throttled or the compositor stalled, so the
+// sample says nothing about the display's cadence.
+const MAX_PLAUSIBLE_GAP_MS = 100;
+
+const median = (values: number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+};
+
+const probeRefreshRate = (): Promise<number | null> =>
+  new Promise((resolve) => {
+    const gaps: number[] = [];
+    let previous = 0;
+    let settled = false;
+
+    const finish = (value: number | null): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const timeout = setTimeout(() => finish(null), TIMEOUT_MS);
+
+    const onFrame = (time: number): void => {
+      if (previous) gaps.push(time - previous);
+      previous = time;
+      if (gaps.length < SAMPLE_FRAMES) {
+        requestAnimationFrame(onFrame);
+        return;
+      }
+      clearTimeout(timeout);
+      const gap = median(gaps.filter((value) => value > 0 && value < MAX_PLAUSIBLE_GAP_MS));
+      finish(gap > 0 ? Math.round(1000 / gap) : null);
+    };
+
+    requestAnimationFrame(onFrame);
+  });
+
+export { probeRefreshRate };

--- a/apps/web/src/lib/diagnostics/probe-webgl.ts
+++ b/apps/web/src/lib/diagnostics/probe-webgl.ts
@@ -1,0 +1,53 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Graphics-stack probe. Prefers a WebGL2 context so the reported limits match what
+ * the game canvas actually gets, and unmasks the real adapter string through the
+ * debug-renderer extension rather than the generic "WebKit WebGL" placeholder.
+ */
+import type { WebglDiagnostics } from './types';
+
+type AnyGl = WebGLRenderingContext | WebGL2RenderingContext;
+
+const createContext = (): { gl: AnyGl; version: 1 | 2 } | null => {
+  const canvas = document.createElement('canvas');
+  const gl2 = canvas.getContext('webgl2');
+  if (gl2) return { gl: gl2, version: 2 };
+  const gl1 = canvas.getContext('webgl');
+  return gl1 ? { gl: gl1, version: 1 } : null;
+};
+
+const unmasked = (gl: AnyGl, masked: number, unmaskedName: 'UNMASKED_VENDOR_WEBGL' | 'UNMASKED_RENDERER_WEBGL'): string => {
+  const ext = gl.getExtension('WEBGL_debug_renderer_info');
+  const value = ext ? gl.getParameter(ext[unmaskedName]) : null;
+  return String(value ?? gl.getParameter(masked) ?? '—');
+};
+
+const probeWebgl = (): WebglDiagnostics | null => {
+  try {
+    const context = createContext();
+    if (!context) return null;
+    const { gl, version } = context;
+    const attributes = gl.getContextAttributes();
+    const viewport = gl.getParameter(gl.MAX_VIEWPORT_DIMS) as Int32Array | null;
+    const info: WebglDiagnostics = {
+      version,
+      vendor: unmasked(gl, gl.VENDOR, 'UNMASKED_VENDOR_WEBGL'),
+      renderer: unmasked(gl, gl.RENDERER, 'UNMASKED_RENDERER_WEBGL'),
+      glVersion: String(gl.getParameter(gl.VERSION) ?? '—'),
+      shadingLanguage: String(gl.getParameter(gl.SHADING_LANGUAGE_VERSION) ?? '—'),
+      maxTextureSize: Number(gl.getParameter(gl.MAX_TEXTURE_SIZE) ?? 0),
+      maxViewport: viewport ? `${viewport[0]}×${viewport[1]}` : '—',
+      maxRenderBufferSize: Number(gl.getParameter(gl.MAX_RENDERBUFFER_SIZE) ?? 0),
+      antialias: attributes?.antialias === true,
+      failIfMajorPerformanceCaveat: attributes?.failIfMajorPerformanceCaveat === true,
+    };
+    // Release the probe context immediately — browsers cap live WebGL contexts and
+    // the game canvas needs one of them.
+    gl.getExtension('WEBGL_lose_context')?.loseContext();
+    return info;
+  } catch {
+    return null;
+  }
+};
+
+export { probeWebgl };

--- a/apps/web/src/lib/diagnostics/types.ts
+++ b/apps/web/src/lib/diagnostics/types.ts
@@ -1,0 +1,70 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * What the renderer itself can see: the graphics stack WebGL exposes, the audio
+ * device the mixer will land on, the display the window currently sits on, and the
+ * input devices attached right now. Available on every host, including the web and
+ * mobile builds where there is no main process to ask.
+ */
+
+interface WebglDiagnostics {
+  version: 1 | 2;
+  vendor: string;
+  renderer: string;
+  glVersion: string;
+  shadingLanguage: string;
+  maxTextureSize: number;
+  maxViewport: string;
+  maxRenderBufferSize: number;
+  antialias: boolean;
+  failIfMajorPerformanceCaveat: boolean;
+}
+
+interface AudioDiagnostics {
+  sampleRate: number;
+  baseLatencyMs: number | null;
+  outputLatencyMs: number | null;
+  maxChannels: number;
+  state: string;
+}
+
+interface DisplayEnvironment {
+  screen: { width: number; height: number; availWidth: number; availHeight: number };
+  nativeScreen: { width: number; height: number };
+  viewport: { width: number; height: number };
+  colorDepth: number;
+  pixelDepth: number;
+  devicePixelRatio: number;
+  orientation: string | null;
+  colorScheme: string;
+  colorGamut: string;
+  hdr: boolean;
+  reducedMotion: boolean;
+  refreshHz: number | null;
+}
+
+interface DeviceEnvironment {
+  logicalCores: number | null;
+  deviceMemoryGb: number | null;
+  jsHeap: { usedBytes: number; totalBytes: number; limitBytes: number } | null;
+  maxTouchPoints: number;
+  languages: string[];
+  timeZone: string;
+  online: boolean;
+  /** One entry per connected gamepad, as the Gamepad API names it. */
+  gamepads: string[];
+}
+
+interface RendererDiagnostics {
+  webgl: WebglDiagnostics | null;
+  audio: AudioDiagnostics | null;
+  display: DisplayEnvironment;
+  device: DeviceEnvironment;
+}
+
+export type {
+  WebglDiagnostics,
+  AudioDiagnostics,
+  DisplayEnvironment,
+  DeviceEnvironment,
+  RendererDiagnostics,
+};

--- a/apps/web/src/ui/domains/app/views/About/About.tsx
+++ b/apps/web/src/ui/domains/app/views/About/About.tsx
@@ -5,6 +5,7 @@ import { Text } from '../../../../design-system/primitives/Text';
 import { Image } from '../../../../design-system/primitives/Image';
 import { Button } from '../../../../design-system/primitives/Button';
 import { useAboutInfo } from './behavior/useAboutInfo';
+import { useDebugText } from './behavior/useDebugText';
 import './About.css';
 
 const copyText = async (text: string): Promise<void> => {
@@ -23,13 +24,15 @@ const copyText = async (text: string): Promise<void> => {
 /** About page content (rendered inside a FullScreenLayer by the PageRouter). */
 const About = () => {
   const { rows, buildDebugText } = useAboutInfo();
+  const { debugText } = useDebugText(buildDebugText);
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
-    await copyText(buildDebugText());
+    if (!debugText) return;
+    await copyText(debugText);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
-  }, [buildDebugText]);
+  }, [debugText]);
 
   return (
     <Box className="about">
@@ -47,8 +50,8 @@ const About = () => {
         ))}
       </Box>
 
-      <Button variant="secondary" className="about__copy" onClick={handleCopy}>
-        {copied ? '✓ Copied' : 'Copy debug info'}
+      <Button variant="secondary" className="about__copy" onClick={handleCopy} disabled={!debugText}>
+        {copied ? '✓ Copied' : debugText ? 'Copy debug info' : 'Collecting…'}
       </Button>
 
       <Text as="p" className="about__description">

--- a/apps/web/src/ui/domains/app/views/About/behavior/useAboutInfo.ts
+++ b/apps/web/src/ui/domains/app/views/About/behavior/useAboutInfo.ts
@@ -2,6 +2,8 @@
 import { useCallback } from 'react';
 import { usePlatform } from '@app/platform';
 import { useAppVersion } from '@app/hooks/useAppVersion';
+import { buildDebugText, collectRendererDiagnostics } from '@app/lib/diagnostics';
+import type { SystemDiagnostics } from '@shared/types/diagnostics';
 import type { OsKind, HostShell } from '@shared/platform';
 
 // Injected at build time (apps/web/vite.config.ts) for the Capacitor build; absent
@@ -31,22 +33,19 @@ const OS_LABEL: Record<OsKind, string> = {
 const capacitorVersion = (): string | null =>
   typeof __CAP_VERSION__ === 'string' && __CAP_VERSION__ ? __CAP_VERSION__ : null;
 
-// Best-effort GPU string via WebGL's debug-renderer extension.
-const readGpu = (): string => {
+// Host hardware only exists behind a main process; the web and mobile builds report
+// what the renderer can see on its own.
+const fetchSystem = async (): Promise<SystemDiagnostics | null> => {
   try {
-    const gl = document.createElement('canvas').getContext('webgl');
-    if (!gl) return '—';
-    const ext = gl.getExtension('WEBGL_debug_renderer_info');
-    const renderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
-    return String(renderer);
+    return (await window.api?.getSystemDiagnostics?.()) ?? null;
   } catch {
-    return '—';
+    return null;
   }
 };
 
 /** About page rows (for display) + a debug-info string builder (for the Copy button),
  *  both sourced from the platform facade rather than the user agent. */
-const useAboutInfo = (): { rows: AboutRow[]; buildDebugText: () => string } => {
+const useAboutInfo = (): { rows: AboutRow[]; buildDebugText: () => Promise<string> } => {
   const { info } = usePlatform();
   const version = useAppVersion();
 
@@ -66,20 +65,24 @@ const useAboutInfo = (): { rows: AboutRow[]; buildDebugText: () => string } => {
     { label: 'Platform', value: OS_LABEL[info.os] },
   ];
 
-  const buildDebugText = useCallback((): string => [
-    'Relic of the Past — debug info',
-    `Version: ${version || '—'}`,
-    `Runtime: ${runtime}`,
-    `Engine: ${engine}`,
-    `Platform: ${OS_LABEL[info.os]} (host: ${info.host}, os: ${info.os})`,
-    `Form factor: ${info.formFactor} · Input: ${info.input} · Dev: ${info.isDev}`,
-    `Screen: ${window.screen.width}×${window.screen.height} @ ${window.devicePixelRatio}x`,
-    `Viewport: ${window.innerWidth}×${window.innerHeight}`,
-    `GPU: ${readGpu()}`,
-    `User agent: ${navigator.userAgent}`,
-  ].join('\n'), [version, runtime, engine, info]);
+  const buildText = useCallback(async (): Promise<string> => {
+    const [system, renderer] = await Promise.all([fetchSystem(), collectRendererDiagnostics()]);
+    return buildDebugText({
+      header: [
+        'Relic of the Past — debug info',
+        `Version: ${version || '—'}`,
+        `Runtime: ${runtime}`,
+        `Engine: ${engine}`,
+        `Platform: ${OS_LABEL[info.os]} (host: ${info.host}, os: ${info.os})`,
+        `Form factor: ${info.formFactor} · Input: ${info.input} · Dev: ${info.isDev}`,
+      ],
+      system,
+      renderer,
+      userAgent: navigator.userAgent,
+    });
+  }, [version, runtime, engine, info]);
 
-  return { rows, buildDebugText };
+  return { rows, buildDebugText: buildText };
 };
 
 export { useAboutInfo };

--- a/apps/web/src/ui/domains/app/views/About/behavior/useDebugText.ts
+++ b/apps/web/src/ui/domains/app/views/About/behavior/useDebugText.ts
@@ -1,0 +1,24 @@
+/* @layer renderer-components @kind hook */
+/**
+ * Collects the debug-info text once when the page opens rather than on click. The
+ * probes are asynchronous (the frame-rate one has to watch real frames), and doing
+ * that work inside the click handler would put an await between the user's gesture
+ * and the clipboard write.
+ */
+import { useEffect, useState } from 'react';
+
+const useDebugText = (build: () => Promise<string>): { debugText: string | null } => {
+  const [debugText, setDebugText] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void build().then((text) => {
+      if (active) setDebugText(text);
+    });
+    return () => { active = false; };
+  }, [build]);
+
+  return { debugText };
+};
+
+export { useDebugText };

--- a/shared/ipc/invoke-contract.ts
+++ b/shared/ipc/invoke-contract.ts
@@ -11,6 +11,7 @@ import type { PlaySession } from '@shared/types/session';
 import type { ShadowCastingProject, ScreenShadowData } from '@shared/types/shadow-casting';
 import type { LanguagePack, LanguageSummary } from '@shared/types/language';
 import type { DataLocation, StorageSummary, FileStat } from '@shared/platform';
+import type { SystemDiagnostics } from '@shared/types/diagnostics';
 import type { SimRunConfig } from '@shared/game/simulation';
 
 type Result = { success: boolean; error?: string };
@@ -21,6 +22,9 @@ type ReviewMap = Record<string, { status: string; comment?: string }>;
 interface InvokeContract {
   // App
   'app:getUserDataPath': () => Promise<string>;
+
+  // Diagnostics — host hardware/OS readout for the About page's debug info
+  'diagnostics:getSystem': () => Promise<SystemDiagnostics>;
 
   // Storage — data location, reveal in OS file manager, per-domain usage summary
   'storage:getLocation': () => Promise<DataLocation>;

--- a/shared/ipc/maps.ts
+++ b/shared/ipc/maps.ts
@@ -12,6 +12,7 @@ import type { EventContract } from './event-contract';
 
 const INVOKE_MAP = {
   getUserDataPath: 'app:getUserDataPath',
+  getSystemDiagnostics: 'diagnostics:getSystem',
   getDataLocation: 'storage:getLocation',
   revealDataFolder: 'storage:reveal',
   revealProfileFolder: 'storage:revealProfile',

--- a/shared/types/diagnostics.ts
+++ b/shared/types/diagnostics.ts
@@ -1,0 +1,111 @@
+/* @layer shared-types @kind logic */
+/**
+ * Host hardware/OS readout behind the debug-info block. Collected in the main
+ * process because none of it is reachable from the renderer sandbox.
+ *
+ * Deliberately free of anything identifying — no host name, user name, or file
+ * path — because this text is written to be pasted into a public bug report.
+ */
+
+interface DiagnosticsRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface DisplayDiagnostics {
+  id: number;
+  label: string;
+  primary: boolean;
+  internal: boolean;
+  /** Logical (DIP) bounds in the virtual desktop, as the window manager sees them. */
+  bounds: DiagnosticsRect;
+  /** Native resolution — logical size multiplied by the scale factor. */
+  nativeSize: { width: number; height: number };
+  workArea: DiagnosticsRect;
+  scaleFactor: number;
+  rotation: number;
+  refreshHz: number | null;
+  colorDepth: number;
+  depthPerComponent: number;
+  colorSpace: string;
+  monochrome: boolean;
+  touchSupport: string;
+}
+
+interface CpuDiagnostics {
+  model: string;
+  logicalCores: number;
+  speedMhz: number;
+  arch: string;
+}
+
+interface MemoryDiagnostics {
+  totalBytes: number;
+  freeBytes: number;
+  swapTotalBytes: number | null;
+  swapFreeBytes: number | null;
+}
+
+interface GpuDevice {
+  vendorId: number;
+  deviceId: number;
+  vendor: string | null;
+  device: string | null;
+  driverVersion: string | null;
+  active: boolean;
+}
+
+interface GpuDiagnostics {
+  devices: GpuDevice[];
+  glVendor: string | null;
+  glRenderer: string | null;
+  glVersion: string | null;
+  driverVersion: string | null;
+  hardwareAccelerated: boolean;
+  /** Per-feature acceleration status ('enabled' / 'disabled_software' / …). */
+  features: Record<string, string>;
+}
+
+interface OsDiagnostics {
+  platform: string;
+  /** Human-readable OS name, e.g. the edition string on Windows. */
+  version: string;
+  release: string;
+  arch: string;
+  uptimeSeconds: number;
+  locale: string;
+  systemLocale: string;
+  preferredLanguages: string[];
+  timeZone: string;
+  onBattery: boolean;
+}
+
+interface RuntimeVersions {
+  node: string;
+  v8: string;
+  chrome: string;
+  electron: string;
+}
+
+interface SystemDiagnostics {
+  os: OsDiagnostics;
+  cpu: CpuDiagnostics;
+  memory: MemoryDiagnostics;
+  gpu: GpuDiagnostics;
+  displays: DisplayDiagnostics[];
+  versions: RuntimeVersions;
+}
+
+export type {
+  DiagnosticsRect,
+  DisplayDiagnostics,
+  CpuDiagnostics,
+  MemoryDiagnostics,
+  GpuDevice,
+  GpuDiagnostics,
+  OsDiagnostics,
+  RuntimeVersions,
+  SystemDiagnostics,
+};


### PR DESCRIPTION
The debug info the About page copies was thin: app version, the window's own screen, and the ANGLE renderer string. That leaves out most of what's actually useful when someone reports a rendering, scaling or audio problem, so this fills it in.

- A read-only `diagnostics:getSystem` channel for what the renderer sandbox can't see: OS edition, CPU, RAM and swap, and every attached monitor with its native resolution, refresh rate, scale factor and colour space (not just the one the window happens to be on).
- Per-adapter GPU detail from the main process: PCI ids, driver version, which adapter is active on a hybrid-graphics machine, and which features Chromium actually accelerated.
- Renderer-side probes for the WebGL limits, the audio device's sample rate and latency, the connected gamepads, and the measured frame cadence, which is how you'd catch a 120 Hz panel being driven at 60.
- Nothing identifying goes in the text: no host name, user name or file path, since it's written to be pasted into a public bug report.
- The copy button briefly reads `Collecting…`, because the frame-rate probe has to watch real frames and awaiting that inside the click handler would break the clipboard write.

On the web and Android builds the host sections drop out and the renderer-side ones still carry the report.

Checked by booting the built app, opening About and capturing the exact string handed to the clipboard.