### PR TITLE
Point sync-check at the vault checkout, drop the stale gate exemption

### DIFF
--- a/scripts/copyright-gate/patterns.mjs
+++ b/scripts/copyright-gate/patterns.mjs
@@ -23,8 +23,15 @@ const MEDIA_EXT = new Set([
 const TRADEMARK_RE = /\b(nintendo|the legend of zelda|a link to the past|hyrule|hylian|ganon(dorf)?|triforce|master sword|sheikah|sahasrahla|zelda)\b/i;
 
 // Paths where these names legitimately appear — excluded from the trademark rule.
+//
+// `shared/game/data/` used to be here because the record dataset lived there and
+// the gate was expected to be signed off for it. The dataset moved to the private
+// companion repo and its destination is gitignored, so nothing the gate can see
+// under that path needs the exemption any more — while leaving it would let a
+// trademark land unnoticed in the schema, the aggregators or the facade, which is
+// code and is supposed to stay clean.
 const TEXT_SKIP_PREFIXES = [
-  'docs/', 'shared/game/data/', 'shared/input/data/',
+  'docs/', 'shared/input/data/',
   'scripts/copyright-gate/', '.github/', '.githooks/',
 ];
 // Files whose whole point is to NAME the rights holder. Nominative use — removing

--- a/scripts/hooks/sync-check/index.mjs
+++ b/scripts/hooks/sync-check/index.mjs
@@ -1,16 +1,19 @@
 /* @layer tooling-scripts @kind logic */
 /**
  * Local-only gate wired into .githooks/commit-msg. Checks whether either
- * gitignored mirror — .claude/ (ai-config) or .vault/ (rotp-vault) — is
- * currently carrying local-only work that would be silently lost: a hand-edit
- * to a rendered ai-config file (overwritten by the next bootstrap render), or
- * an uncommitted change inside .vault (never sent upstream via vault:push).
+ * gitignored mirror — .claude/ (ai-config) or the vault checkout — is currently
+ * carrying local-only work that would be silently lost: a hand-edit to a
+ * rendered ai-config file (overwritten by the next bootstrap render), or an
+ * uncommitted change in the vault (which nothing else holds a record of).
  *
  * Read-only and offline: no clone, no fetch, no network call at all — so it
- * works identically with or without access to either private repo, and
- * degrades to "nothing to report" the moment either mirror isn't set up.
- * Exits 1 (blocking the commit) only when real local-only work is found;
- * [sync-ack] in the commit message bypasses this entire check.
+ * works identically with or without access to either private repo, and degrades
+ * to "nothing to report" the moment either mirror isn't set up. Exits 1
+ * (blocking the commit) only when real local-only work is found; [sync-ack] in
+ * the commit message bypasses this entire check.
+ *
+ * An unpushed vault commit is reported but does not block — see vault-check.mjs
+ * for why the two are weighted differently.
  */
 import { checkAiConfig } from './ai-config-check.mjs';
 import { checkVault } from './vault-check.mjs';
@@ -20,5 +23,5 @@ const ai = checkAiConfig();
 const vault = checkVault();
 const blocking = ai.status === 'drift' || vault.status === 'dirty';
 
-printReport({ ai, vault });
+printReport({ ai, vault, blocking });
 process.exit(blocking ? 1 : 0);

--- a/scripts/hooks/sync-check/print.mjs
+++ b/scripts/hooks/sync-check/print.mjs
@@ -2,8 +2,13 @@
 /**
  * One short report to stderr — silent when both mirrors are clean/unmanaged,
  * specific about what to do when they aren't.
+ *
+ * Not everything reported here blocks. An unpushed vault commit is worth saying
+ * out loud but is recoverable, so the bypass line only appears when something
+ * actually stands in the way — otherwise it reads as an instruction to silence a
+ * warning that was never stopping anything.
  */
-const printReport = ({ ai, vault }) => {
+const printReport = ({ ai, vault, blocking }) => {
   const lines = [];
 
   if (ai.status === 'drift') {
@@ -14,9 +19,14 @@ const printReport = ({ ai, vault }) => {
   }
 
   if (vault.status === 'dirty') {
-    lines.push('vault: .vault/ has local changes never sent to rotp-vault:');
+    lines.push(`vault: ${vault.dir} has uncommitted changes:`);
     vault.files.forEach((p) => lines.push(`  ${p}`));
-    lines.push('  -> npm run vault:push "<what changed>"');
+    lines.push('  -> commit them there, or run npm run vault:sync to settle both sides');
+  }
+
+  if (vault.ahead > 0) {
+    lines.push(`vault: ${vault.ahead} commit(s) in ${vault.dir} not pushed to rotp-vault`);
+    lines.push(`  -> git -C ${vault.dir} push`);
   }
 
   if (!lines.length) return;
@@ -25,7 +35,7 @@ const printReport = ({ ai, vault }) => {
   console.error('sync-check: local-only work found in ai-config / vault');
   console.error('-'.repeat(60));
   lines.forEach((l) => console.error(l));
-  console.error('Add [sync-ack] to the commit message to bypass this check.');
+  if (blocking) console.error('Add [sync-ack] to the commit message to bypass this check.');
   console.error(`${'-'.repeat(60)}\n`);
 };
 

--- a/scripts/hooks/sync-check/vault-check.mjs
+++ b/scripts/hooks/sync-check/vault-check.mjs
@@ -1,24 +1,48 @@
 /* @layer tooling-scripts @kind logic */
 /**
- * Read-only: does .vault/ have local changes that were never sent upstream
- * via `npm run vault:push`? Plain `git status --porcelain` on the vault
- * clone — no fetch, no network.
+ * Read-only: is the vault checkout carrying work that has not been shared?
+ * Plain `git status --porcelain` plus an ahead-count against its own upstream —
+ * no fetch, no network.
+ *
+ * The vault is a sibling checkout now, not a clone inside this tree, so it is
+ * found the same way the sync finds it rather than at a fixed path. Pointed at
+ * the old `.vault/` this check reported "unmanaged" and silently stopped
+ * watching anything at all.
+ *
+ * Two different risks, kept apart because they are not equally bad:
+ *
+ * - UNCOMMITTED files can be lost outright — an edit nothing holds a record of.
+ *   That still blocks the commit, exactly as it did before.
+ * - UNPUSHED commits are already in git and recoverable, just not shared yet.
+ *   Those are reported and do NOT block: `npm run vault:sync` commits everything
+ *   it writes, so any sync leaves commits here, and blocking on that would fail
+ *   every commit in this repo until the vault had been pushed.
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { locateVault } from '../../vault/locate.mjs';
 
-const ROOT = resolve(import.meta.dirname, '..', '..', '..');
-const VAULT_DIR = join(ROOT, '.vault');
+const git = (dir, args) => {
+  try {
+    return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch {
+    return '';
+  }
+};
 
-/** @returns {{ status: 'unmanaged'|'clean'|'dirty', files: string[] }} */
+/** @returns {{ status: 'unmanaged'|'clean'|'dirty', dir: string|null, files: string[], ahead: number }} */
 const checkVault = () => {
-  if (!existsSync(join(VAULT_DIR, '.git'))) return { status: 'unmanaged', files: [] };
+  const dir = locateVault();
+  if (!dir || !git(dir, ['rev-parse', '--git-dir']).trim()) {
+    return { status: 'unmanaged', dir: null, files: [], ahead: 0 };
+  }
 
-  const porcelain = execFileSync('git', ['-C', VAULT_DIR, 'status', '--porcelain'], { encoding: 'utf8' });
-  const files = porcelain.split('\n').filter(Boolean).map((l) => l.slice(3));
+  const files = git(dir, ['status', '--porcelain']).split('\n').filter(Boolean).map(line => line.slice(3));
 
-  return { status: files.length ? 'dirty' : 'clean', files };
+  // No upstream configured counts as zero rather than as a guess — an
+  // unpublished branch is a deliberate choice, not something to nag about.
+  const ahead = Number(git(dir, ['rev-list', '--count', '@{u}..HEAD']).trim()) || 0;
+
+  return { status: files.length ? 'dirty' : 'clean', dir, files, ahead };
 };
 
 export { checkVault };


### PR DESCRIPTION
Two guards had gone quiet after the dataset moved to the private companion repo.

`sync-check` was still looking for `.vault/`, the clone that used to live inside the repo. That directory is gone, so the check found nothing, reported `unmanaged`, and stopped watching — a guard failing open without saying so. It now locates the vault the way the sync does, following `ROTP_VAULT_DIR` or the sibling checkout.

It also separates two risks that were previously treated the same:

- uncommitted files in the vault still block a commit, because nothing else holds a record of them
- unpushed commits are only reported, since `vault:sync` commits everything it writes and blocking on that would fail every commit here until the vault was pushed

The `[sync-ack]` hint now appears only when something is genuinely blocking, rather than alongside a warning that was never stopping anything.

The copyright gate exempted `shared/game/data/` from the trademark rule. That was correct while the record dataset lived there, but the dataset moved and its destination is gitignored, so nothing the gate can see under that path needs the exemption. Leaving it would let a trademark land unnoticed in the schema, the aggregators or the facade, which are code and are meant to stay clean.

Verified: `npm run lint` clean, `npm run analyze:ci` 0 violations, and the check now reports the real vault as `clean` instead of `unmanaged`.