### PR TITLE
fix(input): register 8BitDo Ultimate 2 XInput PID

### DIFF
--- a/shared/input/data/presets/8bitdo.ts
+++ b/shared/input/data/presets/8bitdo.ts
@@ -1,6 +1,6 @@
 /* @layer shared-input @kind data */
 /**
- * 8BitDo Controllers (Pro 2, SN30 Pro, SN30 Pro+)
+ * 8BitDo Controllers (Pro 2, SN30 Pro, SN30 Pro+, Ultimate 2 in XInput mode)
  * VID: 0x2DC8  PIDs: various
  *
  * Uses Web Gamepad API via Chromium's HID remapping in XInput mode.
@@ -74,7 +74,7 @@ const AXES: ControllerAxis[] = [
   { id: 'rightTrigger', label: 'ZR Trigger',     category: 'trigger' },
 ];
 
-const BITDO_PIDS = ['6003', '6002', '6001', '6100'];
+const BITDO_PIDS = ['6003', '6002', '6001', '6100', '310b'];
 
 class EightBitDoController extends BaseController {
   readonly id = '8bitdo';


### PR DESCRIPTION
Closes #106

Adds 2dc8:310b (8BitDo Ultimate 2 in XInput mode) to the registered 8BitDo PIDs. It was falling through to the generic fallback profile since the PID was never registered, so the pad never actually got the 8BitDo mapping.

## Test plan
- Verified against calibration JSON pulled from the reporting user (real button/trigger byte data, matches the standard Gamepad API layout already used by this preset)