### PR TITLE
fix(sprites): let the Kakariko running man outrun a wide view

### DIFF
--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -165,4 +165,25 @@ void GameHook_ModuleFrameEnd(void);
 // Captures the completed OAM for one frame into a diagnostic ring; no-op without developer tools.
 void GameHook_CaptureOamFrame(void);
 
+// ─── Running Man Widescreen Overrun (running_man.c) ───
+
+// Called every frame right after RunningMan_Draw, before Sprite_ReturnIfInactive gates the rest of
+// the function. No-op unless a wide/tall view is active and he's actively fleeing; otherwise clears
+// the screen-relative active window's per-frame pause and immunizes him against its auto-kill, so a
+// stationary player doesn't leave him frozen mid-view well short of the fence/forest.
+void GameHook_RunningManStayActive(int k);
+
+// Called at the point the scripted right-side leg sequence (right, down, right) would normally
+// hand him back to idle. Vanilla's script is a fixed handful of frames tuned to end past a 256px
+// screen, which falls well short of a wide view. Returns false (vanilla ends the flee, unchanged)
+// unless a wide/tall view is active; when it returns true, the caller must skip that transition —
+// this call has already re-armed him to keep running the same direction.
+bool GameHook_RunningManExtendRun(int k);
+
+// Called each frame Sprite_RunningMan is in a run leg. No-op unless a wide/tall view is active
+// (Wide_Active()); otherwise accelerates his fixed vanilla velocity over time and ends the flee
+// (back to idle, in place) at a world-distance cap or the moment he collides with solid geometry,
+// so a wide view never shows him stuck against the fence/forest bounding the Kakariko race track.
+void GameHook_RunningManOverrun(int k, bool running);
+
 #endif // GAME_HOOKS_H

--- a/core/game-hooks/running_man.c
+++ b/core/game-hooks/running_man.c
@@ -1,0 +1,63 @@
+/* @layer core-game-hooks @kind native */
+#include "game_hooks_internal.h"
+#include "src/sprite.h"
+
+// ─── Running Man Widescreen Overrun ───
+// Vanilla's flee script (Sprite_RunningMan, sprite_main.c) has two problems on a wide view, both
+// only visible once the render area exceeds the stock 256px screen:
+//
+// 1. The scripted right-side path (right, down, right) is a fixed handful of frames tuned to end
+//    just past a 256px screen — GameHook_RunningManExtendRun keeps it going instead of handing him
+//    back to idle partway across a wider view.
+// 2. Sprite_PrepOamCoordOrDoubleRet's screen-relative active window (sprite.c) pauses, and can
+//    kill, a sprite once it's far enough from LINK's on-screen position — a check meant to stop
+//    simulating sprites the stock 256px screen would never have shown. On a wide view that window
+//    is still much narrower than the visible area, so if Link doesn't follow him he freezes mid-
+//    view. GameHook_RunningManStayActive neutralizes both effects while he's actively fleeing.
+//
+// With both handled, GameHook_RunningManOverrun accelerates him over time and ends the flee at a
+// fixed world-distance cap or the instant he hits something solid (wallcoll), by simply returning
+// him to the idle state — never Sprite_KillSelf, which clears his position's "loaded" bit and
+// makes the overworld's own sprite-activation scan spawn a fresh copy back at his start position
+// the moment that (now-visible-in-wide-view) position re-enters the activation rect.
+//
+// No-op in 4:3 or with extended rendering off, so vanilla behavior is untouched byte-for-byte.
+
+enum {
+  kRunningManAccelInterval = 8,   // frames between each acceleration step
+  kRunningManAccelStepsMax = 32,  // caps the speed multiplier at (16+32)/16 = 3x
+  kRunningManMaxRunFrames  = 600, // hard distance cap (~10s @ 60fps) — clears any supported aspect ratio
+};
+
+static uint16 s_runFrames[16];  // per sprite-slot; mirrors g_sprite_in_band's sizing
+
+void GameHook_RunningManStayActive(int k) {
+  if (!Wide_Active()) return;
+  if (sprite_ai_state[k] != 1 && sprite_ai_state[k] != 2) return;  // only while actively fleeing
+  sprite_pause[k] = 0;          // don't let the screen-relative window freeze him mid-flee
+  sprite_defl_bits[k] |= 0x80;  // and don't let it auto-kill him either — we decide when he's done
+}
+
+bool GameHook_RunningManExtendRun(int k) {
+  if (!Wide_Active()) return false;  // vanilla: let the scripted right-side path end normally
+  sprite_A[k] = 255;  // re-arm the per-leg timer; sprite_B/head_dir are left untouched by the caller
+  return true;
+}
+
+void GameHook_RunningManOverrun(int k, bool running) {
+  if (!Wide_Active() || !running) {
+    s_runFrames[k] = 0;  // vanilla path, or the pre-run reaction hop: nothing to accelerate yet
+    return;
+  }
+  int frames = ++s_runFrames[k];
+  int accel = clampi(frames / kRunningManAccelInterval, 0, kRunningManAccelStepsMax);
+  sprite_x_vel[k] = (int8)((int8)sprite_x_vel[k] * (16 + accel) / 16);
+  sprite_y_vel[k] = (int8)((int8)sprite_y_vel[k] * (16 + accel) / 16);
+
+  if (frames >= kRunningManMaxRunFrames || sprite_wallcoll[k]) {
+    // Distance cap reached, or ran into the fence/forest: stop like vanilla's own script does
+    // (back to idle in place), not a kill — killing would respawn a fresh copy at his start spot.
+    sprite_ai_state[k] = 0;
+    s_runFrames[k] = 0;
+  }
+}

--- a/core/wasm-build/build.mjs
+++ b/core/wasm-build/build.mjs
@@ -52,7 +52,7 @@ const hookSrcs = [
   'state_queries_room_objects', 'attr_grid_state', 'gated_empty', 'receive_counters',
   'sim_queries', 'sim_triggers', 'item_overrides', 'check_triggers', 'ui_state', 'cheats', 'haptic_events',
   'player_sprite', 'transition_events', 'state_queries_combat', 'state_queries_oam',
-  'host_gates', 'hud_override',
+  'host_gates', 'hud_override', 'running_man',
 ].map((f) => h(`${f}.c`));
 
 // Our Emscripten entry points (replace the native main.c). Resolved from this dir.

--- a/core/zelda3/src/sprite_main.c
+++ b/core/zelda3/src/sprite_main.c
@@ -6062,6 +6062,7 @@ void Sprite_RunningMan(int k) {  // 85e8b2
   static const uint8 kRunningMan_A[4] = {120, 24, 128, 3};
   int j;
   RunningMan_Draw(k);
+  GameHook_RunningManStayActive(k);
   if (Sprite_ReturnIfInactive(k))
     return;
   Sprite_TrackBodyToHead(k);
@@ -6097,6 +6098,7 @@ void Sprite_RunningMan(int k) {  // 85e8b2
     if (sprite_delay_main[k] != 0) {
       sprite_graphics[k] = frame_counter >> 3 & 1;
       Sprite_MoveXY(k);
+      GameHook_RunningManOverrun(k, false);
     } else {
       RunningBoy_SpawnDustGarnish(k);
       sprite_graphics[k] = frame_counter >> 2 & 1;
@@ -6104,6 +6106,7 @@ void Sprite_RunningMan(int k) {  // 85e8b2
       sprite_x_vel[k] = kRunningMan_Xvel[j];
       sprite_y_vel[k] = kRunningMan_Yvel[j];
       Sprite_MoveXY(k);
+      GameHook_RunningManOverrun(k, true);
       if (sprite_A[k]) {
         sprite_A[k]--;
         break;
@@ -6111,6 +6114,11 @@ void Sprite_RunningMan(int k) {  // 85e8b2
       if (sprite_ai_state[k] == 1) {  // left
         sprite_A[k] = 255;
         sprite_head_dir[k] = 2;
+      } else if (kRunningMan_Dir[sprite_B[k]] < 0 && GameHook_RunningManExtendRun(k)) {
+        // widescreen: the scripted right-side path (right, down, right) is a fixed handful of
+        // frames tuned to end past a 256px screen — skip the vanilla "return to idle" and keep
+        // him running the same direction; sprite_B stays put so this stays reachable every time
+        // its re-armed timer runs out, without ever advancing past the last real leg index.
       } else {
         j = sprite_B[k]++;
         sprite_A[k] = kRunningMan_A[j];


### PR DESCRIPTION
Fixes #48.

At a wide aspect ratio the running man freezes mid-flee instead of running off, well before the fence/forest bounding the track. Two things were calibrated for the original 256px screen:

- His flee is a short, fixed-length scripted dash that hands him back to idle after a few hundred frames, tuned to already be past a 256px screen by then.
- A separate screen-relative active window (keyed to Link's on-screen position, also sized for 256px) can pause him mid-flee if the player doesn't follow.

Under `Wide_Active()` only: keep the scripted path running instead of ending it early, ignore that active-window pause while he's fleeing, and accelerate him over time until he hits the fence/forest or a distance cap, then return him to idle in place. Killing him outright was tried first but respawns a fresh copy the instant his start position re-enters the wider view, so idle-in-place is what actually sticks. 4:3 and non-extended rendering are untouched.

## Test plan
- [x] Rebuilt WASM + Electron bundle clean, `analyze:diff` reports zero gating errors
- [x] Manually verified in-game at 21:9: he now runs continuously (accelerating) and stops cleanly in both directions, including with the player standing still
- [x] Verified 4:3 / extended rendering off is unaffected (gate is a no-op)