### PR TITLE
fix(input): wire the cheat-health binding to a listener

### DIFF
--- a/apps/web/src/lib/input/input-manager-cheats.ts
+++ b/apps/web/src/lib/input/input-manager-cheats.ts
@@ -1,0 +1,22 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Cheat function-action wiring for InputManager — binds `cheat-health` (defined in
+ * shared/types/controls/functions.ts, rebindable in Settings → Controls → Cheats) to
+ * the same full-heal call the Cheats widget's "Full Heal" button uses. Until this
+ * wiring existed the binding was registered but had no listener, so pressing it did
+ * nothing on keyboard or controller (issue #130).
+ */
+import type { InputManager } from './input-manager';
+import { cheatSetHealth, cheatSetMaxHealth } from '../game/cheats';
+
+const FULL_HEALTH = 160;
+
+/** Register the cheat-* function actions so their bindings actually do something. */
+const wireCheatActions = (m: InputManager): void => {
+  m.functionActions.onAction('cheat-health', () => {
+    cheatSetHealth(FULL_HEALTH);
+    cheatSetMaxHealth(FULL_HEALTH);
+  });
+};
+
+export { wireCheatActions };

--- a/apps/web/src/lib/input/input-manager.ts
+++ b/apps/web/src/lib/input/input-manager.ts
@@ -28,6 +28,7 @@ import type { RawInputEvent, RawInputListener } from './raw-input-dispatcher';
 import { startInput, stopInput, refreshDevicesImpl } from './input-manager-lifecycle';
 import { rebuildMaps, guardKeys, keyDown, keyUp, pollFrame, connectedGamepadKeys } from './input-manager-events';
 import { wireProfileActions, setProfiles as setProfilesImpl, subscribeActiveProfile, cycleActiveProfile as cycleActiveProfileImpl } from './input-manager-profiles';
+import { wireCheatActions } from './input-manager-cheats';
 import type { AllowedDevices } from './profile-devices';
 import type { ActiveProfileListener, DeviceChangeListener, InputStateListener } from './input-manager-types';
 import type { DeviceScopedMap } from './device-scoped-map';
@@ -95,6 +96,7 @@ class InputManager {
     };
     this.functionActions.onPauseToggle = () => this.pauseManager.togglePause();
     wireProfileActions(this);
+    wireCheatActions(this);
   }
 
   // ─── Event handler fields (stable identity for add/removeEventListener) ───


### PR DESCRIPTION
## Summary
- `cheat-health` was a fully valid, rebindable function action (Settings → Controls → Cheats) with a default keyboard binding, but nothing ever subscribed a callback to it, so pressing the bound key or button silently did nothing.
- Wires it up the same way `profile-next`/`profile-prev` and the save/load-state actions already are, calling the same full-heal path the Cheats widget's "Full Heal" button uses.

Fixes #130.

## Test plan
- [ ] Bind "Restore Health" to a key or controller button in Settings → Controls → Cheats.
- [ ] In-game, press the binding and confirm health (and max health) restores to full.
- [ ] Confirm the Cheats widget's own "Full Heal" button still works unchanged.