### PR TITLE
fix(widgets): scrollable recommendations list + classification tabs

### DIFF
--- a/apps/web/src/ui/design-system/primitives/TabBar/TabBar.css
+++ b/apps/web/src/ui/design-system/primitives/TabBar/TabBar.css
@@ -42,3 +42,12 @@
 .tab-bar__label {
   line-height: var(--leading-tight);
 }
+
+.tab-bar__badge {
+  padding: 0 var(--space-2xs);
+  border-radius: var(--radius-sm);
+  background: var(--c-hover);
+  color: var(--c-text-dim);
+  font-size: var(--text-xs);
+  line-height: var(--leading-tight);
+}

--- a/apps/web/src/ui/design-system/primitives/TabBar/TabBar.tsx
+++ b/apps/web/src/ui/design-system/primitives/TabBar/TabBar.tsx
@@ -21,6 +21,7 @@ const TabBar = (props: TabBarProps) => {
         >
           {tab.icon && <span className="tab-bar__icon">{tab.icon}</span>}
           {!iconOnly && <span className="tab-bar__label">{tab.label}</span>}
+          {tab.badge != null && <span className="tab-bar__badge">{tab.badge}</span>}
         </button>
       ))}
     </nav>

--- a/apps/web/src/ui/design-system/primitives/TabBar/TabBar.type.ts
+++ b/apps/web/src/ui/design-system/primitives/TabBar/TabBar.type.ts
@@ -3,6 +3,8 @@
   id: string;
   label: string;
   icon?: string;
+  /** A count shown beside the label — omit for a tab with nothing to tally. */
+  badge?: string | number;
 }
 
 interface TabBarProps {

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/LiveDataInspector.css
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/LiveDataInspector.css
@@ -1,5 +1,15 @@
 /* @layer renderer-widgets @kind style */
 
+/* The recommendation list and the record region below each own their own
+   ScrollArea, so in normal use neither needs this shell to scroll: the list is
+   capped at a share of the height and the record region takes the rest, which
+   always adds up to fit.
+   `auto` rather than `hidden` is the escape hatch for the one case that does
+   not fit: shrink the widget far enough and two tab strips plus the list header
+   alone exceed the body, and the record region's own floor below cannot yield
+   any further. Clipping there would hide the record area with no way to reach
+   it, which is the very bug this file exists to fix, arriving from the opposite
+   direction. */
 .live-data-inspector {
   display: flex;
   flex-direction: column;
@@ -14,8 +24,12 @@
   flex-direction: column;
   gap: var(--space-sm);
   flex: 1;
-  min-height: 0;
-  overflow-y: auto;
+
+  /* A real floor, not 0 — enough for one record card's header plus a line or
+     two of fields, so a long recommendation list above can shrink this region
+     but never past the point where it disappears entirely. No token in
+     size.css covers a content-area floor like this yet, hence the rem value. */
+  min-height: 6rem;
 }
 
 /* Eleven tabs never fit the widget's docked width — scroll rather than clip. */

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/behavior/use-recommendation-filter.ts
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/behavior/use-recommendation-filter.ts
@@ -1,0 +1,71 @@
+/* @layer renderer-widgets @kind hook */
+/**
+ * Classifies open findings by what accepting them would DO to the dataset —
+ * change a property, add a missing record, drop an extra one — which is the
+ * axis a reviewer triages on, not the confidence badge already on each card.
+ *
+ * The active filter is derived, not stored-and-synced: if the screen changes
+ * under the player and the selected tab's own count drops to zero, the very
+ * next render already reports "all" rather than needing an effect to notice
+ * the tab vanished and correct the state after the fact.
+ */
+import { useMemo, useState } from 'react';
+import type { Recommendation, RecommendationAction } from '@shared/game/recommendations';
+
+type RecommendationFilter = 'all' | RecommendationAction;
+
+interface FilterTab {
+  id: RecommendationFilter;
+  label: string;
+  count: number;
+}
+
+interface UseRecommendationFilterResult {
+  tabs: readonly FilterTab[];
+  filter: RecommendationFilter;
+  setFilter: (filter: RecommendationFilter) => void;
+  filtered: readonly Recommendation[];
+}
+
+/** Order matters: this is the tab strip's left-to-right order too. */
+const FILTER_ORDER: readonly RecommendationFilter[] = ['all', 'update', 'create', 'delete'];
+
+const FILTER_LABELS: Record<RecommendationFilter, string> = {
+  all: 'All', update: 'Changed', create: 'Missing', delete: 'Extra',
+};
+
+const countFor = (entries: readonly Recommendation[], filter: RecommendationFilter): number =>
+  filter === 'all' ? entries.length : entries.filter(entry => entry.action === filter).length;
+
+/** The tab strip's data, pulled out of the hook so it is directly testable, the same split `use-current-records.ts` uses for `recordsFor`. */
+const buildFilterTabs = (entries: readonly Recommendation[]): readonly FilterTab[] =>
+  FILTER_ORDER
+    .map(id => ({ id, label: FILTER_LABELS[id], count: countFor(entries, id) }))
+    // A tab that could never show anything is noise; "all" always stays so
+    // there is never zero tabs to look at.
+    .filter(tab => tab.id === 'all' || tab.count > 0);
+
+const filterEntries = (
+  entries: readonly Recommendation[],
+  filter: RecommendationFilter,
+): readonly Recommendation[] =>
+  filter === 'all' ? entries : entries.filter(entry => entry.action === filter);
+
+const useRecommendationFilter = (entries: readonly Recommendation[]): UseRecommendationFilterResult => {
+  const [filter, setFilter] = useState<RecommendationFilter>('all');
+
+  const tabs = useMemo(() => buildFilterTabs(entries), [entries]);
+
+  const activeCount = tabs.find(tab => tab.id === filter)?.count ?? 0;
+  const effectiveFilter: RecommendationFilter = activeCount > 0 ? filter : 'all';
+
+  const filtered = useMemo(
+    () => filterEntries(entries, effectiveFilter),
+    [entries, effectiveFilter],
+  );
+
+  return { tabs, filter: effectiveFilter, setFilter, filtered };
+};
+
+export { buildFilterTabs, filterEntries, useRecommendationFilter };
+export type { FilterTab, RecommendationFilter, UseRecommendationFilterResult };

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationList.css
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationList.css
@@ -1,9 +1,16 @@
 /* @layer renderer-widgets @kind style */
 
+/* Bounded to under half the widget body: long enough to be useful, short
+   enough that the record region below it (LiveDataInspector.css) always keeps
+   its own floor. `flex-shrink` (the default, 1) lets it go smaller still when
+   the widget itself is short — the cap only ever stops it from GROWING past
+   this share. */
 .live-rec-list {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
+  max-height: 45%;
+  min-height: 0;
 }
 
 .live-rec-list__header {
@@ -12,6 +19,7 @@
   justify-content: space-between;
   width: 100%;
   padding: var(--space-xs) 0;
+  flex-shrink: 0;
 }
 
 .live-rec-list__count {
@@ -23,8 +31,18 @@
   color: var(--c-text-muted);
 }
 
+/* Pinned above the scrolling list, so it stays put while the cards move. */
+.live-rec-list__batch {
+  flex-shrink: 0;
+}
+
+/* The scrolling itself lives on ScrollArea; this class only carries the
+   layout (fill the space left under the header/tabs/batch button, shrink to
+   fit) and the card gap. */
 .live-rec-list__body {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
+  flex: 1;
+  min-height: 0;
 }

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationList.tsx
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationList.tsx
@@ -1,15 +1,23 @@
 /* @layer renderer-widgets @kind component */
 /**
- * The findings for the current screen: a collapsible count header, one card
- * per open finding (certain-first, oldest-first — the same pass order the
- * Data Inspector's own review works through), and a batch-accept button that
- * only appears once there is something safe to batch.
+ * The findings for the current screen: a collapsible count header, a tab
+ * strip classifying them by what accepting one would DO (change, add, drop),
+ * one card per open finding within the selected tab (certain-first,
+ * oldest-first — the same pass order the Data Inspector's own review works
+ * through), and a batch-accept button that only appears once there is
+ * something safe to batch.
+ *
+ * The card list is its own bounded, scrolling region (see RecommendationList.css)
+ * so a long finding list can never squeeze the record region below it down to
+ * nothing — the bug this replaced.
  */
 import { useState } from 'react';
-import { Box, Button, Text } from '@ds/primitives';
+import { Box, Button, ScrollArea, Text } from '@ds/primitives';
 import { certainOnly } from '@app/ui/domains/app/views/DataInspector/behavior/recommendations/accept-all-certain';
 import { acceptAllCertainHere } from '../behavior/accept-all-certain-here';
+import { useRecommendationFilter } from '../behavior/use-recommendation-filter';
 import { RecommendationCard } from './RecommendationCard';
+import { RecommendationTabs } from './RecommendationTabs';
 import type { Recommendation } from '@shared/game/recommendations';
 import './RecommendationList.css';
 
@@ -23,13 +31,16 @@ const RecommendationList = (props: RecommendationListProps) => {
   const { entries } = props;
   const [collapsed, setCollapsed] = useState(false);
   const [busy, setBusy] = useState(false);
-  const certainCount = certainOnly(entries).length;
+  const { tabs, filter, setFilter, filtered } = useRecommendationFilter(entries);
+  const certainCount = certainOnly(filtered).length;
 
   if (entries.length === 0) return null;
 
+  // Operates on `filtered`, not `entries` — a hidden tab must never let a
+  // reviewer batch-accept a finding they cannot currently see.
   const acceptAll = async (): Promise<void> => {
     setBusy(true);
-    try { await acceptAllCertainHere(entries); } finally { setBusy(false); }
+    try { await acceptAllCertainHere(filtered); } finally { setBusy(false); }
   };
 
   return (
@@ -39,14 +50,26 @@ const RecommendationList = (props: RecommendationListProps) => {
         <Text className="live-rec-list__chevron">{collapsed ? '▸' : '▾'}</Text>
       </Button>
       {!collapsed && (
-        <Box className="live-rec-list__body">
+        <>
+          <RecommendationTabs tabs={tabs} selected={filter} onSelect={setFilter} />
+          {/* Outside the scrolling list on purpose: the whole point of the batch
+              is a long list, and a button that scrolls away with the cards it
+              acts on is unreachable exactly when it is most useful. */}
           {certainCount >= MIN_BATCH && (
-            <Button variant="secondary" size="sm" disabled={busy} onClick={() => void acceptAll()}>
-              {`Accept all certain (${certainCount})`}
+            <Button
+              variant="secondary"
+              size="sm"
+              className="live-rec-list__batch"
+              disabled={busy}
+              onClick={() => void acceptAll()}
+            >
+              {`Accept all certain in view (${certainCount})`}
             </Button>
           )}
-          {entries.map(entry => <RecommendationCard key={entry.id} entry={entry} />)}
-        </Box>
+          <ScrollArea className="live-rec-list__body">
+            {filtered.map(entry => <RecommendationCard key={entry.id} entry={entry} />)}
+          </ScrollArea>
+        </>
       )}
     </Box>
   );

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationTabs.tsx
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationTabs.tsx
@@ -1,0 +1,31 @@
+/* @layer renderer-widgets @kind component */
+/**
+ * The filter strip above the finding list — which action a tab stands for is
+ * `useRecommendationFilter`'s concern; this only turns that into `TabBar`
+ * tabs, badge-per-count, the same primitive `CollectionTabs` already uses
+ * below for the record collections.
+ */
+import { TabBar } from '@ds/primitives';
+import type { FilterTab, RecommendationFilter } from '../behavior/use-recommendation-filter';
+
+interface RecommendationTabsProps {
+  tabs: readonly FilterTab[];
+  selected: RecommendationFilter;
+  onSelect: (filter: RecommendationFilter) => void;
+}
+
+const RecommendationTabs = (props: RecommendationTabsProps) => {
+  const { tabs, selected, onSelect } = props;
+  const items = tabs.map(tab => ({ id: tab.id, label: tab.label, badge: tab.count }));
+
+  return (
+    <TabBar
+      tabs={items}
+      activeTab={selected}
+      onTabChange={(id) => onSelect(id as RecommendationFilter)}
+    />
+  );
+};
+
+export { RecommendationTabs };
+export type { RecommendationTabsProps };


### PR DESCRIPTION
The Live Data Inspector's recommendation list had no height cap, so a long list on a busy screen squeezed the record cards below it down to zero height, hiding them completely with the tabs still visible.

- Bounds the recommendations region and gives it its own scroll area; the record region keeps a hard minimum height so it can never disappear.
- Adds classification tabs over the findings (All / Changed / Missing / Extra) with per-tab counts, hiding empty tabs.
- Batch accept now operates on the currently filtered set and says so in its own label, so a hidden finding can never get swept into a batch accept.
- `TabItem` gained an optional badge, additive, so the existing collection tabs are unaffected.

Stacked on #100 (uses `Recommendation`/`RecordCard` from it). `npx tsc --noEmit` clean, `eslint . --max-warnings=0` clean, full suite 161 files / 1670 tests + 2 todo, all passing, verified on this branch.