### PR TITLE
Tag the files that slipped past the analyze harness

### DIFF
--- a/apps/web/src/ui/domains/app/views/BootProgressBar/index.ts
+++ b/apps/web/src/ui/domains/app/views/BootProgressBar/index.ts
@@ -1,1 +1,2 @@
+/* @layer renderer-other @kind barrel */
 export { BootProgressBar } from './BootProgressBar';

--- a/docs/controllers/linux-setup.md
+++ b/docs/controllers/linux-setup.md
@@ -1,3 +1,4 @@
+<!-- @layer docs @kind doc -->
 # Linux — controller setup (udev rules)
 
 On Linux, raw controller access (node-hid for HID reports, libusb for the Switch/NSO

--- a/docs/controllers/support-matrix.md
+++ b/docs/controllers/support-matrix.md
@@ -1,3 +1,4 @@
+<!-- @layer docs @kind doc -->
 # Controller support
 
 Which controllers work on each platform, over which connection, and where features are

--- a/release-notes/v0.10.0.md
+++ b/release-notes/v0.10.0.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.10.0
 
 ## New features

--- a/release-notes/v0.10.1.md
+++ b/release-notes/v0.10.1.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.10.1
 
 ## Fixes

--- a/release-notes/v0.10.2.md
+++ b/release-notes/v0.10.2.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.10.2
 
 ## Fixes

--- a/release-notes/v0.11.0.md
+++ b/release-notes/v0.11.0.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.11.0
 
 ## Features

--- a/release-notes/v0.12.0.md
+++ b/release-notes/v0.12.0.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.12.0
 
 ## Features

--- a/release-notes/v0.12.1.md
+++ b/release-notes/v0.12.1.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.12.1
 
 ## Features

--- a/release-notes/v0.13.0.md
+++ b/release-notes/v0.13.0.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.13.0
 
 ## Features

--- a/release-notes/v0.8.2.md
+++ b/release-notes/v0.8.2.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.8.2 — Pre-Public Build
 
 A modern desktop wrapper for the A Link to the Past PC port, built to make the experience accessible, polished, and ready for randomizer support.

--- a/release-notes/v0.8.3.md
+++ b/release-notes/v0.8.3.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.8.3
 
 This is the first public release for Relic to the Past with wiki, and website going live at the same time we're posting this on Reddit.

--- a/release-notes/v0.8.4.md
+++ b/release-notes/v0.8.4.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.8.4
 
 ## In-game language switching

--- a/release-notes/v0.8.5.md
+++ b/release-notes/v0.8.5.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.8.5
 
 ## Controllers

--- a/release-notes/v0.8.6.md
+++ b/release-notes/v0.8.6.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.8.6
 
 ## Fixes

--- a/release-notes/v0.9.0.md
+++ b/release-notes/v0.9.0.md
@@ -1,3 +1,4 @@
+<!-- @layer root-config @kind doc -->
 # Relic of the Past v0.9.0
 
 The app now runs on Android & fix a bunch of inherent platform/OS issues

--- a/scripts/analyze/file-tags.jsonc
+++ b/scripts/analyze/file-tags.jsonc
@@ -40,6 +40,10 @@
   "tests/fixtures/save-states/**": { "kind": "asset" },
   // Kept (permanent) app-driven specs — see tests/e2e/README.md.
   "tests/e2e/**": { "kind": "test" },
+  // …but the folder's own README is prose, not a spec. Every other README in
+  // the repo is a doc, and the rule above would otherwise size and lint this
+  // one as a test purely because of where it sits.
+  "tests/e2e/*.md": { "kind": "doc" },
 
   "shared/game/data/**":      { "kind": "data" },
   "shared/input/data/**":     { "kind": "data" },

--- a/scripts/build/linux/deb-postinst.sh
+++ b/scripts/build/linux/deb-postinst.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# @layer tooling-scripts @kind build
 # Relic of the Past — .deb post-install: install controller udev rules so node-hid
 # / libusb can open game controllers without root, then reload udev. Runs as root
 # during `dpkg -i`. Kept in sync with 99-relic-controllers.rules.

--- a/tests/asset-extraction/dialogue-text-roundtrip.test.ts
+++ b/tests/asset-extraction/dialogue-text-roundtrip.test.ts
@@ -1,3 +1,4 @@
+/* @layer tests @kind test */
 import { describe, it, expect } from 'vitest';
 import { formatDialogueText } from '@shared/asset-extraction/text/dialogue-decoder';
 import { parseDialogueText, dialogueTexts } from '@shared/asset-extraction/text/parse-dialogue-text';

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,3 +1,4 @@
+<!-- @layer tests @kind doc -->
 # Permanent app-driven tests (`*.keep.spec.ts`)
 
 Playwright specs in this project are **ephemeral by default**: they are written in


### PR DESCRIPTION
These were sitting uncommitted in my working tree and looked alarming, so here is what they actually are. `npm run analyze:tag` stamped `@layer`/`@kind` headers into nineteen files that had never had one. Rendered markdown does not change, an HTML comment is invisible.

* Nothing was ever forcing these tags. "Untagged" is a counter in the analyze report, not a gating error, so files kept landing without a header ever since the harness arrived in June. Twenty of the ninety markdown files had none, including the most recent release note, while the other seventy have carried one all along.
* Stamped: thirteen release notes, two controller docs, a barrel, the Linux packaging script, an extraction test and the e2e README.
* One real bug came out of it. `tests/e2e/**` forces `kind: test` in the manifest, and the manifest outranks a file's own header, so that folder's README was being sized and linted as though it were a Playwright spec. There is now a `tests/e2e/*.md` rule so prose next to specs reads as a doc. Worth having on its own.
* `.github/**` and `.vscode/**` stay untagged and always will, since `walk.mjs` skips every dotfolder except `.claude`. That is by design, not a gap.

`npm run ci` is clean, and the repo wide count is down to six untagged, all of them vendored or in those skipped dotfolders.
