### PR TITLE
Block commits that leave ai-config or vault work behind

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -3,13 +3,19 @@
 # references unless you acknowledge with [allow-copyright] in the message.
 # CI re-checks regardless, so this is your personal heads-up, not the hard wall.
 
-if grep -qi '\[allow-copyright\]' "$1"; then
-  exit 0
+if ! grep -qi '\[allow-copyright\]' "$1"; then
+  if command -v node >/dev/null 2>&1; then
+    node scripts/copyright-gate/scan.mjs --staged || exit 1
+  else
+    echo "copyright-gate: node not found — skipping local check (CI will enforce)."
+  fi
 fi
 
-if ! command -v node >/dev/null 2>&1; then
-  echo "copyright-gate: node not found — skipping local check (CI will enforce)."
-  exit 0
+# ai-config / vault drift gate (local-only — .claude/ and .vault/ are
+# gitignored, so nothing else ever re-checks this). Blocks a commit that
+# would leave local-only work behind, unless acknowledged with [sync-ack].
+if ! grep -qi '\[sync-ack\]' "$1"; then
+  if command -v node >/dev/null 2>&1; then
+    node scripts/hooks/sync-check/index.mjs || exit 1
+  fi
 fi
-
-node scripts/copyright-gate/scan.mjs --staged

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prepare": "git config core.hooksPath .githooks || true",
     "lint": "tsc --noEmit && eslint .",
     "gate": "node scripts/copyright-gate/scan.mjs --staged",
+    "sync:check": "node scripts/hooks/sync-check/index.mjs",
     "ci": "npm run lint && node scripts/analyze/analyze.mjs --ci",
     "analyze": "node scripts/analyze/analyze.mjs --json",
     "analyze:diff": "node scripts/analyze/analyze.mjs --diff",

--- a/scripts/hooks/sync-check/ai-config-check.mjs
+++ b/scripts/hooks/sync-check/ai-config-check.mjs
@@ -1,0 +1,28 @@
+/* @layer tooling-scripts @kind logic */
+/**
+ * Read-only: does .claude/ (or CLAUDE.md, tools, etc.) differ from what
+ * ai-config last rendered? .ai-config.json already records every rendered
+ * file's hash, so this is a local hash compare — no clone, no network.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const MANIFEST = join(ROOT, '.ai-config.json');
+
+const sha256 = (path) => createHash('sha256').update(readFileSync(path)).digest('hex');
+
+/** @returns {{ status: 'unmanaged'|'clean'|'drift', edits: string[] }} */
+const checkAiConfig = () => {
+  if (!existsSync(MANIFEST)) return { status: 'unmanaged', edits: [] };
+
+  const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));
+  const edits = manifest.files
+    .filter((f) => !existsSync(join(ROOT, f.path)) || sha256(join(ROOT, f.path)) !== f.sha256)
+    .map((f) => f.path);
+
+  return { status: edits.length ? 'drift' : 'clean', edits };
+};
+
+export { checkAiConfig };

--- a/scripts/hooks/sync-check/index.mjs
+++ b/scripts/hooks/sync-check/index.mjs
@@ -1,0 +1,24 @@
+/* @layer tooling-scripts @kind logic */
+/**
+ * Local-only gate wired into .githooks/commit-msg. Checks whether either
+ * gitignored mirror — .claude/ (ai-config) or .vault/ (rotp-vault) — is
+ * currently carrying local-only work that would be silently lost: a hand-edit
+ * to a rendered ai-config file (overwritten by the next bootstrap render), or
+ * an uncommitted change inside .vault (never sent upstream via vault:push).
+ *
+ * Read-only and offline: no clone, no fetch, no network call at all — so it
+ * works identically with or without access to either private repo, and
+ * degrades to "nothing to report" the moment either mirror isn't set up.
+ * Exits 1 (blocking the commit) only when real local-only work is found;
+ * [sync-ack] in the commit message bypasses this entire check.
+ */
+import { checkAiConfig } from './ai-config-check.mjs';
+import { checkVault } from './vault-check.mjs';
+import { printReport } from './print.mjs';
+
+const ai = checkAiConfig();
+const vault = checkVault();
+const blocking = ai.status === 'drift' || vault.status === 'dirty';
+
+printReport({ ai, vault });
+process.exit(blocking ? 1 : 0);

--- a/scripts/hooks/sync-check/print.mjs
+++ b/scripts/hooks/sync-check/print.mjs
@@ -1,0 +1,32 @@
+/* @layer tooling-scripts @kind logic */
+/**
+ * One short report to stderr — silent when both mirrors are clean/unmanaged,
+ * specific about what to do when they aren't.
+ */
+const printReport = ({ ai, vault }) => {
+  const lines = [];
+
+  if (ai.status === 'drift') {
+    lines.push('ai-config: local edits differ from the last render — these live only in the');
+    lines.push('gitignored .claude/ and will be OVERWRITTEN by the next bootstrap render:');
+    ai.edits.forEach((p) => lines.push(`  ${p}`));
+    lines.push('  -> fold the edit back into the claude-config source, commit + push it there');
+  }
+
+  if (vault.status === 'dirty') {
+    lines.push('vault: .vault/ has local changes never sent to rotp-vault:');
+    vault.files.forEach((p) => lines.push(`  ${p}`));
+    lines.push('  -> npm run vault:push "<what changed>"');
+  }
+
+  if (!lines.length) return;
+
+  console.error(`\n${'-'.repeat(60)}`);
+  console.error('sync-check: local-only work found in ai-config / vault');
+  console.error('-'.repeat(60));
+  lines.forEach((l) => console.error(l));
+  console.error('Add [sync-ack] to the commit message to bypass this check.');
+  console.error(`${'-'.repeat(60)}\n`);
+};
+
+export { printReport };

--- a/scripts/hooks/sync-check/vault-check.mjs
+++ b/scripts/hooks/sync-check/vault-check.mjs
@@ -1,0 +1,24 @@
+/* @layer tooling-scripts @kind logic */
+/**
+ * Read-only: does .vault/ have local changes that were never sent upstream
+ * via `npm run vault:push`? Plain `git status --porcelain` on the vault
+ * clone — no fetch, no network.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const VAULT_DIR = join(ROOT, '.vault');
+
+/** @returns {{ status: 'unmanaged'|'clean'|'dirty', files: string[] }} */
+const checkVault = () => {
+  if (!existsSync(join(VAULT_DIR, '.git'))) return { status: 'unmanaged', files: [] };
+
+  const porcelain = execFileSync('git', ['-C', VAULT_DIR, 'status', '--porcelain'], { encoding: 'utf8' });
+  const files = porcelain.split('\n').filter(Boolean).map((l) => l.slice(3));
+
+  return { status: files.length ? 'dirty' : 'clean', files };
+};
+
+export { checkVault };


### PR DESCRIPTION
## Summary
- Extends the existing `.githooks/commit-msg` gate with a second, independent check alongside the copyright gate
- Blocks a commit when `.claude/` has local edits that differ from the last ai-config render (about to be silently overwritten by the next render), or when `.vault/` has uncommitted local changes never sent upstream via `vault:push`
- Both checks are local and offline — a manifest hash compare and `git status`, no clone or fetch — so a contributor without access to either private repo sees nothing at all
- Bypassable per-commit with `[sync-ack]` in the message, same convention as the existing `[allow-copyright]`

## Test plan
- [x] Ran the hook directly against synthetic commit messages covering all four flag combinations (plain / `[sync-ack]` / `[allow-copyright]` / both) and confirmed exit codes and independence of the two gates
- [x] Reproduced real drift (a wiped `.claude/`) and confirmed the gate correctly listed every affected file and blocked
- [x] Made a real commit on this branch with `.claude`/`.vault` restored and confirmed the hook passes silently