### PR TITLE
feat(instance): visible named instances + automation profile metadata + UI badge

### DIFF
--- a/apps/desktop/electron/instance/automation-launch.ts
+++ b/apps/desktop/electron/instance/automation-launch.ts
@@ -37,4 +37,16 @@ const isAutomationLaunch = (): boolean =>
     AUTOMATION_FLAGS.some((flag) => arg === flag || arg.startsWith(`${flag}=`)),
   );
 
-export { AUTOMATION_FLAGS, isAutomationLaunch };
+// Flags that mean "run with no human watching" — everything in AUTOMATION_FLAGS except
+// --instance/--profile, which only select an identity/profile and say nothing about
+// whether anyone is meant to see the window. A bare `--instance=NAME` launch (the
+// collaborative-testing case: a tagged, independent, but human-usable window) must stay
+// visible; `--instance=NAME --no-focus` (a real automated run) must still go headless.
+const HEADLESS_FLAGS = AUTOMATION_FLAGS.filter((flag) => flag !== '--instance' && flag !== '--profile');
+
+const isHeadlessLaunch = (): boolean =>
+  process.argv.some((arg) =>
+    HEADLESS_FLAGS.some((flag) => arg === flag || arg.startsWith(`${flag}=`)),
+  );
+
+export { AUTOMATION_FLAGS, HEADLESS_FLAGS, isAutomationLaunch, isHeadlessLaunch };

--- a/apps/desktop/electron/instance/index.ts
+++ b/apps/desktop/electron/instance/index.ts
@@ -1,5 +1,5 @@
 /* @layer electron-main @kind barrel */
 export { isInstanceLaunch, parseInstanceConfig } from './instance-config';
 export { applyInstanceIdentity } from './instance-identity';
-export { AUTOMATION_FLAGS, isAutomationLaunch } from './automation-launch';
+export { AUTOMATION_FLAGS, HEADLESS_FLAGS, isAutomationLaunch, isHeadlessLaunch } from './automation-launch';
 export type { InstanceConfig } from './instance-config';

--- a/apps/desktop/electron/window/create-window.ts
+++ b/apps/desktop/electron/window/create-window.ts
@@ -8,7 +8,7 @@ import { keepWindowInBackground } from './keep-in-background';
 import { attachTextInteraction } from './text-interaction';
 import { resolveWindowIcon } from './window-icon';
 import { armReveal, openSplash } from './boot';
-import { isAutomationLaunch, parseInstanceConfig } from '../instance';
+import { isHeadlessLaunch, parseInstanceConfig } from '../instance';
 
 const APP_TITLE = 'Relic of the Past';
 
@@ -45,7 +45,7 @@ const offscreenOrigin = (): { x: number; y: number } => {
 };
 
 const createWindow = (): BrowserWindow => {
-  const noFocus = isAutomationLaunch();
+  const noFocus = isHeadlessLaunch();
   const startup = parseStartupConfig();
   const instance = parseInstanceConfig();
   const saved = loadWindowState();
@@ -169,7 +169,7 @@ const createWindow = (): BrowserWindow => {
   // --muted is documented as mandatory alongside --no-focus for every automated
   // launch (docs/contributing/testing.md); enforced the same way so forgetting the
   // literal flag doesn't leave a headless run making noise.
-  if (process.argv.includes('--muted') || isAutomationLaunch()) {
+  if (process.argv.includes('--muted') || isHeadlessLaunch()) {
     mainWindow.webContents.setAudioMuted(true);
   }
 

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -92,6 +92,7 @@ interface Profile {
   lastPlayed: number;
   language?: string;
   msuPack?: string;
+  automation?: boolean;
 }
 
 interface AppState {

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/ProfileManager.tsx
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/ProfileManager.tsx
@@ -5,6 +5,7 @@
 
 import { Box } from '../../../../../design-system/primitives/Box';
 import { Text } from '../../../../../design-system/primitives/Text';
+import { Badge } from '../../../../../design-system/primitives/Badge';
 import { Button } from '../../../../../design-system/primitives/Button';
 import { IconButton } from '../../../../../design-system/primitives/IconButton';
 import { Select } from '../../../../../design-system/primitives/Select';
@@ -102,7 +103,12 @@ const ProfileManager = (props: ProfileManagerProps) => {
           <ListItemRow
             key={profile.id}
             icon="👤"
-            name={profile.name}
+            name={
+              <>
+                {profile.name}
+                {profile.automation && <Badge variant="neutral">Agent</Badge>}
+              </>
+            }
             meta={`${profile.romFile.replace(/\.(sfc|smc)$/i, '')} · ${formatRelativeTime(profile.lastPlayed)}`}
             selected={selected === profile.id}
             onClick={() => setSelected(profile.id)}

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/ProfileDetailPanel.tsx
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/ProfileDetailPanel.tsx
@@ -6,6 +6,7 @@
 import type { CSSProperties } from 'react';
 import { Box } from '../../../../../../design-system/primitives/Box';
 import { Text } from '../../../../../../design-system/primitives/Text';
+import { Badge } from '../../../../../../design-system/primitives/Badge';
 import { Select } from '../../../../../../design-system/primitives/Select';
 import { Button } from '../../../../../../design-system/primitives/Button';
 import { formatRelativeTime } from '../../../../../../../utils';
@@ -35,7 +36,10 @@ const ProfileDetailPanel = (props: ProfileDetailPanelProps) => {
 
   return (
     <Box style={IL.col}>
-      <Text as="h3" className="detail-panel__title">{profile.name}</Text>
+      <Text as="h3" className="detail-panel__title">
+        {profile.name}
+        {profile.automation && <Badge variant="neutral">Agent</Badge>}
+      </Text>
 
       <Box className="profile-form" style={IL.mbMd}>
         <Box className="profile-form__field">

--- a/apps/web/src/ui/domains/app/views/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfilePage/ProfilePage.tsx
@@ -22,7 +22,10 @@ const ProfilePage = (props: ProfilePageProps) => {
   return (
     <Box className="profile-page">
       <Box className="profile-page__header">
-        <Text as="h2" className="profile-page__name">{profile.name}</Text>
+        <Text as="h2" className="profile-page__name">
+          {profile.name}
+          {profile.automation && <Badge variant="neutral">Agent</Badge>}
+        </Text>
         <Text className="profile-page__rom">{formatRomName(profile.romFile)}</Text>
       </Box>
 

--- a/scripts/parallel/commands/clean.mjs
+++ b/scripts/parallel/commands/clean.mjs
@@ -12,7 +12,7 @@
  * Removing a worktree also removes its game profile, and with it that profile's save
  * states. The user's own profiles are never candidates — only ids in the registry.
  */
-import { rmSync, existsSync } from 'node:fs';
+import { rmSync, existsSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { updateRegistry } from '../registry.mjs';
 import { surveyAll } from '../survey.mjs';
@@ -87,8 +87,27 @@ const removeWorktree = (record) => {
     console.warn(`  [wt] Branch ${record.branch} was left in place (delete it by hand if unwanted).`);
   }
 
-  // The profile id is the worktree name, so this only ever touches an agent profile.
-  rmSync(gameDataPath('profiles', record.name), { recursive: true, force: true });
+  // The profile id is the worktree name, so this only ever touches an agent profile — but
+  // that's an inference from the registry, not a fact about the profile itself. Belt and
+  // suspenders: a profile explicitly stamped automation:false (a real profile that happens
+  // to share a worktree's name) is refused outright. A profile with no `automation` field
+  // at all predates this marker, so it's still trusted the old way — only an EXPLICIT false
+  // blocks the delete; missing or true both proceed.
+  const profileDir = gameDataPath('profiles', record.name);
+  const profilePath = `${profileDir}/profile.json`;
+  if (existsSync(profilePath)) {
+    let automation;
+    try {
+      automation = JSON.parse(readFileSync(profilePath, 'utf8')).automation;
+    } catch {
+      automation = undefined;
+    }
+    if (automation === false) {
+      console.warn(`  [wt] Profile at ${profileDir} is explicitly marked automation:false — refusing to delete it.`);
+      return;
+    }
+  }
+  rmSync(profileDir, { recursive: true, force: true });
 };
 
 const run = async ({ positional, options }) => {

--- a/scripts/parallel/provision-profile.mjs
+++ b/scripts/parallel/provision-profile.mjs
@@ -168,7 +168,7 @@ const provisionProfile = async ({ name, romFile, inheritConfigFrom, quickSlot })
 
   const profilePath = join(dir, 'profile.json');
   if (!existsSync(profilePath)) {
-    const profile = { id: name, name: `agent/${name}`, romFile: rom, created: now, lastPlayed: now };
+    const profile = { id: name, name: `agent/${name}`, romFile: rom, created: now, lastPlayed: now, automation: true };
     // Language is per-profile and picks which asset blob loads; inherit it so an agent
     // run renders the same text the user sees.
     if (source?.language) profile.language = source.language;

--- a/shared/types/profile.ts
+++ b/shared/types/profile.ts
@@ -7,6 +7,7 @@ interface Profile {
   lastPlayed: number;
   language?: string;   // language code (e.g. 'en', 'de', 'fr')
   msuPack?: string;    // MSU pack directory name
+  automation?: boolean; // created by `wt new` for a named instance, not a person — safe to prune
 }
 
 interface AppState {


### PR DESCRIPTION
## Summary
- A named instance (`--instance=NAME`) was unconditionally headless, since `--instance` itself was in `AUTOMATION_FLAGS`. There was no way to get a tagged, independent instance that's actually visible for collaborative testing.
- Split off a narrower `isHeadlessLaunch` (excludes `--instance`/`--profile`) from the existing `isAutomationLaunch` (still used for the write-restriction guards, unchanged). A bare `--instance=NAME` launch is now visible/focusable/audible; any real automation flag (`--no-focus` included) still goes fully headless. `wt launch`'s helper always pairs `--instance` with `--no-focus --muted`, so its default behavior doesn't change.
- `provisionProfile` now stamps `automation: true` on profiles it creates. `wt clean` refuses to delete a profile only when it's explicitly stamped `automation: false` (a real profile that happens to share a worktree's name) — missing or `true` still deletes exactly as before, so no existing profile's cleanup changes.
- Added an "Agent" badge next to the profile name wherever a profile is shown to a person (profile list, detail panel, profile home page), shown only when `automation` is true.

## Test plan
- [ ] Typecheck: `npx tsc --noEmit` (clean, verified)
- [ ] Build: `npm run build` (verified)
- [ ] `npm run wt -- new <name>` still creates a usable profile; `wt clean` still removes it
- [ ] `--instance=<name>` with no other flags opens a visible, focused, audible window titled `Relic of the Past — <name>` (verified: real on-screen position, no terminal spawned)
- [ ] A profile with `automation: true` shows the "Agent" badge in the profile list/detail/home screens; one without does not