### PR TITLE
Move the boot splash into its own window

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15,7 +15,7 @@ import { initPaths, ensureDataDirectories } from './lib/paths';
 import { applyPortableMode } from './app/portable-mode';
 import { registerInstallSize } from './app/install-size-type';
 import { applyInstanceIdentity, parseInstanceConfig } from './instance';
-import { createWindow, getMainWindow, registerWindowHandlers, registerAspectRatioHandlers } from './window';
+import { createWindow, getMainWindow, registerWindowHandlers, registerAspectRatioHandlers, setSplashStatus } from './window';
 import { saveWindowState } from './window/window-state';
 import { isEphemeralLaunch } from './window/startup-config';
 import { registerDisplayHandlers } from './display/ipc-handlers';
@@ -153,10 +153,13 @@ app.whenReady().then(async () => {
   }
 
   // Boot-timing diagnostic (opt-in via --boot-timing): renderer HTML loaded, then
-  // the renderer's app-ready signal (splash replaced by the UI).
+  // the renderer's shell-ready signal (splash window replaced by the main window).
   logBoot('window created');
-  mainWindow.webContents.once('did-finish-load', () => logBoot('renderer did-finish-load'));
-  ipcMain.once('window:appReady', () => logBoot('app-ready (splash gone)'));
+  mainWindow.webContents.once('did-finish-load', () => {
+    logBoot('renderer did-finish-load');
+    setSplashStatus('Preparing interface…');
+  });
+  ipcMain.once('window:shellReady', () => logBoot('shell-ready (reveal)'));
 
   // Initialize auto-updater (handlers registered above)
   initAutoUpdater(mainWindow);

--- a/apps/desktop/electron/window/boot/fade-window.ts
+++ b/apps/desktop/electron/window/boot/fade-window.ts
@@ -1,0 +1,41 @@
+/* @layer electron-main @kind logic */
+/**
+ * Opacity ramp for a BrowserWindow — the only animation in the boot sequence.
+ *
+ * setOpacity needs a compositing window manager. Where there is none (a bare X11
+ * session), it is a no-op and the window simply appears at its final opacity. That is
+ * an acceptable degradation: the fade is polish over a boot sequence that is already
+ * correct without it, so nothing downstream may depend on the ramp actually running.
+ */
+import type { BrowserWindow } from 'electron';
+
+const FRAME_MS = 16;
+
+const fadeWindow = (
+  win: BrowserWindow,
+  to: number,
+  durationMs: number,
+  onDone?: () => void,
+): void => {
+  const from = win.getOpacity();
+  if (from === to || durationMs <= 0) {
+    if (!win.isDestroyed()) win.setOpacity(to);
+    onDone?.();
+    return;
+  }
+
+  const startedAt = Date.now();
+  const timer = setInterval(() => {
+    if (win.isDestroyed()) {
+      clearInterval(timer);
+      return;
+    }
+    const t = Math.min(1, (Date.now() - startedAt) / durationMs);
+    win.setOpacity(from + (to - from) * t);
+    if (t < 1) return;
+    clearInterval(timer);
+    onDone?.();
+  }, FRAME_MS);
+};
+
+export { fadeWindow };

--- a/apps/desktop/electron/window/boot/index.ts
+++ b/apps/desktop/electron/window/boot/index.ts
@@ -1,0 +1,4 @@
+/* @layer electron-main @kind barrel */
+export { openSplash, setSplashStatus, closeSplash } from './splash-window';
+export { armReveal, revealMainWindow, REVEAL_MS } from './reveal';
+export { fadeWindow } from './fade-window';

--- a/apps/desktop/electron/window/boot/reveal.ts
+++ b/apps/desktop/electron/window/boot/reveal.ts
@@ -1,0 +1,59 @@
+/* @layer electron-main @kind logic */
+/**
+ * Boot mediator — the one place that knows both the splash and the main window exist.
+ *
+ * The splash never references the main window and the main window never references the
+ * splash; the renderer's shell-ready signal lands here and this module performs the
+ * swap. Idempotent, because three separate things can trigger it: the signal itself, a
+ * watchdog, and a dead renderer. A boot that goes wrong must still end with a visible
+ * window — an invisible app is a worse failure than an ugly one.
+ */
+import type { BrowserWindow } from 'electron';
+import { fadeWindow } from './fade-window';
+import { closeSplash } from './splash-window';
+
+const REVEAL_MS = 220;
+const WATCHDOG_MS = 8000;
+
+let target: BrowserWindow | null = null;
+let watchdog: NodeJS.Timeout | null = null;
+let revealed = true;
+
+const revealMainWindow = (): void => {
+  if (revealed) return;
+  revealed = true;
+
+  const win = target;
+  target = null;
+  if (watchdog) clearTimeout(watchdog);
+  watchdog = null;
+
+  closeSplash(REVEAL_MS);
+  if (!win || win.isDestroyed()) return;
+
+  // A transparent window is still hit-testable, so clicks were being swallowed while it
+  // could not be seen (see armReveal).
+  win.setIgnoreMouseEvents(false);
+  fadeWindow(win, 1, REVEAL_MS, () => {
+    if (!win.isDestroyed()) win.focus();
+  });
+};
+
+/**
+ * Hold `win` invisible until the renderer says its shell has settled.
+ *
+ * Opacity, not show:false — Chromium does not schedule requestAnimationFrame for a
+ * hidden page, so a hidden window would mount React into a stalled frame loop. A shown
+ * window at opacity 0 lays out and paints normally while compositing nothing the user
+ * can see.
+ */
+const armReveal = (win: BrowserWindow): void => {
+  target = win;
+  revealed = false;
+  win.setIgnoreMouseEvents(true);
+  if (watchdog) clearTimeout(watchdog);
+  watchdog = setTimeout(revealMainWindow, WATCHDOG_MS);
+  win.webContents.on('render-process-gone', revealMainWindow);
+};
+
+export { armReveal, revealMainWindow, REVEAL_MS };

--- a/apps/desktop/electron/window/boot/splash-window.ts
+++ b/apps/desktop/electron/window/boot/splash-window.ts
@@ -1,0 +1,85 @@
+/* @layer electron-main @kind logic */
+/**
+ * The boot splash — its own frameless window, so the main window never has to be
+ * splash-sized and then grow in front of the user.
+ *
+ * It is a CHILD of the main window rather than alwaysOnTop: a child floats above its
+ * parent only, so a boot that happens while the user is in another app never covers
+ * their work. It carries no preload and no bundle — plain markup that paints on the
+ * first frame, driven from here through one tiny global.
+ */
+import { BrowserWindow, screen } from 'electron';
+import { join } from 'path';
+import { is } from '@electron-toolkit/utils';
+import { fadeWindow } from './fade-window';
+
+// The size the boot splash has always been. Kept exactly, because the installer's
+// animated splash is generated to match it frame for frame (scripts/build/make-installer-splash.mjs),
+// so install and first launch read as one continuous thing.
+const SPLASH_WIDTH = 480;
+const SPLASH_HEIGHT = 360;
+
+let splash: BrowserWindow | null = null;
+
+/** Centred on the display the main window is on, not blindly on the primary one. */
+const splashOrigin = (parent: BrowserWindow): { x: number; y: number } => {
+  const { workArea } = screen.getDisplayMatching(parent.getBounds());
+  return {
+    x: Math.round(workArea.x + (workArea.width - SPLASH_WIDTH) / 2),
+    y: Math.round(workArea.y + (workArea.height - SPLASH_HEIGHT) / 2),
+  };
+};
+
+const loadSplashPage = (win: BrowserWindow, version: string): void => {
+  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    const url = new URL('/splash.html', process.env['ELECTRON_RENDERER_URL']);
+    url.searchParams.set('v', version);
+    void win.loadURL(url.toString());
+    return;
+  }
+  void win.loadFile(join(__dirname, '../renderer/splash.html'), { query: { v: version } });
+};
+
+const openSplash = (parent: BrowserWindow, version: string): void => {
+  splash = new BrowserWindow({
+    parent,
+    ...splashOrigin(parent),
+    width: SPLASH_WIDTH,
+    height: SPLASH_HEIGHT,
+    frame: false,
+    resizable: false,
+    // A frameless page with no -webkit-app-region:drag cannot be dragged anyway; this
+    // is the second lock, against a window manager that offers its own move handle.
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    skipTaskbar: true,
+    show: false,
+    backgroundColor: '#000000',
+    webPreferences: { nodeIntegration: false, contextIsolation: true },
+  });
+
+  loadSplashPage(splash, version);
+  splash.once('ready-to-show', () => splash?.show());
+};
+
+/**
+ * Status line under the spinner. Best-effort by design: the splash's job is done by
+ * its logo and spinner, so a lost message must never be able to break the boot.
+ */
+const setSplashStatus = (message: string): void => {
+  if (!splash || splash.isDestroyed()) return;
+  const call = `window.__splashStatus?.(${JSON.stringify(message)})`;
+  void splash.webContents.executeJavaScript(call).catch(() => undefined);
+};
+
+const closeSplash = (fadeMs: number): void => {
+  const win = splash;
+  splash = null;
+  if (!win || win.isDestroyed()) return;
+  fadeWindow(win, 0, fadeMs, () => {
+    if (!win.isDestroyed()) win.destroy();
+  });
+};
+
+export { openSplash, setSplashStatus, closeSplash };

--- a/apps/desktop/electron/window/create-window.ts
+++ b/apps/desktop/electron/window/create-window.ts
@@ -1,40 +1,18 @@
 /* @layer electron-main @kind logic */
-import { BrowserWindow, screen } from 'electron';
+import { app, BrowserWindow, screen } from 'electron';
 import { join } from 'path';
 import { is } from '@electron-toolkit/utils';
-import { loadWindowState, trackWindowState } from './window-state';
+import { loadWindowState, applyWindowState, trackWindowState } from './window-state';
 import { parseStartupConfig, startupRendererArgs } from './startup-config';
 import { keepWindowInBackground } from './keep-in-background';
 import { attachTextInteraction } from './text-interaction';
 import { resolveWindowIcon } from './window-icon';
+import { armReveal, openSplash } from './boot';
 import { isAutomationLaunch, parseInstanceConfig } from '../instance';
 
 const APP_TITLE = 'Relic of the Past';
 
 let mainWindow: BrowserWindow | null = null;
-
-// The window opens at this fixed size to frame the boot splash, then grows to the
-// saved size once the renderer signals it's ready (restoreSavedBounds below).
-const SPLASH_WIDTH = 480;
-const SPLASH_HEIGHT = 360;
-
-// Saved bounds are captured at creation but applied only on app-ready, so the
-// splash never flashes at the (possibly maximized) full size first.
-let pendingSavedState: ReturnType<typeof loadWindowState> | null = null;
-let savedStateRestored = false;
-
-// Test/automation launches must never steal focus OR cover the user's other
-// windows. Derived from isAutomationLaunch() rather than the literal --no-focus
-// flag, so a run that carries --auto-state/--dump-nav/--sim-run/etc. but forgot
-// --no-focus itself is still caught (see docs/contributing/testing.md — --no-focus
-// is documented as mandatory, but forgetting it must not cost the user their
-// focus). Tracked at module scope so restoreSavedBounds honours it too (its
-// maximize/fullscreen calls would otherwise activate + raise the window).
-let launchNoFocus = false;
-
-// --window-size opens at a fixed size; the splash→saved-size growth is skipped so
-// the window keeps exactly the requested resolution.
-let fixedWindowSize = false;
 
 const getMainWindow = (): BrowserWindow | null => {
   return mainWindow;
@@ -66,56 +44,21 @@ const offscreenOrigin = (): { x: number; y: number } => {
   return { x: right + 400, y: top };
 };
 
-/** Grow the splash-sized window to the last saved size/position/mode. Idempotent —
- *  fired by the renderer's app-ready signal, with a timeout fallback in createWindow. */
-const restoreSavedBounds = (): void => {
-  if (savedStateRestored || !mainWindow || !pendingSavedState) return;
-  savedStateRestored = true;
-  // A fixed --window-size launch keeps its requested resolution — no growth.
-  if (fixedWindowSize) return;
-  const saved = pendingSavedState;
-
-  // An automation window lives off every monitor (see offscreenOrigin). Grow it to
-  // the saved SIZE so anything layout-sensitive matches a real session, but never
-  // apply the saved POSITION — that would drag it onto a display and back into the
-  // user's way. Maximize/fullscreen are skipped for the same reason, and because
-  // both would activate it.
-  if (launchNoFocus) {
-    mainWindow.setContentSize(saved.width, saved.height);
-    return;
-  }
-
-  if (saved.x !== undefined && saved.y !== undefined) {
-    mainWindow.setContentBounds({ x: saved.x, y: saved.y, width: saved.width, height: saved.height });
-  } else {
-    mainWindow.setContentSize(saved.width, saved.height);
-    mainWindow.center();
-  }
-
-  // Start tracking normal bounds only now, so the splash size is never persisted.
-  trackWindowState(mainWindow);
-
-  if (saved.isMaximized) mainWindow.maximize();
-  if (saved.isFullscreen) mainWindow.setFullScreen(true);
-};
-
 const createWindow = (): BrowserWindow => {
   const noFocus = isAutomationLaunch();
-  launchNoFocus = noFocus;
   const startup = parseStartupConfig();
   const instance = parseInstanceConfig();
-  fixedWindowSize = startup.windowSize !== null;
-  pendingSavedState = loadWindowState();
-  savedStateRestored = false;
+  const saved = loadWindowState();
 
   mainWindow = new BrowserWindow({
-    width: startup.windowSize?.width ?? SPLASH_WIDTH,
-    height: startup.windowSize?.height ?? SPLASH_HEIGHT,
+    width: startup.windowSize?.width ?? saved.width,
+    height: startup.windowSize?.height ?? saved.height,
     minWidth: 360,
     minHeight: 280,
     // Automation opens off every monitor; centring would override that x/y.
     ...(noFocus ? offscreenOrigin() : {}),
-    center: !noFocus,
+    // Positioned by applyWindowState below, while still invisible.
+    center: false,
     titleBarStyle: 'hidden',
     autoHideMenuBar: true,
     // A named instance carries its name in the title and swaps to the bot icon, so
@@ -123,7 +66,11 @@ const createWindow = (): BrowserWindow => {
     title: instance.name ? `${APP_TITLE} — ${instance.name}` : APP_TITLE,
     icon: resolveWindowIcon(instance.name),
     backgroundColor: '#000000',
-    show: !noFocus,
+    // A normal launch is born transparent and is faded in by the boot mediator once
+    // the renderer's shell has settled — see armReveal. Automation has no splash to
+    // hand over from, so it stays opaque (and off-screen).
+    opacity: noFocus ? 1 : 0,
+    show: false,
     // An automation window must be UNABLE to take focus, not merely reluctant to.
     // focusable:false sets WS_EX_NOACTIVATE on Windows, so the OS refuses to
     // activate it at all — SetForegroundWindow (which is what Chromium's
@@ -149,9 +96,6 @@ const createWindow = (): BrowserWindow => {
     },
   });
 
-  // Fallback: if the renderer never signals ready (crash/hang), grow anyway.
-  setTimeout(restoreSavedBounds, 10000);
-
   // The WASM core sets an SDL window title (kWindowTitle in emscripten_main.c), which
   // reaches document.title and overrides the BrowserWindow title — so without this an
   // instance name never shows in the window or on the taskbar. Hold our own title for a
@@ -173,8 +117,23 @@ const createWindow = (): BrowserWindow => {
     //
     // showInactive() rather than show(), so we never even ask to be activated.
     // keepWindowInBackground is the backstop if anything raises us later.
+    //
+    // Sized, never positioned: the saved SIZE keeps anything layout-sensitive matching
+    // a real session, while the saved position would drag the window back onto a
+    // display and into the user's way. Maximize/fullscreen are skipped for the same
+    // reason, and because both would activate it.
+    if (!startup.windowSize) mainWindow.setContentSize(saved.width, saved.height);
     keepWindowInBackground(mainWindow);
     mainWindow.showInactive();
+  } else {
+    // Everything that moves the window happens here, while it is still transparent:
+    // by the time the user sees it, its geometry is final and its UI has settled.
+    if (startup.windowSize) mainWindow.center();
+    else applyWindowState(mainWindow, saved);
+    trackWindowState(mainWindow);
+    armReveal(mainWindow);
+    mainWindow.showInactive();
+    openSplash(mainWindow, app.getVersion());
   }
 
   // Let F1-F12 (and Tab) pass through to the renderer instead of being
@@ -221,4 +180,4 @@ const createWindow = (): BrowserWindow => {
   return mainWindow;
 };
 
-export { createWindow, getMainWindow, restoreSavedBounds };
+export { createWindow, getMainWindow };

--- a/apps/desktop/electron/window/index.ts
+++ b/apps/desktop/electron/window/index.ts
@@ -2,3 +2,4 @@
 export { createWindow, getMainWindow } from './create-window';
 export { registerWindowHandlers } from './ipc-handlers';
 export { registerAspectRatioHandlers } from './aspect-ratio';
+export { setSplashStatus, revealMainWindow } from './boot';

--- a/apps/desktop/electron/window/ipc-handlers.ts
+++ b/apps/desktop/electron/window/ipc-handlers.ts
@@ -1,12 +1,13 @@
 /* @layer electron-main @kind logic */
-import { getMainWindow, restoreSavedBounds } from './create-window';
+import { getMainWindow } from './create-window';
+import { revealMainWindow } from './boot';
 import { handle, on } from '../lib/ipc/handle';
 
 const registerWindowHandlers = (): void => {
   const win = () => getMainWindow();
 
-  // Renderer finished mounting the UI — grow the splash window to the saved size.
-  on('window:appReady', () => restoreSavedBounds());
+  // The renderer's UI has settled and painted — hand over from the splash window.
+  on('window:shellReady', () => revealMainWindow());
 
   // Window controls
   on('window:minimize', () => win()?.minimize());

--- a/apps/desktop/electron/window/startup-config.ts
+++ b/apps/desktop/electron/window/startup-config.ts
@@ -2,8 +2,8 @@
 /**
  * Test/automation startup flags, parsed from process.argv:
  *
- *   --window-size[=WxH]  Open at a fixed size (default 1280x800) instead of the
- *                        boot-splash size; skips the splash→saved-size growth.
+ *   --window-size[=WxH]  Open at a fixed size (default 1280x800) instead of the saved
+ *                        one, and stay there — the saved geometry is not applied.
  *   --widgets=a,b,c      Open these widgets docked (shrinking the game area) with
  *                        their default side, on top of a clean layout.
  *   --fresh              Ignore the saved widget layout, start with nothing open

--- a/apps/desktop/electron/window/window-state.ts
+++ b/apps/desktop/electron/window/window-state.ts
@@ -68,6 +68,25 @@ const loadWindowState = (): WindowState => {
   }
 };
 
+/**
+ * Put a window at its saved size/position/mode. Called BEFORE the window is ever
+ * visible, so none of these moves are seen.
+ *
+ * Saved state holds CONTENT bounds while the BrowserWindow constructor takes WINDOW
+ * bounds, and titleBarStyle:'hidden' makes the two disagree on Windows — which is why
+ * the geometry is applied here rather than passed as constructor options.
+ */
+const applyWindowState = (win: BrowserWindow, state: WindowState): void => {
+  if (state.x !== undefined && state.y !== undefined) {
+    win.setContentBounds({ x: state.x, y: state.y, width: state.width, height: state.height });
+  } else {
+    win.setContentSize(state.width, state.height);
+    win.center();
+  }
+  if (state.isMaximized) win.maximize();
+  if (state.isFullscreen) win.setFullScreen(true);
+};
+
 const trackWindowState = (win: BrowserWindow): void => {
   const updateNormalBounds = (): void => {
         if (!win.isMaximized() && !win.isFullScreen() && !win.isMinimized()) {
@@ -108,4 +127,5 @@ const saveWindowState = (win: BrowserWindow): void => {
   }
 };
 
-export { loadWindowState, trackWindowState, saveWindowState };
+export { loadWindowState, applyWindowState, trackWindowState, saveWindowState };
+export type { WindowState };

--- a/apps/web/src/App/behavior/useShellReady.ts
+++ b/apps/web/src/App/behavior/useShellReady.ts
@@ -1,0 +1,30 @@
+/* @layer renderer-appshell @kind hook */
+/**
+ * useShellReady — tells the main process the UI may be shown.
+ *
+ * The old signal fired on first mount, which was too early: the window was revealed
+ * while profiles were still resolving and the landing page had not been chosen, so the
+ * shell visibly assembled itself afterwards. This one waits for startup to settle and
+ * then for two frames — the first commits the settled layout, the second proves it
+ * painted — so the first thing the user sees is the finished UI.
+ *
+ * No-op off Electron (web/mobile have no window to reveal).
+ */
+import { useEffect, useRef } from 'react';
+
+const useShellReady = (settled: boolean): void => {
+  const signalled = useRef(false);
+
+  useEffect(() => {
+    if (signalled.current || !settled) return;
+    signalled.current = true;
+    // Deliberately not cancelled on cleanup: StrictMode's double-invoke would cancel
+    // the only scheduled signal and the second pass would find the ref already set,
+    // leaving the window hidden until the main-process watchdog fires.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => window.api?.shellReady?.());
+    });
+  }, [settled]);
+};
+
+export { useShellReady };

--- a/apps/web/src/App/behavior/useStartup.ts
+++ b/apps/web/src/App/behavior/useStartup.ts
@@ -1,5 +1,5 @@
 /* @layer renderer-appshell @kind hook */
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { log } from '../../lib/log-bus';
 import { applySpritesForRom } from '../../lib/sprites/apply-sprites-for-rom';
 import { getAppState } from '../../lib/storage/profile-store';
@@ -13,6 +13,10 @@ const useStartup = (
   },
   nav: { setActivePage: (page: PageId) => void },
 ) => {
+  // Startup owns which page the app lands on, so it also owns the moment the shell
+  // stops moving — which is what useShellReady waits for before revealing the window.
+  const [settled, setSettled] = useState(false);
+
   useEffect(() => {
     (async () => {
       try {
@@ -71,9 +75,15 @@ const useStartup = (
       } catch (err) {
         log.error(`Startup failed: ${err}`);
         nav.setActivePage('data');
+      } finally {
+        // Every exit path above, including the early returns — a boot that failed still
+        // has to end with a visible window.
+        setSettled(true);
       }
     })();
   }, []);
+
+  return { settled };
 };
 
 export { useStartup };

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -9,7 +9,10 @@
     />
     <title>Relic of the Past</title>
     <!-- Boot splash: painted instantly (no bundle/JS/WASM needed). React replaces
-         #root on first render, so the splash tears itself down for free. -->
+         #root on first render, so the splash tears itself down for free.
+         Desktop no longer relies on this — it has its own splash WINDOW (splash.html)
+         and keeps this one invisible until the shell settles. It stays for web and
+         Android, where nothing else covers the gap before React mounts. -->
     <style>
       #boot-splash {
         position: fixed;

--- a/apps/web/src/splash.html
+++ b/apps/web/src/splash.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self'"
+    />
+    <title>Relic of the Past</title>
+    <!-- The boot splash, in its own window. No bundle, no preload, no imports: every
+         byte here paints on the first frame, which is the whole point of the window. -->
+    <style>
+      html, body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #000;
+        /* No -webkit-app-region:drag anywhere on this page — a frameless window with no
+           drag region cannot be moved, which is what a splash should be. */
+        user-select: none;
+        cursor: default;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 28px;
+        font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+      }
+      .splash__logo {
+        width: 192px;
+        height: 192px;
+        image-rendering: auto;
+      }
+      .splash__spinner {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: 3px solid rgba(255, 255, 255, 0.12);
+        border-top-color: #c8a84e;
+        animation: splash-rotate 0.7s linear infinite;
+      }
+      .splash__status {
+        /* Out of flow on purpose: the logo + spinner column stays centred exactly where
+           the installer's splash GIF puts it, whatever the status line says. */
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 30px;
+        margin: 0;
+        text-align: center;
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        color: rgba(255, 255, 255, 0.55);
+      }
+      .splash__version {
+        position: fixed;
+        right: 10px;
+        bottom: 8px;
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        color: rgba(255, 255, 255, 0.28);
+      }
+      @keyframes splash-rotate {
+        to { transform: rotate(360deg); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .splash__spinner { animation-duration: 2.4s; }
+      }
+    </style>
+  </head>
+  <body>
+    <img class="splash__logo" src="./logos/logo-256.png" alt="" />
+    <div class="splash__spinner"></div>
+    <p class="splash__status" id="splash-status">Starting…</p>
+    <span class="splash__version" id="splash-version"></span>
+    <script>
+      // The main process drives the status line through this one global (see
+      // window/boot/splash-window.ts). Kept trivial so a failed call costs a message,
+      // never the splash itself.
+      window.__splashStatus = (message) => {
+        document.getElementById('splash-status').textContent = message;
+      };
+      document.getElementById('splash-version').textContent =
+        new URLSearchParams(window.location.search).get('v') ?? '';
+    </script>
+  </body>
+</html>

--- a/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
+++ b/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
@@ -24,6 +24,7 @@ import { useProfileManagement } from '@app/App/behavior/useProfileManagement';
 import { useSaveOverlay } from '@app/App/behavior/useSaveOverlay';
 import { useSaveStateSettings } from '@app/App/behavior/useSaveStateSettings';
 import { useStartup } from '@app/App/behavior/useStartup';
+import { useShellReady } from '@app/App/behavior/useShellReady';
 import { useWasmWarmup } from '@app/App/behavior/useWasmWarmup';
 import { useDebugLaunchHooks } from '@app/App/behavior/useDebugLaunchHooks';
 import { useAppMainEffects } from '@app/App/behavior/useAppMainEffects';
@@ -90,7 +91,7 @@ const AppMain = () => {
 
   useKeyboardShortcuts(nav, dialog, dismissDialog, profileMgmt.activeProfile);
 
-  useStartup(profileMgmt, nav);
+  const startup = useStartup(profileMgmt, nav);
   useWasmWarmup();
   useDebugLaunchHooks({ activeProfile: profileMgmt.activeProfile, loadProfileForGame: profileMgmt.loadProfileForGame, openNavWidget: () => widgets.open('navigation') });
   useIpcLogBridge();
@@ -99,9 +100,9 @@ const AppMain = () => {
   // Default notch mode until a profile loads (keeps startup windows clear of a cutout).
   useEffect(() => { applyNotchMode(true); }, []);
 
-  // Splash → full size: the UI shell has mounted, so grow the splash-sized window
-  // to the last saved bounds (electron only; no-op on web/mobile).
-  useEffect(() => { window.api?.appReady?.(); }, []);
+  // Splash window → main window: reveal only once startup has settled and painted,
+  // so the first frame the user sees is the finished shell (electron only).
+  useShellReady(startup.settled);
 
   const widgetVisibility = useMemo(() => Object.fromEntries(widgets.layout.widgets.map((w) => [w.id, w.visible])), [widgets.layout]);
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -54,7 +54,13 @@ export default defineConfig({
     build: {
       outDir: resolve(__dirname, 'dist/renderer'),
       rollupOptions: {
-        input: resolve(__dirname, 'apps/web/src/index.html'),
+        // Two pages, one output dir: the app, and the boot splash that runs in its own
+        // window while the app loads. Same dir is what lets splash.html reach
+        // ./logos/* exactly like index.html does, in dev and packaged alike.
+        input: {
+          index: resolve(__dirname, 'apps/web/src/index.html'),
+          splash: resolve(__dirname, 'apps/web/src/splash.html'),
+        },
       },
     },
   },

--- a/scripts/build/make-installer-splash.mjs
+++ b/scripts/build/make-installer-splash.mjs
@@ -1,7 +1,7 @@
 /* @layer tooling-scripts @kind logic */
 /**
  * Builds the installer splash as an animated GIF, matching the app's boot splash
- * (apps/web/src/index.html) frame for frame: black ground, 192px mark, a 28px ring
+ * (apps/web/src/splash.html) frame for frame: black ground, 192px mark, a 28px ring
  * whose top quarter is gold, one revolution every 0.7s.
  */
 import { createRequire } from 'module';
@@ -14,7 +14,7 @@ const sharp = require('sharp');
 const ROOT = process.cwd();
 const OUT = process.argv[2] ?? join(ROOT, 'build', 'installer-splash.gif');
 
-// Window, mirroring the splash-sized BrowserWindow in window/create-window.ts.
+// Window, mirroring the splash BrowserWindow in window/boot/splash-window.ts.
 const W = 480;
 const H = 360;
 

--- a/shared/ipc/maps.ts
+++ b/shared/ipc/maps.ts
@@ -155,7 +155,7 @@ const SEND_MAP = {
   toggleFullscreen: 'window:toggleFullscreen',
   setFullscreen: 'window:setFullscreen',
   setAspectRatioLock: 'window:setAspectRatioLock',
-  appReady: 'window:appReady',
+  shellReady: 'window:shellReady',
 } as const satisfies Record<string, keyof SendContract>;
 
 const EVENT_MAP = {

--- a/shared/ipc/send-contract.ts
+++ b/shared/ipc/send-contract.ts
@@ -12,7 +12,8 @@ interface SendContract {
   'window:toggleFullscreen': () => void;
   'window:setFullscreen': (value: boolean) => void;
   'window:setAspectRatioLock': (ratio: number, extraHeight: number) => void;
-  'window:appReady': () => void;
+  /** UI shell settled AND painted — the main window may be revealed. */
+  'window:shellReady': () => void;
 }
 
 export type { SendContract };


### PR DESCRIPTION
The splash used to live inside the main window, which meant the window opened at 480x360, grew to the saved size mid-load, and then let the UI assemble itself on top. This gives the wait its own window and only shows the main one when it is actually ready.

- The main window is created at its final geometry (saved bounds, maximize, fullscreen all applied before it is ever visible) and held at opacity 0 rather than show:false, since a hidden page gets no requestAnimationFrame and React would mount into a stalled frame loop.
- The splash is a separate frameless window parented to the main one, so it floats above our window only and never over whatever else you have open. Same styling and same 480x360 as before, so it still matches the installer splash frame for frame.
- window/boot/reveal.ts is the only module that knows both windows exist. It crossfades them on the renderer's signal, with an 8s watchdog and a render-process-gone path so a bad boot still ends with a visible window.
- window:appReady became window:shellReady and now fires after startup settles plus two frames, instead of on first mount. That is what removes the staged pop-in.
- restoreSavedBounds and its four module-level flags are gone; create-window.ts drops from 225 to 183 lines.
- The WASM warmup is untouched: it keeps running in the main window under the bottom progress bar after the reveal.

The inline boot splash stays in index.html for web and Android, which have nothing else covering the gap before React mounts.

Verified: typecheck, eslint, analyze:diff (0 gating violations), the two-entry renderer build, the automation path unchanged (--no-focus stays off-screen with no splash, shell-ready at +4.0s), and a real file:// load proving the splash renders under its own CSP with the logo, version and main-process status injection working. The visible boot itself is the part that needs a human look, since launching it here would steal focus.

One known soft spot: setOpacity is a no-op without a compositor on some Linux/X11 setups. It degrades to the window appearing at once at the correct size, so the fix does not depend on the fade.