### PR TITLE
fix(electron): reassert background window on focus + robust TS preset loader

### DIFF
--- a/apps/desktop/electron/window/create-window.ts
+++ b/apps/desktop/electron/window/create-window.ts
@@ -136,6 +136,14 @@ const createWindow = (): BrowserWindow => {
     // Re-assert the background position once the first paint is ready (showing the
     // painted frame can otherwise bounce the window back to the top of the z-order).
     mainWindow.once('ready-to-show', () => { if (mainWindow) sendWindowToBack(mainWindow); });
+    // A one-time launch setting isn't enough: focusing a real DOM element (a button
+    // click, a text input) can make Chromium activate the HOSTING native window as a
+    // side effect, on Windows, regardless of showInactive() at launch — this is how a
+    // Playwright-driven click/keypress can steal focus well after a clean no-focus
+    // boot. Rather than enumerate every path that can cause that, treat "focused" as
+    // never a valid state for this window for the rest of its life and immediately
+    // reverse it every time it happens.
+    mainWindow.on('focus', () => { if (mainWindow) showInBackground(mainWindow); });
   }
 
   // Let F1-F12 (and Tab) pass through to the renderer instead of being

--- a/scripts/parallel/provision-profile.mjs
+++ b/scripts/parallel/provision-profile.mjs
@@ -10,11 +10,26 @@
  * key events at all, arrow keys included.
  *
  * The mappings come from the real preset rather than a copy, so a change there reaches
- * agent profiles too. Node runs the TypeScript directly by stripping the types.
+ * agent profiles too. A bare `import()` of the `.ts` file relies on Node's
+ * detect-and-reparse fallback for an ambiguous extension (no "type": "module" at the
+ * repo root) — reliable from a plain `node` invocation, but NOT from inside a test
+ * runner that registers its own module hooks (Playwright's `.ts` transform swallows
+ * it: "Unexpected token 'export'"). Reading the source and stripping its types
+ * ourselves, then importing the plain-JS result from a data: URL, sidesteps whichever
+ * loader is active — keyboard.ts carries only `import type`, which strips to nothing,
+ * so there is no relative import left to resolve.
  */
 import { mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync, cpSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { stripTypeScriptTypes } from 'node:module';
 import { gameDataPath } from './paths.mjs';
+
+const importStrippedTs = async (relativePath) => {
+  const path = join(dirname(fileURLToPath(import.meta.url)), relativePath);
+  const stripped = stripTypeScriptTypes(readFileSync(path, 'utf8'), { mode: 'strip' });
+  return import(`data:text/javascript,${encodeURIComponent(stripped)}`);
+};
 
 const ROM_EXTENSIONS = ['.sfc', '.smc'];
 
@@ -78,7 +93,7 @@ const copyManualSaves = (sourceId, name) => {
 };
 
 const keyboardInputProfile = async (now) => {
-  const { KEYBOARD_DEFAULT } = await import('../../shared/input/data/presets/keyboard.ts');
+  const { KEYBOARD_DEFAULT } = await importStrippedTs('../../shared/input/data/presets/keyboard.ts');
   return {
     id: KEYBOARD_DEFAULT.id,
     name: KEYBOARD_DEFAULT.name,


### PR DESCRIPTION
Two small, unrelated fixes that were already sitting in the working tree before this session's recommendation-engine work started. Splitting them out here so they don't get bundled with unrelated changes; I didn't author either of them this session, so treat this description as a summary of the diff rather than the original author's own account.

- `create-window.ts`: reasserts the background window position on any `focus` event. A one-time no-focus launch flag isn't enough, since a Playwright-driven click or keypress can activate the hosting native window on Windows regardless, well after a clean no-focus boot.
- `provision-profile.mjs`: reads and strips `keyboard.ts`'s TypeScript itself rather than a bare dynamic `import()`, since a test runner with its own module hooks (Playwright's `.ts` transform) doesn't fall back the way a plain `node` invocation does.

`npx tsc --noEmit` clean, `eslint . --max-warnings=0` clean, verified on this branch.