### PR TITLE
Fix manual save thumbnails and dialog name input focus

### DIFF
--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -13,7 +13,7 @@ export { setMsuData, setAutoSaveConfig, setLinkSpriteData } from './lifecycle';
 export { applyPlayerSprite, clearPlayerSprite } from './player-sprite';
 export type { MsuTrackData, AutoSaveConfig } from './lifecycle';
 export { saveState, loadState, loadNamedState, loadStateRef, captureStateBuffer, loadStateFromBuffer } from './save-states';
-export { fulfillFrameCapture } from './capture-frame';
+export { captureGameFrameBlob, fulfillFrameCapture } from './capture-frame';
 export { setItemOverride, clearItemOverrides } from './randomizer';
 export { pushLiveSettings, reassertBackdropBlack, reassertVsync, reassertHudHidden, reassertPauseHidden, reassertVolumes, reassertLiveFlagsAfterLoad, reassertFeatureFlags, primeLiveSettings, LIVE_SETTINGS } from './live-settings';
 export { initMasterVolume, setMasterVolume, suspendAudio, resumeAudio } from './audio-volume';

--- a/apps/web/src/ui/design-system/composites/DialogShell/DialogShell.tsx
+++ b/apps/web/src/ui/design-system/composites/DialogShell/DialogShell.tsx
@@ -1,5 +1,5 @@
 /* @layer renderer-components @kind component */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Portal } from '../../primitives/Portal';
 import { Box } from '../../primitives/Box';
 import { WindowHeader } from '../WindowHeader';
@@ -10,15 +10,31 @@ import { type DialogShellProps } from './DialogShell.type';
 const DialogShell = (props: DialogShellProps) => {
   const { open, onClose, title, headerExtra, actions, className = '', initialFocusRef, children } = props;
 
+  // Read via a ref so the escape listener always calls the latest onClose without
+  // needing it in a dependency array — onClose is typically a fresh closure on
+  // every parent render, which would otherwise re-run the effects below on every
+  // keystroke inside the dialog.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+      if (e.key === 'Escape') { e.preventDefault(); onCloseRef.current(); }
     };
     document.addEventListener('keydown', handler);
-    initialFocusRef?.current?.focus();
     return () => document.removeEventListener('keydown', handler);
-  }, [open, onClose, initialFocusRef]);
+  }, [open]);
+
+  // Runs only when the dialog opens (not on every re-render). Skips stealing focus
+  // if a child already claimed it — e.g. a name TextInput with its own autoFocus.
+  useEffect(() => {
+    if (!open) return;
+    const active = document.activeElement;
+    if (!active || active === document.body) {
+      initialFocusRef?.current?.focus();
+    }
+  }, [open, initialFocusRef]);
 
   if (!open) return null;
 

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/home-tab-helpers.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/home-tab-helpers.ts
@@ -1,6 +1,6 @@
 /* @layer renderer-components @kind logic */
 /** Shared helpers for the Home tab: time formatting, game-ready wait, canvas screenshot. */
-import { subscribeGameState } from '../../../../../../../lib/game';
+import { subscribeGameState, captureGameFrameBlob } from '../../../../../../../lib/game';
 
 const QUICK_SAVE_SLOTS = 12;
 
@@ -37,12 +37,10 @@ const ensureGameRunning = async (isGameRunning: boolean, onStartGame: () => void
   });
 };
 
-/** Capture the live game canvas as a PNG ArrayBuffer (DOM concern — stays in the view layer). */
+/** Capture the currently-rendered game frame as a PNG ArrayBuffer, same path quick-saves use. */
 const captureCanvasScreenshot = async (): Promise<ArrayBuffer | undefined> => {
-  const canvas = document.querySelector('.game-layer__canvas') as HTMLCanvasElement | null;
-  if (!canvas) return undefined;
   try {
-    const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob((b) => resolve(b), 'image/png'));
+    const blob = await captureGameFrameBlob();
     if (blob) return await blob.arrayBuffer();
   } catch { /* ignore */ }
   return undefined;


### PR DESCRIPTION
Manual saves (Create/Overwrite in the Saves list) grabbed a screenshot by reading the raw game canvas directly and calling toBlob on it. That canvas is hidden while the game runs and its WebGL backbuffer clears right after each frame presents, so the capture usually came back blank. Quick-saves already solved this with captureGameFrameBlob, which hooks the FX render loop and grabs the frame in the same tick it's drawn. Manual saves now use that same path.

Also fixed the Create Save dialog's name input losing focus while typing. DialogShell was refocusing its confirm button in a useEffect keyed on onClose, but onClose is a fresh closure every parent render, and typing a character re-renders the parent, so focus kept jumping back to the Save button after each keystroke. The effect now reads onClose through a ref and only claims focus once on open, skipping it entirely if something (like the input's own autoFocus) already has it.

- apps/web/src/lib/game/capture-frame.ts reused via a new barrel export
- apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/home-tab-helpers.ts
- apps/web/src/ui/design-system/composites/DialogShell/DialogShell.tsx