### PR TITLE
fix(input): NSO SNES A/Y swap and d-pad hat masking

### DIFF
--- a/shared/input/data/presets/nso-snes.ts
+++ b/shared/input/data/presets/nso-snes.ts
@@ -90,7 +90,11 @@ class NsoSnesController extends BaseController {
 
     const b0 = data.getUint8(0); // raw byte1: face + shoulders
     const b1 = data.getUint8(1); // raw byte2: Minus / Plus
-    const hat = data.getUint8(2); // raw byte3: d-pad hat (0=Up … 7=Up-Left, 8=neutral)
+    // Masked to the low nibble: the report can set a high-nibble bit while a
+    // face button is held, which pushes the raw value past 7 and fails every
+    // hat comparison below — read unmasked, the player can't move while
+    // holding a button (issue #3).
+    const hat = data.getUint8(2) & 0x0F; // raw byte3 low nibble: d-pad hat (0=Up … 7=Up-Left, 8=neutral)
 
     const dUp = hat === 0 || hat === 1 || hat === 7;
     const dRight = hat === 1 || hat === 2 || hat === 3;
@@ -99,8 +103,8 @@ class NsoSnesController extends BaseController {
 
     const buttons: boolean[] = [
       !!(b0 & 0x01),  //  0: B
-      !!(b0 & 0x02),  //  1: A
-      !!(b0 & 0x04),  //  2: Y
+      !!(b0 & 0x04),  //  1: A  (was 0x02 — confirmed reversed with Y against real hardware, issue #3)
+      !!(b0 & 0x02),  //  2: Y  (was 0x04 — see above)
       !!(b0 & 0x08),  //  3: X
       !!(b0 & 0x10),  //  4: L
       !!(b0 & 0x20),  //  5: R


### PR DESCRIPTION
Closes the loose ends from #3 — both confirmed against real hardware there, but neither actually made it to master.

**A/Y swap.** Directly observed reversed in gameplay by the reporter and confirmed with them: B, X, L, R, ZL, ZR, Select and Start were all separately confirmed correct, so only these two move — swapped which raw bit feeds which array slot rather than guessing at some external HID spec.

**D-pad hat masking.** Read unmasked, a set high-nibble bit (seen while a face button is held) pushes the value past 7 and fails every hat comparison, so directions read as neutral. This was suspected as the cause of the movement freeze also reported in #3, but never confirmed — that freeze turned out to be unrelated (rumble sent to a controller with no vibration support, already fixed in 8023c030 / shipped in v0.8.5). The mask is a pure narrowing of what the hat value can match, so it can't regress anything that already works; kept because it's a real, if unconfirmed, latent bug.

Why these were still missing: the initial PR for #3 merged before either fix was written. The masking fix was pushed to the same branch afterward, but since that PR was already closed, it never got a second merge. The A/Y fix was promised in the same conversation but never actually committed anywhere.