### PR TITLE
Fix enhanced HUD inventory display and pause-menu item names

### DIFF
--- a/apps/web/src/lib/game/ui-bridge-parser.ts
+++ b/apps/web/src/lib/game/ui-bridge-parser.ts
@@ -166,6 +166,11 @@ const parseGameUIBuffer = (heap: Uint8Array, ptr: number): GameUIState => {
   const linkX = b[p + 121] | (b[p + 122] << 8);
   const linkY = b[p + 123] | (b[p + 124] << 8);
 
+  // Current resource caps (bytes 125–128)
+  const maxBombs = b[p + 125];
+  const maxArrows = b[p + 126];
+  const maxRupees = b[p + 127] | (b[p + 128] << 8);
+
   // Derive mode
   const mode = deriveUIMode(mainModule, subModule, subSubModule, floorTimer, overworldScreenIndex);
 
@@ -176,6 +181,7 @@ const parseGameUIBuffer = (heap: Uint8Array, ptr: number): GameUIState => {
     rupees, rupeeTarget, bombs, arrows, keys,
     equippedY, equippedX, equippedL, equippedR,
     heartsFiller, magicFiller, bombFiller, arrowFiller,
+    maxRupees, maxBombs, maxArrows,
   };
 
   const inventoryState: InventoryState = { items, bottles, order };

--- a/apps/web/src/stores/game-ui-store.ts
+++ b/apps/web/src/stores/game-ui-store.ts
@@ -20,6 +20,7 @@ const initialState: GameUIState = {
     rupees: 0, rupeeTarget: 0, bombs: 0, arrows: 0, keys: 0,
     equippedY: 0, equippedX: 0, equippedL: 0, equippedR: 0,
     heartsFiller: 0, magicFiller: 0, bombFiller: 0, arrowFiller: 0,
+    maxRupees: 999, maxBombs: 10, maxArrows: 30,
   },
   inventory: { items: Array(20).fill(0), bottles: [0, 0, 0, 0], order: Array(24).fill(0) },
   equipment: { sword: 0, shield: 0, armor: 0, gloves: 0, boots: 0, flippers: 0, moonPearl: 0, abilityFlags: 0, heartPieces: 0 },

--- a/apps/web/src/stores/hud-settings-store.ts
+++ b/apps/web/src/stores/hud-settings-store.ts
@@ -13,6 +13,7 @@ interface HudSettings {
   countLayout: 'centered' | 'original';
   pauseStyle: 'vanilla' | 'enhanced';
   pauseHighlight: 'box' | 'glow' | 'none';
+  showMaxInYellow: boolean;
 }
 
 interface HudSettingsStore extends HudSettings {
@@ -31,6 +32,7 @@ const useHudSettingsStore = create<HudSettingsStore>()((set) => ({
   countLayout: 'centered',
   pauseStyle: 'vanilla',
   pauseHighlight: 'box',
+  showMaxInYellow: false,
   setHudSettings: (patch) => set(patch),
 }));
 

--- a/apps/web/src/ui/domains/app/views/ProfileHub/behavior/apply-settings-effects.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/behavior/apply-settings-effects.ts
@@ -36,6 +36,7 @@ const syncHudStore = (s: GameSettings): void => {
     countLayout: s.hudCountLayout,
     pauseStyle: s.hudPauseStyle,
     pauseHighlight: s.hudPauseHighlight,
+    showMaxInYellow: s.showMaxItemsInYellow,
   });
 };
 

--- a/apps/web/src/ui/domains/hud/composites/HudCount/HudCount.tsx
+++ b/apps/web/src/ui/domains/hud/composites/HudCount/HudCount.tsx
@@ -10,6 +10,8 @@ interface HudCountProps {
   iconWidth?: number;
   value: number;
   digits?: number;
+  /** Renders the count in the "at max" yellow digit variant — see the "Indicate Max Resources" setting. */
+  isMax?: boolean;
   scale: number;
   spritesBase: string;
 }
@@ -19,7 +21,7 @@ interface HudCountProps {
  * Fully flex-driven — no absolute positioning.
  */
 const HudCount = (props: HudCountProps) => {
-  const { icon, iconWidth = 8, value, digits = 2, scale, spritesBase } = props;
+  const { icon, iconWidth = 8, value, digits = 2, isMax = false, scale, spritesBase } = props;
 
   const iconW = iconWidth * scale;
   const iconH = 8 * scale;
@@ -33,7 +35,7 @@ const HudCount = (props: HudCountProps) => {
         outline
         scale={scale}
       />
-      <HudNumber value={value} digits={digits} scale={scale} spritesBase={spritesBase} />
+      <HudNumber value={value} digits={digits} isMax={isMax} scale={scale} spritesBase={spritesBase} />
     </HudBox>
   );
 };

--- a/apps/web/src/ui/domains/hud/composites/HudCurrentItem/HudCurrentItem.tsx
+++ b/apps/web/src/ui/domains/hud/composites/HudCurrentItem/HudCurrentItem.tsx
@@ -1,35 +1,13 @@
 /* @layer renderer-hud @kind data */
 import { HudBox } from '../../primitives/HudBox';
 import { HudImage } from '../../primitives/HudImage';
-
-/**
- * Maps equippedY slot ID (1-20) to sprite filename.
- */
-const ITEM_SLOT_SPRITES: Record<number, string> = {
-  1: 'hud-bow',
-  2: 'hud-blue-boomerang',
-  3: 'hud-hookshot',
-  4: 'hud-bombs',
-  5: 'hud-mushroom',
-  6: 'hud-fire-rod',
-  7: 'hud-ice-rod',
-  8: 'hud-bombos',
-  9: 'hud-ether',
-  10: 'hud-quake',
-  11: 'hud-lamp',
-  12: 'hud-hammer',
-  13: 'hud-shovel',
-  14: 'hud-bug-net',
-  15: 'hud-book-of-mudora',
-  16: 'hud-bottle',
-  17: 'hud-cane-of-somaria',
-  18: 'hud-cane-of-byrna',
-  19: 'hud-cape',
-  20: 'hud-magic-mirror',
-};
+import { getSlotSprite } from '../PauseItemSlot';
 
 interface HudCurrentItemProps {
+  /** equippedY slot ID (1-20) */
   itemId: number;
+  /** The equipped slot's inventory value (upgrade tier) — see getSlotSprite. */
+  itemValue: number;
   scale: number;
   spritesBase: string;
 }
@@ -40,13 +18,13 @@ interface HudCurrentItemProps {
  * with a black interior and the 16×16 item sprite centered inside.
  */
 const HudCurrentItem = (props: HudCurrentItemProps) => {
-  const { itemId, scale, spritesBase } = props;
+  const { itemId, itemValue, scale, spritesBase } = props;
   const tile = 8 * scale;
 
   // Item box is 4×4 tiles (32×32 SNES px): 1-tile border + 2×2 interior
   const boxSize = 4 * tile;
 
-  const sprite = itemId > 0 ? ITEM_SLOT_SPRITES[itemId] : null;
+  const sprite = itemId > 0 ? getSlotSprite(itemId - 1, itemValue) : null;
 
   return (
     <HudBox style={{
@@ -116,5 +94,5 @@ const HudCurrentItem = (props: HudCurrentItemProps) => {
   );
 };
 
-export { HudCurrentItem, ITEM_SLOT_SPRITES };
+export { HudCurrentItem };
 export type { HudCurrentItemProps };

--- a/apps/web/src/ui/domains/hud/compounds/PauseNamePanel/PauseNamePanel.tsx
+++ b/apps/web/src/ui/domains/hud/compounds/PauseNamePanel/PauseNamePanel.tsx
@@ -11,7 +11,7 @@ import { HudImage } from '../../primitives/HudImage';
 import { PauseBorderBox } from '../../primitives/PauseBorderBox';
 
 interface PauseNamePanelProps {
-  itemName: string;
+  itemName: string | string[];
   itemSprite: string | null;
   borderColor?: 'green' | 'blue' | 'gray' | 'yellow' | 'red';
   scale: number;
@@ -19,21 +19,70 @@ interface PauseNamePanelProps {
   style?: React.CSSProperties;
 }
 
+/** '&' is drawn across 2 native tiles in the ROM's own font data, so its sprite is twice as wide as every other glyph. */
+const AMPERSAND_COLS = 2;
+
+const Glyph = ({ char, size, spritesBase }: { char: string; size: number; spritesBase: string }) => {
+  if (char === ' ') return <HudBox style={{ width: size, height: size }} />;
+  if (char === '&') {
+    return (
+      <HudImage
+        src={`${spritesBase}font-symbol-ampersand.png`}
+        width={size * AMPERSAND_COLS}
+        height={size}
+        style={{ display: 'block', imageRendering: 'pixelated' }}
+      />
+    );
+  }
+  const code = char.toUpperCase();
+  const isLetter = /[A-Z]/.test(code);
+  const isDigit = /[0-9]/.test(code);
+  if (!isLetter && !isDigit) return <HudBox style={{ width: size, height: size }} />;
+
+  const prefix = isDigit ? 'font-digit' : 'font-letter';
+  const suffix = isDigit ? code : code.toLowerCase();
+
+  return (
+    <HudImage
+      src={`${spritesBase}${prefix}-${suffix}.png`}
+      width={size}
+      height={size}
+      style={{ display: 'block', imageRendering: 'pixelated' }}
+    />
+  );
+};
+
+/** Renders one name line at the shared glyph size computed for the whole name (see PauseNamePanel). */
+const NameLine = ({ line, glyphSize, spritesBase }: { line: string; glyphSize: number; spritesBase: string }) => (
+  <HudBox style={{ display: 'flex' }}>
+    {line.split('').map((char, idx) => (
+      <Glyph key={idx} char={char} size={glyphSize} spritesBase={spritesBase} />
+    ))}
+  </HudBox>
+);
+
 const PauseNamePanel = ({ itemName, itemSprite, borderColor = 'green', scale, spritesBase, style }: PauseNamePanelProps) => {
   const tile = 8 * scale;
   // Box: 8 inner cols × 4 inner rows (+ 2 border = 10×6)
   const innerCols = 8;
   const innerRows = 4;
+  const lines = Array.isArray(itemName) ? itemName : [itemName];
+  // One shared size for every line in the name — a name's line break is hand-placed (see
+  // getItemNameForSlot), not computed per line, so all its lines read at the same scale.
+  // '&' counts as 2 columns (see AMPERSAND_COLS) since its sprite is double-width.
+  const lineWidth = (line: string): number =>
+    line.split('').reduce((cols, char) => cols + (char === '&' ? AMPERSAND_COLS : 1), 0);
+  const longestLine = Math.max(...lines.map(lineWidth));
+  const glyphSize = longestLine > innerCols ? (tile * innerCols) / longestLine : tile;
 
   return (
     <PauseBorderBox color={borderColor} cols={innerCols} rows={innerRows} scale={scale} spritesBase={spritesBase} style={style}>
-      {/* Item icon + name */}
+      {/* Item icon + name — packed directly together, matching the original's fixed 2-row icon + 2-row name layout */}
       <HudBox style={{
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'flex-start',
         width: innerCols * tile,
-        gap: `${tile}px`,
       }}>
         {/* Item icon (16×16 SNES pixels) */}
         {itemSprite && (
@@ -45,34 +94,17 @@ const PauseNamePanel = ({ itemName, itemSprite, borderColor = 'green', scale, sp
           />
         )}
 
-        {/* Item name rendered as font sprites */}
+        {/* Item name rendered as font sprites, one explicit line per row, bottom-aligned within the reserved 2-row area */}
         <HudBox style={{
           display: 'flex',
-          flexWrap: 'wrap',
-          justifyContent: 'flex-start',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+          height: tile * 2,
+          overflow: 'hidden',
         }}>
-          {itemName.split('').map((char, idx) => {
-            if (char === ' ') {
-              return <HudBox key={idx} style={{ width: tile, height: tile }} />;
-            }
-            const code = char.toUpperCase();
-            const isLetter = /[A-Z]/.test(code);
-            const isDigit = /[0-9]/.test(code);
-            if (!isLetter && !isDigit) return <HudBox key={idx} style={{ width: tile, height: tile }} />;
-
-            const prefix = isDigit ? 'font-digit' : 'font-letter';
-            const suffix = isDigit ? code : code.toLowerCase();
-
-            return (
-              <HudImage
-                key={idx}
-                src={`${spritesBase}${prefix}-${suffix}.png`}
-                width={tile}
-                height={tile}
-                style={{ display: 'block', imageRendering: 'pixelated' }}
-              />
-            );
-          })}
+          {lines.map((line, idx) => (
+            <NameLine key={idx} line={line} glyphSize={glyphSize} spritesBase={spritesBase} />
+          ))}
         </HudBox>
       </HudBox>
     </PauseBorderBox>

--- a/apps/web/src/ui/domains/hud/hooks/useHud.ts
+++ b/apps/web/src/ui/domains/hud/hooks/useHud.ts
@@ -22,6 +22,12 @@ interface HudData {
   arrows: number;
   keys: number;
   equippedY: number;
+  /** 20 item slots (inventory.items) — used to pick the equipped item's upgrade-tier sprite. */
+  items: number[];
+  /** Current resource caps — the max a counter can reach right now (accounts for upgrades/settings). */
+  maxRupees: number;
+  maxBombs: number;
+  maxArrows: number;
 }
 
 interface HudConfig {
@@ -39,6 +45,7 @@ interface UseHudResult {
 
 const useHud = (scale: number): UseHudResult => {
   const hud = useGameUIStore((s) => s.hud);
+  const items = useGameUIStore((s) => s.inventory.items);
   const spritesBase = getSpritesBase();
 
   const data: HudData = {
@@ -51,6 +58,10 @@ const useHud = (scale: number): UseHudResult => {
     arrows: hud.arrows,
     keys: hud.keys,
     equippedY: hud.equippedY,
+    items,
+    maxRupees: hud.maxRupees,
+    maxBombs: hud.maxBombs,
+    maxArrows: hud.maxArrows,
   };
 
   const config: HudConfig = { scale, spritesBase };

--- a/apps/web/src/ui/domains/hud/primitives/HudNumber/HudNumber.tsx
+++ b/apps/web/src/ui/domains/hud/primitives/HudNumber/HudNumber.tsx
@@ -7,26 +7,30 @@ const digitShadowFilter = (s: number): string => {
 interface HudNumberProps {
   value: number;
   digits?: number;
+  /** Renders with the "at max" yellow digit variant instead of white — see the "Indicate Max Resources" setting. */
+  isMax?: boolean;
   scale: number;
   spritesBase: string;
 }
 
 const HudNumber = (props: HudNumberProps) => {
-  const { value, digits = 3, scale, spritesBase } = props;
+  const { value, digits = 3, isMax = false, scale, spritesBase } = props;
 
-  const str = Math.min(Math.max(0, value), 999)
+  const max = 10 ** digits - 1;
+  const str = Math.min(Math.max(0, value), max)
     .toString()
     .padStart(digits, '0');
 
   const tile = 8 * scale;
   const shadow = scale;
+  const suffix = isMax ? '-yellow' : '';
 
   return (
     <div style={{ display: 'flex', alignItems: 'center' }}>
       {str.split('').map((d, i) => (
         <img
           key={i}
-          src={`${spritesBase}font-digit-${d}.png`}
+          src={`${spritesBase}font-digit-${d}${suffix}.png`}
           height={tile}
           draggable={false}
           style={{

--- a/apps/web/src/ui/domains/hud/views/HudView/HudView.tsx
+++ b/apps/web/src/ui/domains/hud/views/HudView/HudView.tsx
@@ -10,7 +10,7 @@ import { useRef, useEffect, useState, useCallback } from 'react';
 import { aspectRatioValue } from '@app/lib/game/aspect-ratio';
 
 const HudView = ({ slideTransform, slideTransition }: { slideTransform?: string; slideTransition?: string } = {}) => {
-  const { heartMode, magicMode, countLayout, ratio: hudRatio, customW, customH } = useHudSettingsStore();
+  const { heartMode, magicMode, countLayout, ratio: hudRatio, customW, customH, showMaxInYellow } = useHudSettingsStore();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(2);
@@ -57,12 +57,28 @@ const HudView = ({ slideTransform, slideTransition }: { slideTransform?: string;
 
   // Keys: game uses 0xFF (255) to indicate "no key display"
   const showKeys = data.keys !== 255 && data.keys !== 0xFF;
+  // Rupee counter needs a 4th digit once the "Larger Wallet" cap raises it past 999.
+  const rupeeDigits = data.maxRupees > 999 ? 4 : 3;
+  // Bow value >= 3 means Silver Arrows have been obtained — mirrors hud.c's Hud_Update_Inventory.
+  const hasSilverArrows = data.items[0] >= 3;
 
   const counts = (
     <>
-      <HudCount icon="hud-rupee-icon" iconWidth={8} value={data.rupees} digits={3} scale={scale} spritesBase={spritesBase} />
-      <HudCount icon="hud-bomb-icon" iconWidth={16} value={data.bombs} digits={2} scale={scale} spritesBase={spritesBase} />
-      <HudCount icon="hud-arrow-icon" iconWidth={16} value={data.arrows} digits={2} scale={scale} spritesBase={spritesBase} />
+      <HudCount
+        icon="hud-rupee-icon" iconWidth={8} value={data.rupees} digits={rupeeDigits}
+        isMax={showMaxInYellow && data.rupees === data.maxRupees}
+        scale={scale} spritesBase={spritesBase}
+      />
+      <HudCount
+        icon="hud-bomb-icon" iconWidth={16} value={data.bombs} digits={2}
+        isMax={showMaxInYellow && data.bombs === data.maxBombs}
+        scale={scale} spritesBase={spritesBase}
+      />
+      <HudCount
+        icon={hasSilverArrows ? 'hud-silver-arrow-icon' : 'hud-arrow-icon'} iconWidth={16} value={data.arrows} digits={2}
+        isMax={showMaxInYellow && data.arrows === data.maxArrows}
+        scale={scale} spritesBase={spritesBase}
+      />
       {showKeys && (
         <HudCount icon="hud-key-icon" iconWidth={8} value={data.keys} digits={1} scale={scale} spritesBase={spritesBase} />
       )}
@@ -104,6 +120,7 @@ const HudView = ({ slideTransform, slideTransition }: { slideTransform?: string;
             <HudBox style={{ marginLeft: -tile }}>
               <HudCurrentItem
                 itemId={data.equippedY}
+                itemValue={data.equippedY > 0 ? data.items[data.equippedY - 1] ?? 0 : 0}
                 scale={scale}
                 spritesBase={spritesBase}
               />

--- a/apps/web/src/ui/domains/hud/views/PauseMenuView/PauseMenuView.tsx
+++ b/apps/web/src/ui/domains/hud/views/PauseMenuView/PauseMenuView.tsx
@@ -46,21 +46,21 @@ const BOTTLE_CONTENT_NAMES: Record<number, string> = {
 const GRID_TO_SAVE = [0, 3, 2, 14, 1, 10, 5, 6, 15, 16, 17, 9, 4, 8, 7, 12, 11, 18, 13, 19];
 
 /** Item names indexed by save-RAM slot (0-19) */
-const SAVE_SLOT_NAMES = [
-  'BOW', 'BOOMERANG', 'HOOKSHOT', 'BOMBS', 'MUSHROOM',
+const SAVE_SLOT_NAMES: (string | string[])[] = [
+  'BOW', 'BOOMERANG', 'HOOKSHOT', 'BOMB', 'MUSHROOM',
   'FIRE ROD', 'ICE ROD', 'BOMBOS', 'ETHER', 'QUAKE',
-  'LAMP', 'HAMMER', 'SHOVEL', 'BUG NET', 'BOOK',
-  'BOTTLE', 'SOMARIA', 'BYRNA', 'CAPE', 'MIRROR',
+  'LAMP', ['MAGIC', 'HAMMER'], 'SHOVEL', 'BUG NET', ['BOOK OF', 'MUDORA'],
+  'BOTTLE', ['CANE OF', 'SOMARIA'], ['CANE OF', 'BYRNA'], ['MAGIC', 'CAPE'], ['MAGIC', 'MIRROR'],
 ];
 
-const getItemNameForSlot = (saveIdx: number, items: number[]): string => {
+const getItemNameForSlot = (saveIdx: number, items: number[]): string | string[] => {
   if (saveIdx < 0 || saveIdx >= 20) return '';
   const value = items[saveIdx];
   if (!value) return '';
-  // Upgrade variants
-  if (saveIdx === 0 && value >= 2) return 'SILVER BOW';
-  if (saveIdx === 1 && value >= 2) return 'MAGIC BOOM';
-  if (saveIdx === 4 && value >= 2) return 'POWDER';
+  // Upgrade variants — the boomerang has no separate upgrade-tier name (only its icon
+  // color changes), so it always falls through to the base SAVE_SLOT_NAMES entry.
+  if (saveIdx === 0 && value >= 4) return ['BOW &', 'SILVER ARROWS'];
+  if (saveIdx === 4 && value >= 2) return ['MAGIC', 'POWDER'];
   if (saveIdx === 12 && value >= 2) return 'FLUTE';
   if (saveIdx === 12 && value === 1) return 'SHOVEL';
   return SAVE_SLOT_NAMES[saveIdx];

--- a/apps/web/src/ui/domains/widgets/cheats/tabs/StatsTab.tsx
+++ b/apps/web/src/ui/domains/widgets/cheats/tabs/StatsTab.tsx
@@ -8,13 +8,16 @@ import {
   cheatSetHealth, cheatSetMaxHealth, cheatSetRupees,
   cheatSetBombs, cheatSetArrows, cheatRefillMagic,
 } from '../../../../../lib/game';
+import { useGameUIStore } from '../../../../../stores/game-ui-store';
 
 const StatsTab = () => {
+  const { maxRupees, maxBombs, maxArrows } = useGameUIStore(s => s.hud);
+
   const [health, setHealth] = useState(160);
   const [maxHealth, setMaxHealth] = useState(160);
-  const [rupees, setRupees] = useState(999);
-  const [bombs, setBombs] = useState(99);
-  const [arrows, setArrows] = useState(99);
+  const [rupees, setRupees] = useState(maxRupees);
+  const [bombs, setBombs] = useState(maxBombs);
+  const [arrows, setArrows] = useState(maxArrows);
 
   return (
     <Box className="cheats-tab-stats">
@@ -24,16 +27,16 @@ const StatsTab = () => {
           <Button variant="secondary" size="sm" onClick={() => { cheatSetHealth(160); cheatSetMaxHealth(160); }}>
             Full Heal (20♥)
           </Button>
-          <Button variant="secondary" size="sm" onClick={() => cheatSetRupees(999)}>
-            999 Rupees
+          <Button variant="secondary" size="sm" onClick={() => cheatSetRupees(maxRupees)}>
+            Max Rupees ({maxRupees})
           </Button>
           <Button variant="secondary" size="sm" onClick={() => cheatRefillMagic()}>
             Fill Magic
           </Button>
         </Box>
         <Box className="cheats-row">
-          <Button variant="tertiary" size="sm" onClick={() => { cheatSetBombs(99); cheatSetArrows(99); }}>
-            Max Bombs & Arrows
+          <Button variant="tertiary" size="sm" onClick={() => { cheatSetBombs(maxBombs); cheatSetArrows(maxArrows); }}>
+            Max Bombs & Arrows ({maxBombs}/{maxArrows})
           </Button>
           <Button variant="danger" size="sm" onClick={() => cheatSetHealth(8)}>
             Set 1♥
@@ -79,8 +82,8 @@ const StatsTab = () => {
           <Box className="cheats-row__controls">
             <NumberInput
               className="cheats-input"
-              min={0} max={999} value={rupees}
-              onChange={v => setRupees(Math.min(999, Math.max(0, v)))}
+              min={0} max={maxRupees} value={rupees}
+              onChange={v => setRupees(Math.min(maxRupees, Math.max(0, v)))}
             />
             <Button variant="tertiary" size="sm" onClick={() => cheatSetRupees(rupees)}>Set</Button>
           </Box>
@@ -90,8 +93,8 @@ const StatsTab = () => {
           <Box className="cheats-row__controls">
             <NumberInput
               className="cheats-input"
-              min={0} max={99} value={bombs}
-              onChange={v => setBombs(Math.min(99, Math.max(0, v)))}
+              min={0} max={maxBombs} value={bombs}
+              onChange={v => setBombs(Math.min(maxBombs, Math.max(0, v)))}
             />
             <Button variant="tertiary" size="sm" onClick={() => cheatSetBombs(bombs)}>Set</Button>
           </Box>
@@ -101,8 +104,8 @@ const StatsTab = () => {
           <Box className="cheats-row__controls">
             <NumberInput
               className="cheats-input"
-              min={0} max={99} value={arrows}
-              onChange={v => setArrows(Math.min(99, Math.max(0, v)))}
+              min={0} max={maxArrows} value={arrows}
+              onChange={v => setArrows(Math.min(maxArrows, Math.max(0, v)))}
             />
             <Button variant="tertiary" size="sm" onClick={() => cheatSetArrows(arrows)}>Set</Button>
           </Box>

--- a/core/game-hooks/cheats.c
+++ b/core/game-hooks/cheats.c
@@ -99,7 +99,10 @@ void WasmCheatSetMaxHealth(int value) {
 // Set rupee goal (game animates counter toward this value).
 EMSCRIPTEN_KEEPALIVE
 void WasmCheatSetRupees(int value) {
-  uint16 capped = (uint16)clampi(value, 0, 999);
+  // Cap tracks the real current max — 9999 with the "Larger Wallet" feature on, 999 otherwise —
+  // same condition as hud.c's MaxRupees() (that helper has internal linkage, so duplicated here).
+  int max = (enhanced_features0 & kFeatures0_CarryMoreRupees) ? 9999 : 999;
+  uint16 capped = (uint16)clampi(value, 0, max);
   link_rupees_goal = capped;
   printf("[Cheat] SetRupees: %d\n", capped);
 }

--- a/core/game-hooks/ui_state.c
+++ b/core/game-hooks/ui_state.c
@@ -139,6 +139,13 @@ int WasmGetGameUIState(void) {
   PutU16(b, 121, link_x_coord);
   PutU16(b, 123, link_y_coord);
 
+  // ─── Bytes 125–128: Current Resource Caps (for "indicate max resources") ───
+  // Rupee cap mirrors hud.c's static MaxRupees() — duplicated here since that helper has internal
+  // linkage; the underlying condition (enhanced_features0 & kFeatures0_CarryMoreRupees) is the same.
+  b[125] = kMaxBombsForLevel[link_bomb_upgrades];
+  b[126] = kMaxArrowsForLevel[link_arrow_upgrades];
+  PutU16(b, 127, (enhanced_features0 & kFeatures0_CarryMoreRupees) ? 9999 : 999);
+
   return (int)g_ui_state_buf;
 }
 

--- a/shared/game/types/game-state.ts
+++ b/shared/game/types/game-state.ts
@@ -32,6 +32,10 @@ interface HUDState {
   magicFiller: number;
   bombFiller: number;
   arrowFiller: number;
+  /** Current resource caps — the max a counter can reach right now (accounts for upgrades/settings). */
+  maxRupees: number;
+  maxBombs: number;
+  maxArrows: number;
 }
 
 interface InventoryState {


### PR DESCRIPTION
## Summary
- Pause-menu item name panel: fixed mid-word wrapping, text overflow past the box border, and corrected several item names to match the real game (decoded directly from the ROM's HUD font data). Closes #60, closes #61.
- Gameplay HUD arrow-count icon now swaps to the silver-arrow variant once Silver Arrows are obtained. Closes #56.
- Gameplay HUD equipped-item icon now reflects the item's real upgrade tier (e.g. Boomerang color) instead of always showing the base sprite. Closes #62.
- "Indicate Max Resources" now works in the enhanced HUD too — added a small WASM export exposing the real current caps for rupees/bombs/arrows (upgrade- and setting-aware), used for both the max-yellow indicator and the rupee counter's digit count above 999. Closes #58, closes #59.
- Cheat widget's "max" quick actions and manual Set-field bounds now read those same live caps instead of hardcoded values that could over- or under-shoot the real max.

## Test plan
- [x] Verified live in the built app via Playwright-driven checks (bow + silver arrows name display, boomerang icon upgrade, silver-arrow HUD icon, max-yellow indicator on bombs/arrows/rupees, rupee counter above 999)
- [x] `tsc --noEmit` and `eslint` clean on all changed files
- [x] WASM core rebuilt and copyright gate passed on commit