### PR TITLE
Fix the widescreen rendering faults in the overworld special-switch areas

### DIFF
--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -30,12 +30,19 @@ void GameHook_TriggerOverworldCheck(uint8 screen, uint8 mask, uint8 item_id);
 
 // ─── State Queries (state_queries.c) ───
 
-// True while main_module_index is MODULE_FALLING_ENTRANCE (11) via the vanilla
-// overworld special-switch-area path (one of 3 locked-view locations reached by
-// walking onto a switch tile) rather than an actual dungeon pit-fall. Both reuse the
-// same module; overworld_screen_index staying >= 128 is what's unique to the
-// special-area flavor. Anything gating on "is this normal interactive gameplay"
-// should treat this the same as MODULE_OVERWORLD.
+// True while `effectiveModule` is MODULE_FALLING_ENTRANCE (11) via the vanilla overworld
+// special-switch-area path (one of 3 locked-view locations reached by walking onto a
+// switch tile) rather than an actual dungeon pit-fall. Both reuse the same module;
+// overworld_screen_index staying >= 128 is what's unique to the special-area flavor.
+// Use this form once a menu-overlay remap has already been resolved (main_module_index
+// == 14, the real module in saved_module_for_menu) — passing the raw main_module_index
+// there would stop recognizing the special area the instant the pause menu opens over it.
+bool GameHook_IsOverworldSpecialAreaFor(int effectiveModule);
+
+// Raw-module form: true while main_module_index itself is the special-area flavor.
+// Anything gating on "is this normal interactive gameplay right now" (accepting live
+// input) should use this — it correctly excludes the paused/menu-overlay state, matching
+// how a normal overworld location already behaves while paused.
 bool GameHook_IsOverworldSpecialArea(void);
 
 // ─── Cheats (cheats.c) ───

--- a/core/game-hooks/state_queries.c
+++ b/core/game-hooks/state_queries.c
@@ -3,8 +3,16 @@
 
 // ─── Overworld Special-Area Query ───
 
+// The parameterized version a caller uses once it has already resolved a menu-overlay
+// remap (main_module_index==14, the real module sitting in saved_module_for_menu) —
+// otherwise the special area silently stops being recognized the instant the player
+// opens the pause menu over it, since main_module_index reads 14 there, not 11.
+bool GameHook_IsOverworldSpecialAreaFor(int effectiveModule) {
+  return effectiveModule == MODULE_FALLING_ENTRANCE && overworld_screen_index >= OVERWORLD_SPECIAL_AREA_SCREEN_MIN;
+}
+
 bool GameHook_IsOverworldSpecialArea(void) {
-  return main_module_index == MODULE_FALLING_ENTRANCE && overworld_screen_index >= OVERWORLD_SPECIAL_AREA_SCREEN_MIN;
+  return GameHook_IsOverworldSpecialAreaFor(main_module_index);
 }
 
 // ─── Inventory State Query ───
@@ -160,8 +168,9 @@ int WasmGetViewportInfo(void) {
   }
   // The overworld-special-area flavor of MODULE_FALLING_ENTRANCE is normal outdoor
   // gameplay — report it as such so consumers keyed on locationModule === MODULE_OVERWORLD
-  // (the edge-glow effect) still engage there.
-  if (mod == MODULE_FALLING_ENTRANCE && GameHook_IsOverworldSpecialArea()) {
+  // (the edge-glow effect) still engage there. Checked against `mod` (already
+  // menu-remapped above), not the raw module, so this still holds while paused.
+  if (GameHook_IsOverworldSpecialAreaFor(mod)) {
     mod = MODULE_OVERWORLD;
   }
   g_viewport_buf[9] = mod;

--- a/core/game-hooks/state_queries.c
+++ b/core/game-hooks/state_queries.c
@@ -3,16 +3,51 @@
 
 // ─── Overworld Special-Area Query ───
 
+// dungeon_room_index values Overworld_CheckSpecialSwitchArea assigns for the 3 special-
+// switch locations (overworld.c's kSpecialSwitchArea_Exit table: 0x180, 0x181, 0x182,
+// 0x189) — set in the SAME call that flips main_module_index to 11, so unlike
+// overworld_screen_index (which only reaches its special-area value a few frames later,
+// once Overworld_EnterSpecialArea/LoadOverworldFromSpecialOverworld actually runs), this
+// is already correct on the very first frame of the transition.
+static bool IsKnownSpecialAreaRoomIndex(uint16 idx) {
+  return idx == 0x180 || idx == 0x181 || idx == 0x182 || idx == 0x189;
+}
+
+// Sticky across a whole module-11 episode: overworld_screen_index and dungeon_room_index
+// each independently have a brief window — a few frames, both on entering and (especially)
+// on leaving — where neither confirms the special-area flavor even though we're still
+// mid-transition, because the game hasn't finished updating them relative to the module
+// flip. Latching on any positive signal and holding it for as long as main_module_index
+// stays MODULE_FALLING_ENTRANCE closes that gap instead of the widescreen view (and the
+// HUD/cheat gates) flashing back to collapsed for those few frames every single crossing.
+static bool s_stickySpecialArea = false;
+
 // The parameterized version a caller uses once it has already resolved a menu-overlay
 // remap (main_module_index==14, the real module sitting in saved_module_for_menu) —
 // otherwise the special area silently stops being recognized the instant the player
-// opens the pause menu over it, since main_module_index reads 14 there, not 11.
+// opens the pause menu over it, since main_module_index reads 14 there, not 11. This is
+// also the only form that updates the latch above — see GameHook_IsOverworldSpecialArea
+// for why the raw form must not.
 bool GameHook_IsOverworldSpecialAreaFor(int effectiveModule) {
-  return effectiveModule == MODULE_FALLING_ENTRANCE && overworld_screen_index >= OVERWORLD_SPECIAL_AREA_SCREEN_MIN;
+  if (effectiveModule != MODULE_FALLING_ENTRANCE) {
+    s_stickySpecialArea = false;
+    return false;
+  }
+  if (overworld_screen_index >= OVERWORLD_SPECIAL_AREA_SCREEN_MIN || IsKnownSpecialAreaRoomIndex(dungeon_room_index)) {
+    s_stickySpecialArea = true;
+  }
+  return s_stickySpecialArea;
 }
 
+// Raw-module form for cheats.c's gameplay-input gate, where excluding the paused state is
+// correct (matches how a normal overworld location already behaves while paused). Reads
+// the latch WITHOUT the reset-on-mismatch above: pausing sets main_module_index to 14,
+// and if this form ran that through the same reset it would clear the latch on every
+// pause, then need a fresh signal to relatch on unpausing (screen_index still would give
+// one immediately, but there is no reason to let a pure input-gate query mutate location
+// state that ConfigurePpuSideSpace/WasmGetViewportInfo are the source of truth for).
 bool GameHook_IsOverworldSpecialArea(void) {
-  return GameHook_IsOverworldSpecialAreaFor(main_module_index);
+  return main_module_index == MODULE_FALLING_ENTRANCE && s_stickySpecialArea;
 }
 
 // ─── Inventory State Query ───

--- a/core/zelda3/snes/ppu.c
+++ b/core/zelda3/snes/ppu.c
@@ -25,6 +25,11 @@ static void PpuDrawWholeLine(Ppu *ppu, uint y);
 #define IS_SCREEN_ENABLED(ppu, sub, layer) (ppu->screenEnabled[sub] & (1 << layer))
 #define IS_SCREEN_WINDOWED(ppu, sub, layer) (ppu->screenWindowed[sub] & (1 << layer))
 #define IS_MOSAIC_ENABLED(ppu, layer) ((ppu->mosaicEnabled & (1 << layer)))
+// Start coordinate of the mosaic block containing `v`. `v` is a SIGNED screen coordinate and routinely
+// falls outside 0..255 once the wide/tall view is on — the left window edge is -extraLeftCur and the
+// right one runs past 256 — so the lookup is biased (see kPpuMosaicBias in ppu.h). Indexing
+// ppu->mosaicModulo directly with such a coordinate reads outside the table.
+#define MOSAIC_START(ppu, v) ((ppu)->mosaicModulo[(int)(v) + kPpuMosaicBias])
 #define GET_WINDOW_FLAGS(ppu, layer) (ppu->windowsel >> (layer * 4))
 enum {
   kWindow1Inversed = 1,
@@ -195,9 +200,13 @@ void ppu_runLine(Ppu *ppu, int line) {
     if (ppu->mosaicSize != ppu->lastMosaicModulo) {
       int mod = ppu->mosaicSize;
       ppu->lastMosaicModulo = mod;
-      for (int i = 0, j = 0; i < countof(ppu->mosaicModulo); i++) {
-        ppu->mosaicModulo[i] = i - j;
-        j = (j + 1 == mod ? 0 : j + 1);
+      // Anchor the block lattice on coordinate 0 — where the hardware's 256-px screen begins — and carry
+      // the same lattice into the negative margin, so blocks stay aligned across the whole wide frame
+      // rather than restarting at the base window's left edge. Floored remainder, not C's truncating %,
+      // or every negative coordinate would round toward zero and shift its block by one.
+      for (int i = -kPpuMosaicBias; i < kPpuMosaicHigh + 1; i++) {
+        int r = i % mod;
+        ppu->mosaicModulo[i + kPpuMosaicBias] = (int16_t)(i - (r < 0 ? r + mod : r));
       }
     }
     // Tall screens: `line` is the physical buffer row+1; the content scanline `sl` is shifted up by the
@@ -550,7 +559,7 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu, uint y, bool sub, uint layer
   PpuWindows win;
   IS_SCREEN_WINDOWED(ppu, sub, layer) ? PpuWindows_Calc(&win, ppu, layer) : PpuWindows_Clear(&win, ppu, layer);
   BgLayer *bglayer = &ppu->bgLayer[layer];
-  y = ppu->mosaicModulo[y] + bglayer->vScroll;
+  y = MOSAIC_START(ppu, y) + bglayer->vScroll;
   int sc_offs = bglayer->tilemapAdr + (((y >> 3) & 0x1f) << 5);
   if ((y & 0x100) && bglayer->tilemapHigher)
     sc_offs += bglayer->tilemapWider ? 0x800 : 0x400;
@@ -571,7 +580,7 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu, uint y, bool sub, uint layer
     const uint16 *tp = tps[x >> 8 & 1] + ((x >> 3) & 0x1f);
     const uint16 *tp_last = tps[x >> 8 & 1] + 31, *tp_next = tps[(x >> 8 & 1) ^ 1];
     x &= 7;
-    int w = ppu->mosaicSize - (sx - ppu->mosaicModulo[sx]);
+    int w = ppu->mosaicSize - (sx - MOSAIC_START(ppu, sx));
     do {
       w = IntMin(w, dstz_end - dstz);
       uint32 tile = *tp;
@@ -609,7 +618,7 @@ static void PpuDrawBackground_2bpp_mosaic(Ppu *ppu, int y, bool sub, uint layer,
   PpuWindows win;
   IS_SCREEN_WINDOWED(ppu, sub, layer) ? PpuWindows_Calc(&win, ppu, layer) : PpuWindows_Clear(&win, ppu, layer);
   BgLayer *bglayer = &ppu->bgLayer[layer];
-  y = ppu->mosaicModulo[y] + bglayer->vScroll;
+  y = MOSAIC_START(ppu, y) + bglayer->vScroll;
   int sc_offs = bglayer->tilemapAdr + (((y >> 3) & 0x1f) << 5);
   if ((y & 0x100) && bglayer->tilemapHigher)
     sc_offs += bglayer->tilemapWider ? 0x800 : 0x400;
@@ -630,7 +639,7 @@ static void PpuDrawBackground_2bpp_mosaic(Ppu *ppu, int y, bool sub, uint layer,
     const uint16 *tp = tps[x >> 8 & 1] + ((x >> 3) & 0x1f);
     const uint16 *tp_last = tps[x >> 8 & 1] + 31, *tp_next = tps[(x >> 8 & 1) ^ 1];
     x &= 7;
-    int w = ppu->mosaicSize - (sx - ppu->mosaicModulo[sx]);
+    int w = ppu->mosaicSize - (sx - MOSAIC_START(ppu, sx));
     do {
       w = IntMin(w, dstz_end - dstz);
       uint32 tile = *tp;
@@ -720,7 +729,7 @@ static void PpuDrawBackground_mode7(Ppu *ppu, uint y, bool sub, PpuZbufType z) {
   clippedV = (clippedV & 0x2000) ? (clippedV | ~1023) : (clippedV & 1023);
   bool mosaic_enabled = IS_MOSAIC_ENABLED(ppu, 0);
   if (mosaic_enabled)
-    y = ppu->mosaicModulo[y];
+    y = MOSAIC_START(ppu, y);
   uint32 ry = ppu->m7yFlip ? 255 - y : y;
   uint32 m7startX = (ppu->m7matrix[0] * clippedH & ~63) + (ppu->m7matrix[1] * ry & ~63) +
     (ppu->m7matrix[1] * clippedV & ~63) + (xCenter << 8);
@@ -740,7 +749,7 @@ static void PpuDrawBackground_mode7(Ppu *ppu, uint y, bool sub, PpuZbufType z) {
     uint32 outside_value = ppu->m7largeField ? 0x3ffff : 0xffffffff;
     bool char_fill = ppu->m7charFill;
     if (mosaic_enabled) {
-      int w = ppu->mosaicSize - (x - ppu->mosaicModulo[x]);
+      int w = ppu->mosaicSize - (x - MOSAIC_START(ppu, x));
       do {
         w = IntMin(w, dstz_end - dstz);
         if ((uint32)(xpos | ypos) > outside_value) {

--- a/core/zelda3/snes/ppu.c
+++ b/core/zelda3/snes/ppu.c
@@ -559,7 +559,13 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu, uint y, bool sub, uint layer
   PpuWindows win;
   IS_SCREEN_WINDOWED(ppu, sub, layer) ? PpuWindows_Calc(&win, ppu, layer) : PpuWindows_Clear(&win, ppu, layer);
   BgLayer *bglayer = &ppu->bgLayer[layer];
+  // Mosaic quantizes the SCREEN row, then scroll and the camera lock turn it into a world row — the same
+  // order PpuDrawBackground_4bpp uses. This path used to skip the lock and the linear-world fetch
+  // entirely, so every mosaic frame of a transition fell back to the stock wrapping 2-screen tilemap with
+  // an unshifted camera: the terrain tore at each 256px tilemap boundary and slid out from under the
+  // sprites, which stayed on the locked coordinates.
   y = MOSAIC_START(ppu, y) + bglayer->vScroll;
+  if (layer == 1) y -= ppu->cameraLockShiftY;
   int sc_offs = bglayer->tilemapAdr + (((y >> 3) & 0x1f) << 5);
   if ((y & 0x100) && bglayer->tilemapHigher)
     sc_offs += bglayer->tilemapWider ? 0x800 : 0x400;
@@ -569,6 +575,9 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu, uint y, bool sub, uint layer
   };
   int tileadr = ppu->bgLayer[layer].tileAdr, pixel;
   int tileadr1 = tileadr + 7 - (y & 0x7), tileadr0 = tileadr + (y & 0x7);
+  bool useWorld = bglayer->useWorld;
+  int worldTileY = useWorld ? (((int)y + bglayer->worldOffY) >> 3) : 0;
+  uint16 worldRowBuf[kPpuXPixels / 8 + 8];
   const uint16 *addr;
   for (size_t windex = 0; windex < win.nr; windex++) {
     if (win.bits & (1 << windex))
@@ -577,8 +586,25 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu, uint y, bool sub, uint layer
     PpuZbufType *dstz = ppu->bgBuffers[sub].data + sx + kPpuExtraLeftRight;
     PpuZbufType *dstz_end = ppu->bgBuffers[sub].data + win.edges[windex + 1] + kPpuExtraLeftRight;
     uint x = sx + bglayer->hScroll;
-    const uint16 *tp = tps[x >> 8 & 1] + ((x >> 3) & 0x1f);
-    const uint16 *tp_last = tps[x >> 8 & 1] + 31, *tp_next = tps[(x >> 8 & 1) ^ 1];
+    if (layer == 1) x -= ppu->cameraLockShiftX;
+    const uint16 *tp, *tp_last, *tp_next;
+    if (useWorld) {
+      // Gather this run's tiles into a contiguous buffer (clamped), so the step below is linear.
+      int firstCol = ((int)x + bglayer->worldOffX) >> 3;
+      int ntiles = (int)(((x & 7) + (uint)(win.edges[windex + 1] - sx) + 7) >> 3) + 1;
+      if (ntiles > kPpuXPixels / 8 + 7) ntiles = kPpuXPixels / 8 + 7;
+      bool validY = (worldTileY >= 0 && worldTileY < (int)bglayer->worldH);
+      const uint16 *wrow = validY ? bglayer->world + (size_t)worldTileY * bglayer->worldW : NULL;
+      for (int k = 0; k <= ntiles; k++) {
+        int c = firstCol + k;
+        worldRowBuf[k] = (validY && c >= 0 && c < (int)bglayer->worldW) ? wrow[c] : 0;
+      }
+      tp = worldRowBuf, tp_next = worldRowBuf, tp_last = worldRowBuf + (kPpuXPixels / 8 + 7);
+    } else {
+      tp = tps[x >> 8 & 1] + ((x >> 3) & 0x1f);
+      tp_last = tps[x >> 8 & 1] + 31;
+      tp_next = tps[(x >> 8 & 1) ^ 1];
+    }
     x &= 7;
     int w = ppu->mosaicSize - (sx - MOSAIC_START(ppu, sx));
     do {
@@ -586,7 +612,7 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu, uint y, bool sub, uint layer
       uint32 tile = *tp;
       int ta = (tile & 0x8000) ? tileadr1 : tileadr0;
       PpuZbufType z = (tile & 0x2000) ? zhi : zlo;
-      uint32 bits = READ_BITS(ta, tile & 0x3ff);
+      uint32 bits = (tile || !useWorld) ? READ_BITS(ta, tile & 0x3ff) : 0;  // world gap (entry 0) => backdrop, not char 0
       if (tile & 0x4000) bits >>= x, GET_PIXEL(); else bits <<= x, GET_PIXEL_HFLIP();
       if (pixel) {
         pixel += (tile & 0x1c00) >> kPaletteShift;
@@ -595,6 +621,8 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu, uint y, bool sub, uint layer
           if (z > dstz[i])
             dstz[i] = pixel + z;
         } while (++i != w);
+      } else if (useWorld && !tile) {  // no-data gap: paint the backdrop run black via the sentinel
+        for (int q = 0; q < w; q++) { if (dstz[q] == 0x0500) dstz[q] = kPpuWorldGapPixel; }
       }
       dstz += w, x += w;
       for (; x >= 8; x -= 8)

--- a/core/zelda3/snes/ppu.h
+++ b/core/zelda3/snes/ppu.h
@@ -32,6 +32,15 @@ typedef struct BgLayer {
 
 enum {
   kPpuXPixels = 256 + kPpuExtraLeftRight * 2,
+  // Bounds of the mosaic block-start table (Ppu.mosaicModulo). It is indexed by SIGNED screen
+  // coordinates, not by 0..255: with the wide/tall view a window edge starts at -extraLeftCur and a tall
+  // scanline at -extraTopBottom, while the far ends reach past 256/240. kPpuMosaicBias biases every index
+  // positive, and an entry must be able to hold a coordinate up to kPpuMosaicHigh — which is why the
+  // entries are int16 rather than uint8.
+  kPpuMosaicBias = kPpuExtraLeftRight > kPpuExtraTopBottom ? kPpuExtraLeftRight : kPpuExtraTopBottom,
+  kPpuMosaicHigh = (256 + kPpuExtraLeftRight) > (240 + kPpuExtraTopBottom)
+                     ? (256 + kPpuExtraLeftRight) : (240 + kPpuExtraTopBottom),
+  kPpuMosaicEntries = kPpuMosaicBias + kPpuMosaicHigh + 1,
   // Max linear-world tilemap dimension in 8x8 tiles. A single 2x2 overworld area is 1024px = 128 tiles;
   // during a scroll transition we build a buffer spanning BOTH the source and destination areas (so the
   // wide/tall view pans across the seam without the wrapping stock tilemap), needing up to two large areas
@@ -168,7 +177,9 @@ struct Ppu {
   // onward is the player's private bank, derived from the loaded sheet and re-pushed whenever gear palettes
   // reload, so growing this array leaves the snapshot byte-identical.
   uint16_t cgram[0x110];
-  uint8_t mosaicModulo[kPpuXPixels];
+  // Block-start coordinate per screen coordinate. Read through MOSAIC_START (ppu.c), never indexed raw:
+  // the index is signed and biased by kPpuMosaicBias.
+  int16_t mosaicModulo[kPpuMosaicEntries];
   // Brightness-mapped mirror of cgram for the 4x scale path, player bank included.
   uint32_t colorMapRgb[0x110];
   PpuPixelPrioBufs bgBuffers[2];

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -177,19 +177,6 @@ static void BlitAreaMap16(uint16 *world, int worldW, int worldH, const uint16 *m
   }
 }
 
-// Identity of the area whose map16 is known to be RESIDENT in dung_bg2, recorded on every build made in
-// a settled frame (submodule 0 / the menu overlay). The special-overworld entry/exit chain flips
-// ow_scroll_vars0 several frames before it finishes rebuilding dung_bg2, so during those frames "current
-// bounds" and "resident map" disagree — comparing against this key is how the build below knows whether
-// dung_bg2 can be trusted for the full wide view or only for the base window the stock screen shows.
-static int g_ow_resident_screen = -1, g_ow_resident_ox = -1, g_ow_resident_oy = -1;
-
-static bool OwResidentMatchesBounds() {
-  return g_ow_resident_screen == (int)overworld_screen_index &&
-         g_ow_resident_ox == (int)ow_scroll_vars0.xstart &&
-         g_ow_resident_oy == (int)ow_scroll_vars0.ystart;
-}
-
 // Expand the resident overworld map16 (dung_bg2 — the full current area) into the BG2 layer's linear
 // "world" tilemap so the widescreen view can extend past the 512px SNES tilemap into real map instead of
 // wrapping. Out-of-area columns clamp to transparent (edge-mirror). Also snapshots the area for transitions.
@@ -315,19 +302,6 @@ static void ConfigurePpuSideSpace() {
       // bounds. Its own scroll bounds (ow_scroll_vars0, set by Overworld_EnterSpecialArea) are already
       // correct here regardless of submodule_index.
       if (submodule_index == 0 || main_module_index == 14 || isSpecialArea) {
-        // Settled frames (and the menu overlay, which freezes a settled state) always have the
-        // current area resident in dung_bg2. The one way to be here NON-settled is the latched
-        // special-overworld chain, which flips ow_scroll_vars0 several frames before the destination
-        // map16 finishes rebuilding — during that window nothing can render valid extended content:
-        // BG2's world build would blit the previous area's stale rows, and the other layers' stock
-        // 512px fetch wraps equally stale VRAM into the margins. So when the bounds don't match the
-        // resident area, keep the base window exactly as vanilla draws it (stock fetch, no lock
-        // shift) and let the margins hold plain black at constant frame size, until the first
-        // settled frame brings the real wide view back.
-        bool residentOk = submodule_index == 0 || main_module_index == 14 || OwResidentMatchesBounds();
-        if (!residentOk) {
-          extra_left = extra_right = extra_top = extra_bottom = 0;
-        } else {
         if (enhanced_features0 & kFeatures0_CameraLockToViewport) {
           // Render-level camera lock: clamp the RENDERED view to the area so its edges rest on the
           // boundary (no out-of-area black), then shift the world fetch (below) + sprites (ppu eval) by
@@ -352,12 +326,6 @@ static void ConfigurePpuSideSpace() {
           g_lock_last_cam_x = BG2HOFS_copy2;
           g_lock_last_cam_y = BG2VOFS_copy2;
           BuildOverworldWorldTilemap();
-          if (submodule_index == 0 || main_module_index == 14) {
-            g_ow_resident_screen = overworld_screen_index;
-            g_ow_resident_ox = ow_scroll_vars0.xstart;
-            g_ow_resident_oy = ow_scroll_vars0.ystart;
-          }
-        }
         }
       } else {
         // Non-stationary outdoor sub-states. A screen-to-screen scroll transition (the submodule 1-8 chain)

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -267,10 +267,13 @@ static void ConfigurePpuSideSpace() {
   if (mod == 14)
     mod = saved_module_for_menu;
   // The overworld-special-area flavor of MODULE_FALLING_ENTRANCE is normal interactive
-  // outdoor gameplay even though the module never returns to 9 — see
-  // GameHook_IsOverworldSpecialArea. Without this, the wide/tall PPU extension and camera
-  // lock never engage there and the view collapses to the base 256x224 frame.
-  if (mod == 9 || GameHook_IsOverworldSpecialArea()) {
+  // outdoor gameplay even though the module never returns to 9. Checked against `mod`
+  // (already menu-remapped above) via the *For() form, not GameHook_IsOverworldSpecialArea()
+  // — that reads the raw module and would miss this case the instant the pause menu opens
+  // over it (main_module_index is 14 then, not 11, even though the location hasn't
+  // changed), collapsing the view back to the base 256x224 frame on every pause.
+  bool isSpecialArea = GameHook_IsOverworldSpecialAreaFor(mod);
+  if (mod == 9 || isSpecialArea) {
     if (main_module_index == 14 && submodule_index == 7 && overworld_map_state >= 4) {
       // World map
       extra_left = kPpuExtraLeftRight, extra_right = kPpuExtraLeftRight;
@@ -284,10 +287,13 @@ static void ConfigurePpuSideSpace() {
       // Apply the lock + linear world tilemap whenever the overworld view is stationary in a fully-loaded
       // area: submodule 0 (normal play) OR the inventory menu overlay (main_module 14), which can only be
       // opened from submodule 0 and freezes the camera/area at that state — so the same lock keeps the
-      // overworld behind the menu aligned instead of snapping back to an unshifted view.
-      // During screen-to-screen scroll transitions the camera spans two areas that a single-area buffer
-      // can't represent — fall back to the stock streaming path, which scrolls correctly.
-      if (submodule_index == 0 || main_module_index == 14) {
+      // overworld behind the menu aligned instead of snapping back to an unshifted view. The special-area
+      // flavor also always takes this branch, never the destArea-based transition interpolation below:
+      // that path assumes a normal area index (0-63) on both ends of the scroll, and the special area's own
+      // overworld_area_index (>=128) would index kOverworldMapIsSmall/kOverworld_OffsetBaseX/etc out of
+      // bounds. Its own scroll bounds (ow_scroll_vars0, set by Overworld_EnterSpecialArea) are already
+      // correct here regardless of submodule_index.
+      if (submodule_index == 0 || main_module_index == 14 || isSpecialArea) {
         if (enhanced_features0 & kFeatures0_CameraLockToViewport) {
           // Render-level camera lock: clamp the RENDERED view to the area so its edges rest on the
           // boundary (no out-of-area black), then shift the world fetch (below) + sprites (ppu eval) by

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -177,6 +177,19 @@ static void BlitAreaMap16(uint16 *world, int worldW, int worldH, const uint16 *m
   }
 }
 
+// Identity of the area whose map16 is known to be RESIDENT in dung_bg2, recorded on every build made in
+// a settled frame (submodule 0 / the menu overlay). The special-overworld entry/exit chain flips
+// ow_scroll_vars0 several frames before it finishes rebuilding dung_bg2, so during those frames "current
+// bounds" and "resident map" disagree — comparing against this key is how the build below knows whether
+// dung_bg2 can be trusted for the full wide view or only for the base window the stock screen shows.
+static int g_ow_resident_screen = -1, g_ow_resident_ox = -1, g_ow_resident_oy = -1;
+
+static bool OwResidentMatchesBounds() {
+  return g_ow_resident_screen == (int)overworld_screen_index &&
+         g_ow_resident_ox == (int)ow_scroll_vars0.xstart &&
+         g_ow_resident_oy == (int)ow_scroll_vars0.ystart;
+}
+
 // Expand the resident overworld map16 (dung_bg2 — the full current area) into the BG2 layer's linear
 // "world" tilemap so the widescreen view can extend past the 512px SNES tilemap into real map instead of
 // wrapping. Out-of-area columns clamp to transparent (edge-mirror). Also snapshots the area for transitions.
@@ -188,7 +201,14 @@ static void BuildOverworldWorldTilemap() {
   int h = (((int)ow_scroll_vars0.yend - originY) >> 3) + 32;
   w = IntMax(0, IntMin(w, kPpuWorldTiles));
   h = IntMax(0, IntMin(h, kPpuWorldTiles));
-  BlitAreaMap16(bg->world, w, h, dung_bg2, w, h, 0, 0, GetMap16toMap8Table());
+  // dung_bg2 is a 64x64 map16 = at most 128x128 map8 tiles. The special overworld's scroll range
+  // overshoots that by a few rows (yend 0x320 + the 256px view = 132 tile rows), and blitting the
+  // overshoot would read past the map16 (see the same note in BuildTransitionWorldTilemap). Blit only
+  // the real extent and clear the overshoot to the no-data sentinel so it renders as backdrop.
+  int bw = IntMin(w, 128), bh = IntMin(h, 128);
+  if (bw < w || bh < h)
+    memset(bg->world, 0, (size_t)w * h * sizeof(uint16));
+  BlitAreaMap16(bg->world, w, h, dung_bg2, bw, bh, 0, 0, GetMap16toMap8Table());
   bg->worldW = w, bg->worldH = h;
   // The overworld BG scroll wraps at the 1024px tilemap, so the PPU hScroll/vScroll carry only the low 10
   // bits. worldOff re-adds the 1024-aligned high part minus the area origin, so the fetch's local (x,y)
@@ -202,6 +222,7 @@ static void BuildOverworldWorldTilemap() {
   g_ow_src_ys = originY, g_ow_src_ye = ow_scroll_vars0.yend;
   g_ow_src_area = (BYTE(current_area_of_player) >> 1) & 0x3f;
 }
+
 
 // Build a world tilemap spanning the source area (from the snapshot) AND the destination area (live
 // dung_bg2, loaded partway through the transition), so the camera-locked wide/tall view pans smoothly
@@ -294,6 +315,19 @@ static void ConfigurePpuSideSpace() {
       // bounds. Its own scroll bounds (ow_scroll_vars0, set by Overworld_EnterSpecialArea) are already
       // correct here regardless of submodule_index.
       if (submodule_index == 0 || main_module_index == 14 || isSpecialArea) {
+        // Settled frames (and the menu overlay, which freezes a settled state) always have the
+        // current area resident in dung_bg2. The one way to be here NON-settled is the latched
+        // special-overworld chain, which flips ow_scroll_vars0 several frames before the destination
+        // map16 finishes rebuilding — during that window nothing can render valid extended content:
+        // BG2's world build would blit the previous area's stale rows, and the other layers' stock
+        // 512px fetch wraps equally stale VRAM into the margins. So when the bounds don't match the
+        // resident area, keep the base window exactly as vanilla draws it (stock fetch, no lock
+        // shift) and let the margins hold plain black at constant frame size, until the first
+        // settled frame brings the real wide view back.
+        bool residentOk = submodule_index == 0 || main_module_index == 14 || OwResidentMatchesBounds();
+        if (!residentOk) {
+          extra_left = extra_right = extra_top = extra_bottom = 0;
+        } else {
         if (enhanced_features0 & kFeatures0_CameraLockToViewport) {
           // Render-level camera lock: clamp the RENDERED view to the area so its edges rest on the
           // boundary (no out-of-area black), then shift the world fetch (below) + sprites (ppu eval) by
@@ -318,6 +352,12 @@ static void ConfigurePpuSideSpace() {
           g_lock_last_cam_x = BG2HOFS_copy2;
           g_lock_last_cam_y = BG2VOFS_copy2;
           BuildOverworldWorldTilemap();
+          if (submodule_index == 0 || main_module_index == 14) {
+            g_ow_resident_screen = overworld_screen_index;
+            g_ow_resident_ox = ow_scroll_vars0.xstart;
+            g_ow_resident_oy = ow_scroll_vars0.ystart;
+          }
+        }
         }
       } else {
         // Non-stationary outdoor sub-states. A screen-to-screen scroll transition (the submodule 1-8 chain)

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -189,13 +189,19 @@ static void BuildOverworldWorldTilemap() {
   w = IntMax(0, IntMin(w, kPpuWorldTiles));
   h = IntMax(0, IntMin(h, kPpuWorldTiles));
   // dung_bg2 is a 64x64 map16 = at most 128x128 map8 tiles. The special overworld's scroll range
-  // overshoots that by a few rows (yend 0x320 + the 256px view = 132 tile rows), and blitting the
-  // overshoot would read past the map16 (see the same note in BuildTransitionWorldTilemap). Blit only
-  // the real extent and clear the overshoot to the no-data sentinel so it renders as backdrop.
+  // overshoots that (yend 0x320 + the 256px view = 132 tile rows), and blitting the overshoot would read
+  // past the map16 (see the same note in BuildTransitionWorldTilemap), so only the real extent is blitted.
   int bw = IntMin(w, 128), bh = IntMin(h, 128);
   if (bw < w || bh < h)
     memset(bg->world, 0, (size_t)w * h * sizeof(uint16));
   BlitAreaMap16(bg->world, w, h, dung_bg2, bw, bh, 0, 0, GetMap16toMap8Table());
+  // Repeat the last real row over the vertical overshoot instead of leaving it a no-data gap. The camera
+  // range genuinely allows one row more than the area owns: the bottom scanline samples vScroll + 224, so
+  // at the range's lowest camera (yend) that is row 1024 of a 1024-row area. Left as a gap it rendered as
+  // a hard coloured line across the foot of the screen; repeating the row above makes it continue the
+  // terrain, which is what the hardware's overscan hid.
+  for (int ry = bh; ry < h; ry++)
+    memcpy(bg->world + (size_t)ry * w, bg->world + (size_t)(bh - 1) * w, (size_t)w * sizeof(uint16));
   bg->worldW = w, bg->worldH = h;
   // The overworld BG scroll wraps at the 1024px tilemap, so the PPU hScroll/vScroll carry only the low 10
   // bits. worldOff re-adds the 1024-aligned high part minus the area origin, so the fetch's local (x,y)

--- a/scripts/parallel/provision-profile.mjs
+++ b/scripts/parallel/provision-profile.mjs
@@ -111,17 +111,26 @@ const copyManualSaves = (sourceId, name) => {
  * profile into the new one, for reproducing a bug tied to a specific in-progress state.
  * Quick slots are `saveN.sav`/`saveN.png` with no manifest — unlike manual saves, a
  * quick slot has no stable name, so the caller must know which index holds the state.
+ *
+ * Skips (does not overwrite) if the destination slot already has a save — provisionProfile
+ * is meant to be safely re-runnable against an EXISTING, already-in-use profile (that's the
+ * whole point of its idempotency elsewhere), so a second run must never clobber a quick save
+ * someone has since made by playing in that profile. This silently destroyed a user's live
+ * test save once already: re-provisioning an instance the user was actively testing in
+ * overwrote their fresh save0.sav/save1.sav with stale copies from the source profile.
  */
 const copyQuickSave = (sourceId, name, slot) => {
   if (!sourceId || slot == null) return false;
   const fromDir = gameDataPath('profiles', sourceId, 'saves', 'quick');
   const toDir = gameDataPath('profiles', name, 'saves', 'quick');
   const savPath = join(fromDir, `save${slot}.sav`);
+  const destPath = join(toDir, `save${slot}.sav`);
+  if (existsSync(destPath)) return false;
   if (!existsSync(savPath)) {
     throw new Error(`Quick slot ${slot} has no save${slot}.sav under ${fromDir} — nothing to copy.`);
   }
   mkdirSync(toDir, { recursive: true });
-  cpSync(savPath, join(toDir, `save${slot}.sav`));
+  cpSync(savPath, destPath);
   const pngPath = join(fromDir, `save${slot}.png`);
   if (existsSync(pngPath)) cpSync(pngPath, join(toDir, `save${slot}.png`));
   return true;


### PR DESCRIPTION
## Summary

Follow-up to #133, which made the HUD and widescreen survive in the three
overworld special-switch areas while standing still but left everything else
about them broken. Reported and re-tested in the app at each step.

- **Pause menu.** `ConfigurePpuSideSpace` already remaps `main_module_index==14`
  to the module active before pausing, so a normal area keeps its wide view
  across a pause; the special-area check read the *raw* module (14 while paused,
  not 11) and stopped recognising the area the moment the menu opened. Added a
  form of the check parameterised on an already-resolved module, and used it
  wherever the menu remap has happened. The raw-module form stays for the
  cheat input gate, where excluding the paused state is correct.
- **Mosaic corruption.** The real cause of the garbage in the side columns
  during the transition. `Ppu.mosaicModulo` maps a screen coordinate to its
  mosaic block start; it was `uint8_t` and indexed raw. The index is *signed*
  (the left window edge is `-extraLeftCur`), so the left margin read memory in
  front of the array — the palette — and the resulting run lengths smeared one
  pixel into long horizontal streaks. Entries past 255 also wrapped, so the
  right margin resolved to a block hundreds of pixels away and the whole lattice
  shifted. Now biased, widened to int16, sized for both axes, and read through a
  single accessor. At 4:3 the table is byte-identical to before.
- **Mosaic never got the wide view.** `PpuDrawBackground_4bpp_mosaic` lacked
  both the linear-world fetch and the camera-lock shift its non-mosaic twin has,
  so every mosaic frame fell back to the stock 2-screen fetch that wraps every
  256/512px — the terrain tore at each boundary (one seam entering, two
  returning) and slid out from under the sprites. Ported both, plus the no-data
  gap handling.
- **Coloured line at the foot of the map.** Not transition-related. The camera
  range permits one row more than the area owns: the bottom scanline reads
  `vScroll + 224`, which at the lowest camera is row 1024 of a 1024-row area.
  That row fell outside the blitted map and rendered the no-data sentinel, which
  resolves to a palette entry rather than black. The overshoot now repeats the
  last real row. (At 4:3 the world buffer is off by design, so that path still
  wraps; changing it would mean altering the stock fetch.)
- **Tooling.** `wt new --quick-slot` no longer overwrites an existing quick
  save — it destroyed a live test save during this investigation.

Also removes an earlier workaround of mine that hid the mosaic artefacts by
zeroing the extra extents, which pillarboxed the frame to 4:3 for the length of
the load. With the real causes fixed the wide view stays engaged throughout.

## Gating

Every branch touched is already behind the wide/tall budgets or
`kFeatures0_CameraLockToViewport`. With `extendedRendering` off, `serializeToIni`
forces `ExtendedAspectRatio` to `"4:3"` regardless of the ratio setting, which
zeroes those budgets at boot — so with widescreen off these areas render exactly
as they did before.

## Test plan

- [x] Replicated the reported artefacts first, frame-accurately: dense capture
      (~90 frames, no throttle) of both directions, since sampling every 150ms
      had been stepping straight over the affected frames.
- [x] Pause / unpause: full widescreen and complete HUD in all three states.
- [x] Entry and exit transitions: margins carry real terrain, mosaic blocks are
      square and aligned across the full frame, no seams, player correctly
      positioned, full 16:9 with no bars at any point.
- [x] Bottom-of-map line: measured the cause (camera y = 800 = `yend`,
      `extra_bottom` = 0, world height 132 rows vs the 128 the map16 has) and
      confirmed it gone afterwards.
- [x] Normal overworld screen re-checked for regressions.
- [x] Confirmed by the maintainer in the running app.