### PR TITLE
fix(input): skip Gamepad API when a pad is already served over HID

### DIFF
--- a/apps/web/src/lib/input/function-actions.ts
+++ b/apps/web/src/lib/input/function-actions.ts
@@ -106,12 +106,13 @@ class FunctionActionEngine {
    * Fires callbacks on rising edge, fires keyUp listeners on falling edge.
    */
   checkGamepads(hidStates: Map<string, { buttons: boolean[]; axes: number[] }>, allowed: AllowedDevices, gamepadVidPid: Map<number, { vid: string; pid: string }>): void {
-    // --- Web Gamepad API controllers — only devices in the active profile's map ---
+    // --- Web Gamepad API controllers — only devices in the active profile's map,
+    // and only when not already served over HID (see polling-engine.ts computeBitmask). ---
     for (const gp of navigator.getGamepads()) {
       if (!gp || !gp.connected) continue;
       const vp = gamepadVidPid.get(gp.index);
       const key = vp ? `${vp.vid}:${vp.pid}` : null;
-      if (!key || !allowed.gamepadKeys.has(key)) continue;
+      if (!key || !allowed.gamepadKeys.has(key) || hidStates.has(key)) continue;
       // Normalize Web Gamepad buttons (objects) to booleans, then share one code path.
       this.processDeviceState(`gamepad-${gp.index}`, gp.buttons.map((b) => b.pressed), gp.axes);
     }

--- a/apps/web/src/lib/input/polling-engine.ts
+++ b/apps/web/src/lib/input/polling-engine.ts
@@ -57,12 +57,14 @@ const computeBitmask = (keyStates: Map<string, boolean>, keyboardMap: Map<string
     }
   }
 
-  // Web Gamepad API (XInput controllers like Xbox) — only devices in the profile's map
+  // Web Gamepad API (XInput controllers like Xbox) — only devices in the profile's map,
+  // and only when not already served over HID (some HID pads can surface on both buses;
+  // reading both would apply the HID-indexed maps to two differently-laid-out sources).
   for (const gp of navigator.getGamepads()) {
     if (!gp || !gp.connected) continue;
     const vp = gamepadVidPid.get(gp.index);
     const key = vp ? `${vp.vid}:${vp.pid}` : null;
-    if (!key || !allowed.gamepadKeys.has(key)) continue;
+    if (!key || !allowed.gamepadKeys.has(key) || hidStates.has(key)) continue;
     mask = applyDeviceState(mask, gp.buttons.map(b => b.pressed), gp.axes, gamepadButtonMap, gamepadAxisMap);
   }
 


### PR DESCRIPTION
## Summary
- Nintendo Switch-family HID pads (SPC2, GameCube Wireless) can also surface through `navigator.getGamepads()` once Windows' GameInput layer has registered them, which can happen after another DirectInput/GameInput app touches the device
- `computeBitmask` and `checkGamepads` had no guard against this, so the same physical pad got read twice per frame through two incompatible layouts: HID-indexed maps applied to Chromium's own differently-laid-out Gamepad object, on top of the correct HID reading
- That caused glitchy analog stick movement and misfired digital bindings (D-pad Down opening the pause menu)
- `haptic-bridge.ts`, `raw-input-dispatcher.ts`, and `snapshotGamepads()` already guard against this double-serving; this adds the same skip to the two paths that drive real gameplay input

## Test plan
- [x] Reproduced with a Switch Pro Controller 2 and a GameCube Wireless controller after both had been used by another app; confirmed the fix resolves it
- [x] `npx tsc --noEmit` clean