### PR TITLE
Approval stops being something a commit message can grant

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,21 +1,28 @@
 #!/bin/sh
-# Copyright / media gate (local). Blocks commits that add media or Nintendo
-# references unless you acknowledge with [allow-copyright] in the message.
-# CI re-checks regardless, so this is your personal heads-up, not the hard wall.
+# Two gates, and neither can be waved through from inside a commit message.
+#
+# Both used to accept a marker in the message ([allow-copyright], [sync-ack]).
+# That made them trivial to self-approve: anyone, including an agent working in
+# this repo, could type the words and the gate would stand aside. Approval is the
+# owner's to give, so it now happens somewhere a commit message cannot reach.
+#
+#   copyright / media  -> the maintainer-only 'copyright-ok' label on the PR,
+#                         which .github/workflows/copyright-gate.yml enforces
+#   ai-config drift    -> resolve it. Fold the edit into the claude-config
+#                         source, push it, re-render. There is no bypass,
+#                         because .claude/ is gitignored and nothing else will
+#                         ever notice the loss.
+#
+# An owner who genuinely needs to commit past one of these can pass --no-verify,
+# which is a deliberate act on their own machine rather than a string an
+# assistant can add to a message it wrote.
 
-if ! grep -qi '\[allow-copyright\]' "$1"; then
-  if command -v node >/dev/null 2>&1; then
-    node scripts/copyright-gate/scan.mjs --staged || exit 1
-  else
-    echo "copyright-gate: node not found — skipping local check (CI will enforce)."
-  fi
+if command -v node >/dev/null 2>&1; then
+  node scripts/copyright-gate/scan.mjs --staged || exit 1
+else
+  echo "copyright-gate: node not found — skipping local check (CI enforces it)."
 fi
 
-# ai-config / vault drift gate (local-only — .claude/ and .vault/ are
-# gitignored, so nothing else ever re-checks this). Blocks a commit that
-# would leave local-only work behind, unless acknowledged with [sync-ack].
-if ! grep -qi '\[sync-ack\]' "$1"; then
-  if command -v node >/dev/null 2>&1; then
-    node scripts/hooks/sync-check/index.mjs || exit 1
-  fi
+if command -v node >/dev/null 2>&1; then
+  node scripts/hooks/sync-check/index.mjs || exit 1
 fi

--- a/.github/workflows/copyright-gate.yml
+++ b/.github/workflows/copyright-gate.yml
@@ -39,3 +39,35 @@ jobs:
           fi
           echo "Scanning range: $RANGE"
           node scripts/copyright-gate/scan.mjs --range "$RANGE"
+
+  # Guard the guards. The gates above are only worth anything if editing them is
+  # visible: without this, disabling a check and committing the change in the same
+  # pull request passes silently, because the weakened gate is the one that runs.
+  # Touching any of these paths now requires the maintainer-only 'gate-change-ok'
+  # label, which is a decision only the repository owner can make.
+  gate-integrity:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Refuse unreviewed changes to the gates
+        env:
+          APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'gate-change-ok') && '1' || '0' }}
+        run: |
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            -- .githooks scripts/hooks scripts/copyright-gate .github/workflows/copyright-gate.yml)
+          if [ -z "$CHANGED" ]; then
+            echo "No gate files touched."
+            exit 0
+          fi
+          echo "This pull request changes the gates:"
+          echo "$CHANGED" | sed 's/^/  /'
+          if [ "$APPROVED" = "1" ]; then
+            echo "Owner approved with the 'gate-change-ok' label."
+            exit 0
+          fi
+          echo "::error::Changing the gates needs the maintainer-only 'gate-change-ok' label."
+          exit 1

--- a/scripts/copyright-gate/patterns.mjs
+++ b/scripts/copyright-gate/patterns.mjs
@@ -40,7 +40,6 @@ const TEXT_SKIP_EXACT = new Set([
 const TEXT_RULE_BLOCKS = true;
 
 // Owner-approval signals.
-const ALLOW_MARKER = '[allow-copyright]'; // in a commit message
 const PR_LABEL = 'copyright-ok'; // on a pull request (maintainer-only)
 
 export {
@@ -49,6 +48,5 @@ export {
   TEXT_SKIP_PREFIXES,
   TEXT_SKIP_EXACT,
   TEXT_RULE_BLOCKS,
-  ALLOW_MARKER,
   PR_LABEL,
 };

--- a/scripts/copyright-gate/rules.mjs
+++ b/scripts/copyright-gate/rules.mjs
@@ -21,7 +21,7 @@ const mediaRule = (changes) =>
       rule: 'media',
       severity: 'block',
       file,
-      hint: 'media file (image/audio/video/font/rom) — add [allow-copyright] if intentional',
+      hint: "media file (image/audio/video/font/rom) — needs the 'copyright-ok' label",
     }));
 
 // Nintendo / ALttP references introduced in added text lines.
@@ -37,7 +37,7 @@ const trademarkRule = (changes) =>
           file,
           line: line.n,
           match: line.text.match(TRADEMARK_RE)[0],
-          hint: 'Nintendo reference in added line — verify, then [allow-copyright] or reword',
+          hint: "Nintendo reference in added line — reword it, or label the PR 'copyright-ok'",
         })));
 
 const RULES = [mediaRule, trademarkRule];

--- a/scripts/copyright-gate/scan.mjs
+++ b/scripts/copyright-gate/scan.mjs
@@ -6,12 +6,15 @@
  *   node scan.mjs --range <base>...<head>  CI: scans a diff range
  *
  * Exits 1 when blocking findings exist and the change is not owner-approved.
- * Approval = `[allow-copyright]` in a commit message (range mode) OR the
- * COPYRIGHT_APPROVED=1 env var (CI sets it when the PR has the owner label).
+ *
+ * Approval is COPYRIGHT_APPROVED=1, which CI sets only when the PR carries the
+ * maintainer-only 'copyright-ok' label. A commit message deliberately cannot grant
+ * it: a marker in the message is written by whoever writes the commit, which makes
+ * it self-approval rather than the owner's decision.
  */
 import { execSync } from 'child_process';
 import { RULES } from './rules.mjs';
-import { TEXT_RULE_BLOCKS, ALLOW_MARKER } from './patterns.mjs';
+import { TEXT_RULE_BLOCKS } from './patterns.mjs';
 
 const git = (cmd) => execSync(`git ${cmd}`, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 
@@ -39,15 +42,7 @@ const collectChanges = (spec) => {
   return { files, addedLines };
 };
 
-const isApproved = (spec) => {
-  if (process.env.COPYRIGHT_APPROVED === '1') return true;
-  if (spec === '--cached') return false;
-  try {
-    return git(`log --format=%B ${spec}`).toLowerCase().includes(ALLOW_MARKER.toLowerCase());
-  } catch {
-    return false;
-  }
-};
+const isApproved = () => process.env.COPYRIGHT_APPROVED === '1';
 
 const main = () => {
   const spec = diffSpec();
@@ -61,8 +56,8 @@ const main = () => {
     console.error(`  [${f.rule}] ${where}${f.match ? ` — "${f.match}"` : ''}`);
     console.error(`      ${f.hint}`);
   }
-  if (isApproved(spec)) {
-    console.log("\n✓ owner-approved ([allow-copyright] / 'copyright-ok' label) — allowing.");
+  if (isApproved()) {
+    console.log("\n✓ owner-approved (the 'copyright-ok' label) — allowing.");
     return;
   }
   const blocking = findings.filter((f) => f.severity === 'block' || (f.severity === 'text' && TEXT_RULE_BLOCKS));
@@ -71,7 +66,8 @@ const main = () => {
     return;
   }
   console.error(`\n✗ copyright gate blocked: ${blocking.length} item(s) need owner approval.`);
-  console.error("  Commit: add [allow-copyright] to the message.   PR: apply the 'copyright-ok' label.");
+  console.error("  Approval is the maintainer-only 'copyright-ok' label on the pull request.");
+  console.error('  Nothing you can put in a commit message will stand this down.');
   process.exit(1);
 };
 

--- a/scripts/hooks/sync-check/index.mjs
+++ b/scripts/hooks/sync-check/index.mjs
@@ -9,8 +9,10 @@
  * Read-only and offline: no clone, no fetch, no network call at all — so it
  * works identically with or without access to either private repo, and
  * degrades to "nothing to report" the moment either mirror isn't set up.
- * Exits 1 (blocking the commit) only when real local-only work is found;
- * [sync-ack] in the commit message bypasses this entire check.
+ * Exits 1 (blocking the commit) only when real local-only work is found. There is
+ * no bypass: .claude/ and .vault/ are gitignored, so nothing downstream will ever
+ * notice the loss, which makes this the only chance to catch it. Resolving the
+ * drift is the way through.
  */
 import { checkAiConfig } from './ai-config-check.mjs';
 import { checkVault } from './vault-check.mjs';

--- a/scripts/hooks/sync-check/print.mjs
+++ b/scripts/hooks/sync-check/print.mjs
@@ -25,7 +25,8 @@ const printReport = ({ ai, vault }) => {
   console.error('sync-check: local-only work found in ai-config / vault');
   console.error('-'.repeat(60));
   lines.forEach((l) => console.error(l));
-  console.error('Add [sync-ack] to the commit message to bypass this check.');
+  console.error('There is no marker for this. Fold the work into its source and push,');
+  console.error('or --no-verify if you are the owner and you accept losing it.');
   console.error(`${'-'.repeat(60)}\n`);
 };
 


### PR DESCRIPTION
Both gates accepted a marker in the commit message, so whoever wrote the commit could approve their own work. The copyright gate honoured that marker in CI too, which meant the message alone satisfied the server side. I did exactly this earlier today on #125, which is how it surfaced.

- Media approval is now only the maintainer-only `copyright-ok` label. The commit-message path is gone from both the hook and CI.
- The ai-config drift check has no bypass at all. `.claude/` is gitignored, so nothing downstream would ever notice work being lost, which makes that hook the only chance to catch it. Resolving the drift is the way through, and an owner who means it can still pass `--no-verify` on their own machine.
- A new `gate-integrity` job fails a pull request that touches the hooks, the gate scripts or this workflow without the maintainer-only `gate-change-ok` label. Without that, weakening a check and committing it together passes quietly, because the weakened check is the one that runs.

Verified locally: with a media file staged the gate exits 1 and prints that only the label clears it, and exits 0 with `COPYRIGHT_APPROVED=1` as CI sets it. The drift check passes silently now that the ai-config sources carry the tag headers that were being dropped on every render.

This pull request touches the gates, so by its own rule it needs `gate-change-ok` to go green. That is deliberate.