### PR TITLE
Fix HUD/widescreen/cheats in the overworld special-switch areas

### DIFF
--- a/apps/web/src/lib/game/ui-bridge-parser.ts
+++ b/apps/web/src/lib/game/ui-bridge-parser.ts
@@ -25,7 +25,14 @@ const INTERFACE_SUBMODULE_MODES: Record<number, UIMode> = {
   11: 'save_menu',
 };
 
-const deriveUIMode = (mainModule: number, subModule: number, _subSubModule: number, floorTimer: number): UIMode => {
+// Module 11 (MODULE_FALLING_ENTRANCE) floor for overworld_screen_index — mirrors
+// OVERWORLD_SPECIAL_AREA_SCREEN_MIN in core/game-hooks/game_constants.h. Real overworld
+// screens (light or dark world) are always 0-127.
+const OVERWORLD_SPECIAL_AREA_SCREEN_MIN = 128;
+
+const deriveUIMode = (
+  mainModule: number, subModule: number, _subSubModule: number, floorTimer: number, overworldScreenIndex: number,
+): UIMode => {
   switch (mainModule) {
     case 0: // Module00_Intro
     case 1: // Module01_FileSelect
@@ -38,10 +45,16 @@ const deriveUIMode = (mainModule: number, subModule: number, _subSubModule: numb
     case 6:
     case 8:
     case 10:
-    case 11:
     case 15:
     case 16:
       return 'loading';
+    case 11:
+      // Module 11 is the dungeon pit-fall transition, but the engine also reuses it,
+      // unchanged, for the 3 vanilla overworld locations reached by walking onto a switch
+      // tile — normal interactive gameplay even though the module never returns to 9.
+      // overworld_screen_index stays >= 128 only in that flavor; an actual pit-fall into a
+      // dungeon room never reaches it that high.
+      return overworldScreenIndex >= OVERWORLD_SPECIAL_AREA_SCREEN_MIN ? 'gameplay' : 'loading';
     case 7:
     case 9:
       // Active gameplay — check floor indicator
@@ -154,7 +167,7 @@ const parseGameUIBuffer = (heap: Uint8Array, ptr: number): GameUIState => {
   const linkY = b[p + 123] | (b[p + 124] << 8);
 
   // Derive mode
-  const mode = deriveUIMode(mainModule, subModule, subSubModule, floorTimer);
+  const mode = deriveUIMode(mainModule, subModule, subSubModule, floorTimer, overworldScreenIndex);
 
   const gameMode: GameModeState = { mainModule, subModule, subSubModule };
 

--- a/core/game-hooks/cheats.c
+++ b/core/game-hooks/cheats.c
@@ -26,8 +26,10 @@ static uint8 g_cheat_extra_armor_pct = 0;   // Extra damage reduction % (0-100),
 // clampi() comes from num_util.h (shared with the volume setters).
 
 // True when the engine is in normal interactive gameplay (overworld or indoor).
+// Includes the overworld-special-area flavor of MODULE_FALLING_ENTRANCE — see
+// GameHook_IsOverworldSpecialArea.
 static inline bool IsInGameplay(void) {
-  return main_module_index == MODULE_DUNGEON || main_module_index == MODULE_OVERWORLD;
+  return main_module_index == MODULE_DUNGEON || main_module_index == MODULE_OVERWORLD || GameHook_IsOverworldSpecialArea();
 }
 
 // ─── Accessors (called from hooks in sprite.c / player.c) ───

--- a/core/game-hooks/game_constants.h
+++ b/core/game-hooks/game_constants.h
@@ -14,6 +14,15 @@
 #define MODULE_MENU             14  // text / inventory / map overlay
 #define MODULE_SPOTLIGHT_CLOSE  15  // transient spotlight (iris closing)
 #define MODULE_SPOTLIGHT_OPEN   16  // transient spotlight (iris opening)
+#define MODULE_FALLING_ENTRANCE 11  // dungeon pit-fall transition — also reused, unchanged, by
+                                    // Overworld_CheckSpecialSwitchArea for the 3 vanilla overworld
+                                    // locations reached by walking onto a switch tile. Interactive
+                                    // gameplay resumes normally in that flavor even though the module
+                                    // never returns to 9 — see GameHook_IsOverworldSpecialArea, the only
+                                    // reliable way to tell it apart from an actual, non-interactive
+                                    // pit-fall into a dungeon room.
+#define OVERWORLD_SPECIAL_AREA_SCREEN_MIN 128  // overworld_screen_index floor for the flavor above —
+                                                // real overworld screens (light or dark world) are 0-127.
 
 // Sprite type ids referenced by hook branching logic.
 #define SPRITE_UNCLE_PRIEST     0x73  // Uncle (sprite_E == 0) / Priest family

--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -28,6 +28,16 @@ void GameHook_TriggerNpcCheck(uint8 flag_type, uint8 flag_mask, uint8 item_id,
 // event bit and grants the item.
 void GameHook_TriggerOverworldCheck(uint8 screen, uint8 mask, uint8 item_id);
 
+// ─── State Queries (state_queries.c) ───
+
+// True while main_module_index is MODULE_FALLING_ENTRANCE (11) via the vanilla
+// overworld special-switch-area path (one of 3 locked-view locations reached by
+// walking onto a switch tile) rather than an actual dungeon pit-fall. Both reuse the
+// same module; overworld_screen_index staying >= 128 is what's unique to the
+// special-area flavor. Anything gating on "is this normal interactive gameplay"
+// should treat this the same as MODULE_OVERWORLD.
+bool GameHook_IsOverworldSpecialArea(void);
+
 // ─── Cheats (cheats.c) ───
 
 // Returns the current outgoing damage multiplier (1 = normal).

--- a/core/game-hooks/state_queries.c
+++ b/core/game-hooks/state_queries.c
@@ -1,6 +1,12 @@
 /* @layer core-game-hooks @kind native */
 #include "game_hooks_internal.h"
 
+// ─── Overworld Special-Area Query ───
+
+bool GameHook_IsOverworldSpecialArea(void) {
+  return main_module_index == MODULE_FALLING_ENTRANCE && overworld_screen_index >= OVERWORLD_SPECIAL_AREA_SCREEN_MIN;
+}
+
 // ─── Inventory State Query ───
 
 static uint8 g_inventory_buf[40];
@@ -150,10 +156,15 @@ int WasmGetViewportInfo(void) {
   uint8 mod = main_module_index;
   if ((mod == MODULE_MENU || mod == MODULE_SPOTLIGHT_CLOSE || mod == MODULE_SPOTLIGHT_OPEN) &&
       saved_module_for_menu != 0) {
-    g_viewport_buf[9] = saved_module_for_menu;
-  } else {
-    g_viewport_buf[9] = mod;
+    mod = saved_module_for_menu;
   }
+  // The overworld-special-area flavor of MODULE_FALLING_ENTRANCE is normal outdoor
+  // gameplay — report it as such so consumers keyed on locationModule === MODULE_OVERWORLD
+  // (the edge-glow effect) still engage there.
+  if (mod == MODULE_FALLING_ENTRANCE && GameHook_IsOverworldSpecialArea()) {
+    mod = MODULE_OVERWORLD;
+  }
+  g_viewport_buf[9] = mod;
   // locationType: 0=overworld/other, 1=house/cave, 2=dungeon
   uint8 locMod = g_viewport_buf[9];
   g_viewport_buf[10] = (locMod == MODULE_DUNGEON) ? (cur_palace_index_x2 == 0xff ? 1 : 2) : 0;

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -13,6 +13,7 @@
 #include "util.h"
 #include "audio.h"
 #include "assets.h"
+#include "game_hooks.h"
 ZeldaEnv g_zenv;
 uint8 g_ram[131072];
 
@@ -265,7 +266,11 @@ static void ConfigurePpuSideSpace() {
   int mod = main_module_index;
   if (mod == 14)
     mod = saved_module_for_menu;
-  if (mod == 9) {
+  // The overworld-special-area flavor of MODULE_FALLING_ENTRANCE is normal interactive
+  // outdoor gameplay even though the module never returns to 9 — see
+  // GameHook_IsOverworldSpecialArea. Without this, the wide/tall PPU extension and camera
+  // lock never engage there and the view collapses to the base 256x224 frame.
+  if (mod == 9 || GameHook_IsOverworldSpecialArea()) {
     if (main_module_index == 14 && submodule_index == 7 && overworld_map_state >= 4) {
       // World map
       extra_left = kPpuExtraLeftRight, extra_right = kPpuExtraLeftRight;

--- a/scripts/hooks/sync-check/vault-check.mjs
+++ b/scripts/hooks/sync-check/vault-check.mjs
@@ -23,9 +23,14 @@
  * does not clear an inherited GIT_DIR — so without stripping it, git would ignore
  * the vault's own repo entirely and diff its files against the caller's index
  * instead, reporting every single file in the vault as modified.
+ *
+ * Scoped to relevance first, on top of that: a commit that doesn't touch any
+ * vault-managed path makes zero git calls into the vault and reports nothing, no
+ * matter what state the vault happens to be in — its own unrelated notes/exports
+ * are its business, not a reason to block work here.
  */
 import { execFileSync } from 'node:child_process';
-import { locateVault } from '../../vault/locate.mjs';
+import { locateVault, MANAGED_ROOTS } from '../../vault/locate.mjs';
 
 const GIT_ENV_OVERRIDES = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY', 'GIT_ALTERNATE_OBJECT_DIRECTORIES'];
 
@@ -43,8 +48,20 @@ const git = (dir, args) => {
   }
 };
 
+/** True when the commit about to land touches a path the vault mirrors. No -C — this
+ *  deliberately reads the calling repo's own staged diff, not the vault's. */
+const stagedTouchesVault = () => {
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { encoding: 'utf8' })
+    .split('\n').filter(Boolean);
+  return staged.some((f) => MANAGED_ROOTS.some((root) => f === root || f.startsWith(`${root}/`)));
+};
+
 /** @returns {{ status: 'unmanaged'|'clean'|'dirty', dir: string|null, files: string[], ahead: number }} */
 const checkVault = () => {
+  if (!stagedTouchesVault()) {
+    return { status: 'unmanaged', dir: null, files: [], ahead: 0 };
+  }
+
   const dir = locateVault();
   if (!dir || !git(dir, ['rev-parse', '--git-dir']).trim()) {
     return { status: 'unmanaged', dir: null, files: [], ahead: 0 };

--- a/scripts/parallel/commands/new.mjs
+++ b/scripts/parallel/commands/new.mjs
@@ -22,10 +22,25 @@ const NAME_RULE = /^[a-z0-9][a-z0-9-]{0,38}$/;
 
 /** Matches the app's own --instance validation: the name becomes a directory. */
 const assertName = (name) => {
-  if (!name) throw new Error('Usage: npm run wt -- new <name> [--from <ref>] [--no-build]');
+  if (!name) throw new Error('Usage: npm run wt -- new <name> [--from <ref>] [--rom <file>] [--quick-slot <N>] [--no-build]');
   if (!NAME_RULE.test(name)) {
     throw new Error(`"${name}" is not a valid name — lowercase letters, digits and dashes, max 39 chars.`);
   }
+};
+
+/**
+ * `--quick-slot` takes the human "Slot N" number shown in the save UI (1-based) and
+ * converts it to the 0-based index `--auto-state=<number>` and the quick-save files
+ * (`saveN.sav`) actually use — the same off-by-one every other slot reference in this
+ * project has to account for.
+ */
+const resolveQuickSlot = (raw) => {
+  if (raw == null) return null;
+  const human = Number(raw);
+  if (!Number.isInteger(human) || human < 1) {
+    throw new Error(`--quick-slot must be a slot number ≥ 1 (the number shown in the save UI), got "${raw}".`);
+  }
+  return human - 1;
 };
 
 const assertBranchFree = (branch) => {
@@ -64,13 +79,18 @@ const run = async ({ positional, options }) => {
   const build = await bootstrapWorktree({ worktree: path, skipBuild: flag(options, 'no-build') });
 
   console.log('\n[wt] Provisioning the game profile…');
-  const { romFile, savesCopied } = await provisionProfile({
+  const quickSlot = resolveQuickSlot(options['quick-slot']);
+  const { romFile, savesCopied, quickSaveCopied } = await provisionProfile({
     name,
     romFile: typeof options.rom === 'string' ? options.rom : null,
     inheritConfigFrom: typeof options.from_profile === 'string' ? options.from_profile : null,
+    quickSlot,
   });
   console.log(`  profile ${name} → ${romFile}`);
   console.log(`  ${savesCopied} named save state(s) copied — what --auto-state=<name> can load`);
+  if (quickSaveCopied) {
+    console.log(`  quick slot ${quickSlot} copied — load it with --auto-state=${quickSlot}`);
+  }
 
   await updateRegistry((registry) => {
     const record = createRecord({ name, path, branch, baseCommit });
@@ -88,7 +108,7 @@ const run = async ({ positional, options }) => {
 
 const command = {
   summary: 'Create a worktree, its branch and its profile (slow)',
-  usage: 'npm run wt -- new <name> [--from <ref>] [--rom <file>] [--no-build]',
+  usage: 'npm run wt -- new <name> [--from <ref>] [--rom <file>] [--quick-slot <N>] [--no-build]',
   run,
 };
 

--- a/scripts/parallel/provision-profile.mjs
+++ b/scripts/parallel/provision-profile.mjs
@@ -72,6 +72,20 @@ const defaultRom = () => {
 };
 
 /**
+ * A profile's `romFile` is just a filename, resolved against the shared `Data/roms/`
+ * folder at launch time. Inheriting that filename from another profile (the normal
+ * path) says nothing about whether the file is still there — it could have been
+ * renamed or removed since that profile last played. Failing here, with the exact
+ * filename and folder, beats the app failing later with an opaque "pick a ROM" prompt.
+ */
+const assertRomExists = (romFile) => {
+  const path = gameDataPath('roms', romFile);
+  if (!existsSync(path)) {
+    throw new Error(`ROM "${romFile}" is not in ${gameDataPath('roms')} — the file this profile inherited is missing.`);
+  }
+};
+
+/**
  * Copy the source profile's NAMED manual saves into the new profile.
  *
  * Without these, `--auto-state=test-jail-cell` has nothing to load and the app boots to
@@ -90,6 +104,27 @@ const copyManualSaves = (sourceId, name) => {
   if (!existsSync(from) || existsSync(to)) return 0;
   cpSync(from, to, { recursive: true });
   return readJson(join(to, 'manifest.json'), []).length;
+};
+
+/**
+ * Copy one quick-save slot (0-based, matching `--auto-state=<number>`) from the source
+ * profile into the new one, for reproducing a bug tied to a specific in-progress state.
+ * Quick slots are `saveN.sav`/`saveN.png` with no manifest — unlike manual saves, a
+ * quick slot has no stable name, so the caller must know which index holds the state.
+ */
+const copyQuickSave = (sourceId, name, slot) => {
+  if (!sourceId || slot == null) return false;
+  const fromDir = gameDataPath('profiles', sourceId, 'saves', 'quick');
+  const toDir = gameDataPath('profiles', name, 'saves', 'quick');
+  const savPath = join(fromDir, `save${slot}.sav`);
+  if (!existsSync(savPath)) {
+    throw new Error(`Quick slot ${slot} has no save${slot}.sav under ${fromDir} — nothing to copy.`);
+  }
+  mkdirSync(toDir, { recursive: true });
+  cpSync(savPath, join(toDir, `save${slot}.sav`));
+  const pngPath = join(fromDir, `save${slot}.png`);
+  if (existsSync(pngPath)) cpSync(pngPath, join(toDir, `save${slot}.png`));
+  return true;
 };
 
 const keyboardInputProfile = async (now) => {
@@ -112,7 +147,7 @@ const keyboardInputProfile = async (now) => {
  * its saves and is only topped up with anything missing, so re-running never destroys
  * an agent's state.
  */
-const provisionProfile = async ({ name, romFile, inheritConfigFrom }) => {
+const provisionProfile = async ({ name, romFile, inheritConfigFrom, quickSlot }) => {
   const now = Date.now();
   const dir = gameDataPath('profiles', name);
 
@@ -127,6 +162,7 @@ const provisionProfile = async ({ name, romFile, inheritConfigFrom }) => {
   const source = candidates.find((p) => p.id === inheritConfigFrom) ?? candidates[0] ?? null;
   const sourceConfig = source ? readJson(gameDataPath('profiles', source.id, 'config.json'), {}) : {};
   const rom = romFile ?? source?.romFile ?? defaultRom();
+  assertRomExists(rom);
 
   mkdirSync(join(dir, 'saves'), { recursive: true });
 
@@ -154,8 +190,9 @@ const provisionProfile = async ({ name, romFile, inheritConfigFrom }) => {
   }
 
   const savesCopied = copyManualSaves(source?.id ?? null, name);
+  const quickSaveCopied = quickSlot != null ? copyQuickSave(source?.id ?? null, name, quickSlot) : false;
 
-  return { dir, romFile: rom, inheritedFrom: source?.id ?? null, savesCopied };
+  return { dir, romFile: rom, inheritedFrom: source?.id ?? null, savesCopied, quickSaveCopied };
 };
 
 export { provisionProfile };


### PR DESCRIPTION
## Summary

- Root-caused the HUD-invisible / widescreen-collapses-to-4:3 / cheat-won't-apply
  bug reported for the overworld locations reached by walking onto a switch tile
  (issue #63 and related): `main_module_index` legitimately stays at 11
  (`MODULE_FALLING_ENTRANCE`, the dungeon pit-fall handler, reused unchanged for
  these 3 vanilla locations) the whole time the player is there, and three
  separate places only recognized module 9 as real gameplay. Added a single
  shared check, `GameHook_IsOverworldSpecialArea()`, keyed on
  `overworld_screen_index >= 128` (the reliable tell vs. an actual dungeon
  pit-fall), and wired it into the HUD mode derivation, the widescreen PPU-side
  extension, the cheat gameplay gate, and the edge-glow effect's location
  reporting.
- Fixed a real bug in the `sync-check` commit hook found while landing the fix
  above: it inherited `GIT_DIR`/`GIT_WORK_TREE` from the calling hook when
  querying the vault checkout with `git -C`, so it reported this repo's own
  modified files back as bogus "vault uncommitted changes." Also scoped it to
  only run when the commit actually touches a vault-managed path, instead of
  blocking on unrelated vault state.
- Added `--quick-slot <N>` to `wt new`, to hand a fresh agent profile the exact
  quick-save slot a bug was reported against.

## Test plan

- [x] Rebuilt the WASM core + renderer and reproduced the reported save state
      headlessly: before the fix, `mode=loading showMainSlot=false` and the
      screenshot showed a pillarboxed frame with no HUD; after, `mode=gameplay
      showMainSlot=true` and the screenshot shows full widescreen + complete HUD.
- [x] Confirmed movement is unaffected by the fix (linkX/linkY still update
      normally with input, both before and after).
- [x] Reproduced the sync-check false positive directly (env vars set by hand,
      outside of any commit) and confirmed it's silent after the fix; confirmed
      staging a file under a vault-managed path still engages the real check.
- [x] `npx eslint` clean on all changed JS/TS files.