### PR TITLE
fix(worldmap): map/flute markers shifted left in widescreen

### DIFF
--- a/core/zelda3/src/messaging.c
+++ b/core/zelda3/src/messaging.c
@@ -1507,7 +1507,12 @@ static void WorldMap_AddSprite(int spr, uint8 big, uint8 flags, uint8 ch, uint16
   }
   if (enhanced_features0 & kFeatures0_ExtendScreen64)
     big |= (x >> 8 & 1);
-  SetOamPlain(&oam_buf[spr], x, y, ch, flags, big);
+  // OamSetX (not SetOamPlain) so g_oam_x_high carries this sprite's true X when a wide view is active.
+  OamSetX(&oam_buf[spr], x);
+  oam_buf[spr].y = y;
+  oam_buf[spr].charnum = ch;
+  oam_buf[spr].flags = flags;
+  bytewise_extended_oam[spr] = big;
 }
 
 bool OverworldMap_CheckForPendant(int k) {  // 8ac5a9


### PR DESCRIPTION
## Summary
- `WorldMap_AddSprite` (pause map, flute-travel destination screen) placed markers via `SetOamPlain`, which never populates `g_oam_x_high`
- In a wide view the PPU trusts that array for a sprite's true X, so every marker (and the flute cursor) rendered shifted left, or outside the visible range entirely
- Routes through `OamSetX` instead, same fix shape as the desert-boss widescreen fix (#39)

Fixes #54.

## Test plan
- [ ] Load a save in 16:9 (or any non-4:3 ratio), open the pause map and the flute-travel screen, confirm markers land in the correct spot
- [ ] Confirm the flute cursor no longer disappears at any of the 8 destinations
- [ ] Spot-check 4:3 is unchanged