### PR TITLE
fix(hooks): stop sync-check false-flagging vault status from a worktree

### DIFF
--- a/scripts/hooks/sync-check/locate-ai-config-repo.mjs
+++ b/scripts/hooks/sync-check/locate-ai-config-repo.mjs
@@ -1,0 +1,21 @@
+/* @layer tooling-scripts @kind logic */
+/**
+ * Where the ai-config source repo lives, if it happens to be checked out on this
+ * machine — the same "sibling checkout" search as the vault (scripts/vault/locate.mjs).
+ * Best-effort only: rendering .claude/ never needs this repo present, so a miss just
+ * means the drift message stays generic instead of naming the exact command to run.
+ *
+ * Reuses the vault's `mainCheckout()` because the same worktree problem applies here:
+ * from a worktree (rotp-worktrees/<name>), `../claude-config` is a sibling of the
+ * worktree, not of the repository, so a naive lookup would never find it.
+ */
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { mainCheckout } from '../../vault/locate.mjs';
+
+const locateAiConfigRepo = () => {
+  const candidate = resolve(mainCheckout(), '..', 'claude-config');
+  return existsSync(join(candidate, 'ai', 'bootstrap.mjs')) ? candidate : null;
+};
+
+export { locateAiConfigRepo };

--- a/scripts/hooks/sync-check/print.mjs
+++ b/scripts/hooks/sync-check/print.mjs
@@ -8,14 +8,21 @@
  * actually stands in the way — otherwise it reads as an instruction to silence a
  * warning that was never stopping anything.
  */
+import { join } from 'node:path';
+import { locateAiConfigRepo } from './locate-ai-config-repo.mjs';
+
 const printReport = ({ ai, vault, blocking }) => {
   const lines = [];
 
   if (ai.status === 'drift') {
+    const repo = locateAiConfigRepo();
     lines.push('ai-config: local edits differ from the last render — these live only in the');
     lines.push('gitignored .claude/ and will be OVERWRITTEN by the next bootstrap render:');
     ai.edits.forEach((p) => lines.push(`  ${p}`));
     lines.push('  -> fold the edit back into the claude-config source, commit + push it there');
+    lines.push(repo
+      ? `  -> then re-render: node "${join(repo, 'ai', 'bootstrap.mjs')}" claude rotp --confirm`
+      : '  -> then re-render with your ai-config bootstrap command');
   }
 
   if (vault.status === 'dirty') {

--- a/scripts/hooks/sync-check/vault-check.mjs
+++ b/scripts/hooks/sync-check/vault-check.mjs
@@ -17,13 +17,27 @@
  *   Those are reported and do NOT block: `npm run vault:sync` commits everything
  *   it writes, so any sync leaves commits here, and blocking on that would fail
  *   every commit in this repo until the vault had been pushed.
+ *
+ * Committing from a git WORKTREE runs this hook with GIT_DIR (and friends) set to
+ * that worktree's private git-dir. `-C <dir>` only changes the child's cwd — it
+ * does not clear an inherited GIT_DIR — so without stripping it, git would ignore
+ * the vault's own repo entirely and diff its files against the caller's index
+ * instead, reporting every single file in the vault as modified.
  */
 import { execFileSync } from 'node:child_process';
 import { locateVault } from '../../vault/locate.mjs';
 
+const GIT_ENV_OVERRIDES = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY', 'GIT_ALTERNATE_OBJECT_DIRECTORIES'];
+
+const cleanGitEnv = () => {
+  const env = { ...process.env };
+  for (const key of GIT_ENV_OVERRIDES) delete env[key];
+  return env;
+};
+
 const git = (dir, args) => {
   try {
-    return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env: cleanGitEnv() });
   } catch {
     return '';
   }

--- a/scripts/vault/locate.mjs
+++ b/scripts/vault/locate.mjs
@@ -75,4 +75,4 @@ const MANAGED_ROOTS = [
   '.claude/nav-baselines',
 ];
 
-export { ROOT, TREE, MANAGED_ROOTS, locateVault, treeDirOf, candidates };
+export { ROOT, TREE, MANAGED_ROOTS, locateVault, mainCheckout, treeDirOf, candidates };


### PR DESCRIPTION
## Summary
- Committing from a git worktree runs the commit-msg hook with `GIT_DIR` (and friends) set to that worktree's private git-dir. `-C <dir>` only changes the child process's cwd, not that inherited env, so `vault-check.mjs` was comparing the vault checkout's files against the caller's own git index instead of the vault's — making every single file in the vault look modified. Strips those env vars before shelling out.
- Also points the ai-config drift message at the exact re-render command when the claude-config checkout is findable on the machine, instead of leaving that lookup to whoever hits the gate next.

## Test plan
- [ ] Commit something from a worktree checkout with a clean vault and confirm sync-check no longer false-flags it.
- [ ] Confirm a genuinely dirty vault is still reported and still blocks.
- [ ] Confirm the ai-config drift message shows the re-render command when `../claude-config` exists on disk.