### PR TITLE
docs(release): write v0.14.0 release notes

### DIFF
--- a/release-notes/v0.14.0.md
+++ b/release-notes/v0.14.0.md
@@ -1,0 +1,33 @@
+<!-- @layer root-config @kind doc -->
+# Relic of the Past v0.14.0
+
+Mostly a controllers and navigation-widget release, plus a couple of things that make the app easier to live with day to day.
+
+## Navigation widget
+
+- Auto mode no longer corrupts the room you're standing in — it used to be able to strand you inside a doorway, or leave an invisible wall over a switch after lifting the pot sitting on it.
+- Fixed the reachability overlay reading a tile wrong when the floor above or below it didn't match — a walkway with open air underneath (or the reverse) used to falsely show as walkable, or not show as walkable when it actually was.
+- Diagonal cliff jumps are rebuilt to match the game's own logic. Some directions never worked at all, others jumped along the cliff face instead of across it, and a whole diagonal cliff used to draw one jump arrow instead of one per tile.
+- The tile info popup now shows separate, accurate info for behavior, appearance, room type, collision, and any lock/switch on that tile, instead of one blended description that was sometimes flat out wrong — a locked door could read as a bombable wall.
+- Reachability dots now show a colored ring for which floor (ground or upper) they were reached on, and the legend is smaller and collapsible so it doesn't eat the screen.
+- Multi-screen areas (like the castle exterior) no longer miscount, and a route can no longer sneak through a wall gap it shouldn't be able to cross.
+
+## Controllers
+
+- Fixed glitchy stick movement and misfired D-pad presses (like the D-pad opening the pause menu on its own) when a supported pad was also showing up through the browser's generic gamepad layer on top of its proper reading.
+- Nintendo SNES Controller (NSO): fixed A and Y being swapped, and a rare freeze that could happen while holding a button down.
+- Added support for the 8BitDo Ultimate 2 (XInput mode).
+
+## Around the app
+
+- New search — the magnifying glass icon in the title bar, or Ctrl+K — jumps straight to any screen, setting, or tab, and can flip a toggle right from the search results.
+- New in-app bug reporting form, also in the title bar. It fills in your system info automatically and files a GitHub issue for you, no account needed.
+
+## Fixes
+
+- Manual save thumbnails were sometimes blank. They're captured the same reliable way quick-saves already were.
+- The Create Save dialog's name field no longer loses focus while you're typing.
+
+## Under the hood
+
+Ongoing internal work on the data layer and the tools I use to build the upcoming randomizer. Nothing player-visible yet, but a lot of it landed this cycle.

--- a/release-notes/v0.14.0.md
+++ b/release-notes/v0.14.0.md
@@ -1,7 +1,7 @@
 <!-- @layer root-config @kind doc -->
 # Relic of the Past v0.14.0
 
-Mostly a controllers and navigation-widget release, plus a couple of things that make the app easier to live with day to day.
+Mostly a controllers and navigation-widget release, plus a couple of things that make the app itself nicer to use.
 
 ## Navigation widget
 


### PR DESCRIPTION
Prep for the v0.14.0 release. Triaged everything merged since v0.13.0 (16 PRs) — most of the recent batch is pre-release internal tooling for the upcoming randomizer/data-editor work, kept out per how past notes handle unreleased groundwork. What's genuinely player-visible is in the notes.