### PR TITLE
fix(worldmap): shift table-driven map markers for wide/tall views

### DIFF
--- a/core/zelda3/src/messaging.c
+++ b/core/zelda3/src/messaging.c
@@ -20,6 +20,17 @@
 static void WorldMap_AddSprite(int spr, uint8 big, uint8 flags, uint8 ch, uint16 x, uint16 y);
 static bool WorldMap_CalculateOamCoordinates(Point16U *pt);
 
+// Table-driven markers (flute destinations, dungeon prizes) are calibrated for the native
+// frame's edge at 0; a wide/tall view's Mode 7 background samples further out automatically
+// (same matrix, more columns/rows), so these need the same shift or they land short of where
+// the background now starts. WorldMap_HandleSprites' own markers (Link's live position, the
+// mirror-return marker) track the panning camera directly instead, and must NOT get this —
+// applying it there overshoots past the correct spot.
+static void WorldMap_ShiftMarkerForWideView(Point16U *pt) {
+  pt->x += (uint16)g_oam_wide_budget;
+  pt->y += (uint16)g_oam_tall_budget;
+}
+
 static const int8 kDungMap_Tab0[14] = {-1, -1, -1, -1, -1, 2, 0, 10, 4, 8, -1, 6, 12, 14};
 static const uint16 kDungMap_Tab1[8] = {0x2108, 0x2109, 0x2109, 0x210a, 0x210b, 0x210c, 0x210d, 0x211d};
 static const uint16 kDungMap_Tab2[8] = {0x2118, 0x2119, 0xa109, 0x211a, 0x211b, 0x211c, 0x2118, 0xa11d};
@@ -977,8 +988,10 @@ void FluteMenu_HandleSelection() {  // 8ab78b
     sound_effect_2 = 32;
   }
   birdtravel_var1[0] = birdtravel_var1[0] & 7;
-  if (frame_counter & 0x10 && WorldMap_CalculateOamCoordinates(&pt))
+  if (frame_counter & 0x10 && WorldMap_CalculateOamCoordinates(&pt)) {
+    WorldMap_ShiftMarkerForWideView(&pt);
     WorldMap_AddSprite(16, 2, 0x3e, 0, pt.x - 4, pt.y - 4);
+  }
 
   uint16 ybak = link_y_coord_spexit;
   uint16 xbak = link_x_coord_spexit;
@@ -991,8 +1004,10 @@ void FluteMenu_HandleSelection() {  // 8ab78b
     bird_travel_y_hi[i] = kBirdTravel_y_hi[i];
     link_y_coord_spexit = kBirdTravel_y_hi[i] << 8 | kBirdTravel_y_lo[i];
 
-    if (WorldMap_CalculateOamCoordinates(&pt))
+    if (WorldMap_CalculateOamCoordinates(&pt)) {
+      WorldMap_ShiftMarkerForWideView(&pt);
       WorldMap_AddSprite(i, 0, (i == birdtravel_var1[0]) ? 0x30 + (frame_counter & 6) : 0x32, kBirdTravel_tab1[i], pt.x, pt.y);
+    }
   }
   link_x_coord_spexit = xbak;
   link_y_coord_spexit = ybak;


### PR DESCRIPTION
## Summary
- Fixes #54 properly this time: the flute-travel destination markers (the numbered 1-8 spots and the moving cursor) are computed from fixed lookup tables via a formula calibrated for the native 256x224 frame, with its edge at 0.
- In a wide or tall view, the Mode 7 background samples further out automatically (same projection matrix, more columns/rows), so a marker near the native edge lands past where the background now starts, in the border decoration instead of on the map.
- Verified against a real save state where two of the eight markers did exactly that: computed positions were confirmed at the raw value level, and the fix moves them onto the map to match a 4:3 render of the same save.
- The shift is applied only at the two `FluteMenu_HandleSelection` call sites, not inside the shared `WorldMap_AddSprite`. That function is also used by `WorldMap_HandleSprites` for Link's own live position marker and the mirror-return marker, which track the panning camera directly and don't need this — an earlier version of the fix applied it there too and visibly overshot Link's own marker on the quick-zoom map screen.

## Test plan
- [x] Verified against a real save with two markers rendering off the map in a wide view: both land correctly with the fix
- [x] Confirmed unchanged in 4:3
- [x] Confirmed the quick-zoom/pause map screen (Link's own marker, mirror marker, dungeon/pendant icons) is untouched and behaves as before