### PR TITLE
Fix the Linux AppImage failing to launch since 0.16.0

### DIFF
--- a/scripts/build/pack-velopack.mjs
+++ b/scripts/build/pack-velopack.mjs
@@ -60,12 +60,9 @@ const args = [
   '--outputDir', outputDir,
 ];
 
-if (linux) {
-  // xz over the default gzip. The payload is mostly one enormous binary, which is
-  // exactly what a bigger dictionary helps with, and an AppImage is decompressed
-  // once per launch rather than per update.
-  args.push('--compression', 'xz');
-} else {
+// Linux stays on vpk's default gzip. The AppImage runtime vpk embeds reads zlib and
+// zstd only, so an xz payload packs fine and then cannot be mounted at launch.
+if (!linux) {
   // The window shown while installing, which only the Windows setup has. Same artwork
   // as the app's boot splash, so the install and the first launch read as one
   // sequence, and the bar over it is the app's accent rather than Velopack's green.


### PR DESCRIPTION
The Linux AppImage has not launched since 0.16.0. Running it from a terminal gives "Squashfs image uses xz compression, this version supports only zlib, zstd" followed by a FUSE complaint, which sends you off looking at FUSE when that is not the problem.

We tell vpk to compress the squashfs with xz, but the AppImage runtime it embeds only reads zlib and zstd, so the thing cannot open its own payload. mksquashfs applies the codec and nothing at pack time checks it against the runtime, so the build succeeds and ships something that can never mount.

Dropping the flag falls back to gzip.

- Reproduced in a container: an xz build fails to extract with that exact error, a gzip build extracts fine
- gzip came out 1.4 MiB smaller than xz here, since the payload is mostly the electron binary, the wasm and the asar, all already compressed
- The .deb was never affected, so it is the workaround for anyone stuck right now
- Reported on Discord against Linux Mint, where 0.15.2 is the last version that runs