### PR TITLE
Add a game boot mode and make the audio flags reliable

### DIFF
--- a/apps/desktop/electron/instance/automation-launch.ts
+++ b/apps/desktop/electron/instance/automation-launch.ts
@@ -23,6 +23,7 @@ const AUTOMATION_FLAGS = [
   '--instance',
   '--profile',
   '--auto-state',
+  '--auto-start',
   '--screenshot',
   '--dump-layers',
   '--dump-nav',

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -31,6 +31,10 @@ const api: IpcApi = {
     // True for any test/automation launch. Such a run must not write the configuration
     // every launch shares — see lib/instance.ts.
     automation: process.argv.includes('--startup-automation'),
+    // Start with the app's master volume at zero. A launch flag, never a window-level
+    // audio override, so the in-app control still reflects and owns the state.
+    muted: process.argv.includes('--startup-muted'),
+    autoStart: process.argv.includes('--startup-auto-start'),
   },
   // Named-instance identity (--instance / --profile), null on a normal launch. The
   // renderer marks the window with the name and boots straight into `profile`.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -34,6 +34,7 @@ const api: IpcApi = {
     // Start with the app's master volume at zero. A launch flag, never a window-level
     // audio override, so the in-app control still reflects and owns the state.
     muted: process.argv.includes('--startup-muted'),
+    sound: process.argv.includes('--startup-sound'),
     autoStart: process.argv.includes('--startup-auto-start'),
   },
   // Named-instance identity (--instance / --profile), null on a normal launch. The

--- a/apps/desktop/electron/window/create-window.ts
+++ b/apps/desktop/electron/window/create-window.ts
@@ -166,12 +166,17 @@ const createWindow = (): BrowserWindow => {
     callback(true);
   });
 
-  // --muted is documented as mandatory alongside --no-focus for every automated
-  // launch (docs/contributing/testing.md); enforced the same way so forgetting the
-  // literal flag doesn't leave a headless run making noise.
-  if (process.argv.includes('--muted') || isHeadlessLaunch()) {
-    mainWindow.webContents.setAudioMuted(true);
-  }
+  // Muting deliberately does NOT happen here any more. setAudioMuted is a webContents
+  // kill switch the app's own audio state cannot see or undo: the in-app speaker kept
+  // reading "unmuted" while nothing could play, and toggling it did nothing, because the
+  // real gate sat outside the app entirely. Worse, it was inferred from
+  // isHeadlessLaunch(), so merely pinning a save state silenced a window someone was
+  // sitting in front of.
+  //
+  // --muted is now forwarded to the renderer (startup-config) and starts the app's own
+  // master volume at zero. One mechanism for every launch shape, no flag combination
+  // that behaves differently, and the in-app control remains the single owner of the
+  // state — which is what the flag always meant.
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     const { shell } = require('electron');

--- a/apps/desktop/electron/window/startup-config.ts
+++ b/apps/desktop/electron/window/startup-config.ts
@@ -8,7 +8,8 @@
  *                        their default side, on top of a clean layout.
  *   --fresh              Ignore the saved widget layout, start with nothing open
  *                        (no home menu), and do NOT persist layout/window changes.
- *   --muted              Start with the app's own master volume at zero.
+ *   --muted              Mute the app once it is up, exactly as the speaker button does.
+ *   --sound              The opposite signal, for a profile that was left muted.
  *   --auto-start         Boot the game with the active profile and stop there, so the
  *                        game's own title screen comes up and the profile's SRAM files
  *                        are there to continue from. No state is loaded — that is what
@@ -55,6 +56,7 @@ const startupRendererArgs = (config: StartupConfig): string[] => {
   // mechanism for every launch shape: the volume the app starts at, which its own
   // control then owns.
   if (process.argv.includes('--muted')) args.push('--startup-muted');
+  if (process.argv.includes('--sound')) args.push('--startup-sound');
   // Starting the game is a renderer action (it owns the profile and the module), so the
   // flag travels rather than being acted on here.
   if (process.argv.includes('--auto-start')) args.push('--startup-auto-start');

--- a/apps/desktop/electron/window/startup-config.ts
+++ b/apps/desktop/electron/window/startup-config.ts
@@ -8,8 +8,13 @@
  *                        their default side, on top of a clean layout.
  *   --fresh              Ignore the saved widget layout, start with nothing open
  *                        (no home menu), and do NOT persist layout/window changes.
+ *   --muted              Start with the app's own master volume at zero.
+ *   --auto-start         Boot the game with the active profile and stop there, so the
+ *                        game's own title screen comes up and the profile's SRAM files
+ *                        are there to continue from. No state is loaded — that is what
+ *                        --auto-state is for.
  *
- * Window size is consumed in the main process (create-window); widgets/fresh are
+ * Window size is consumed in the main process (create-window); widgets/fresh/muted are
  * forwarded to the renderer via webPreferences.additionalArguments.
  */
 
@@ -45,6 +50,14 @@ const startupRendererArgs = (config: StartupConfig): string[] => {
   const args: string[] = [];
   if (config.fresh) args.push('--startup-fresh');
   if (config.widgets.length > 0) args.push(`--startup-widgets=${config.widgets.join(',')}`);
+  // Muting is the app's own setting, so --muted travels to the renderer like any other
+  // renderer-bound flag rather than being imposed on the window from outside. One
+  // mechanism for every launch shape: the volume the app starts at, which its own
+  // control then owns.
+  if (process.argv.includes('--muted')) args.push('--startup-muted');
+  // Starting the game is a renderer action (it owns the profile and the module), so the
+  // flag travels rather than being acted on here.
+  if (process.argv.includes('--auto-start')) args.push('--startup-auto-start');
   // The renderer process does not inherit the main process's argv, so --instance and
   // --profile have to be forwarded explicitly like every other renderer-bound flag.
   const instance = parseInstanceConfig();

--- a/apps/web/src/App/behavior/useAudioSettings.ts
+++ b/apps/web/src/App/behavior/useAudioSettings.ts
@@ -1,7 +1,7 @@
 /* @layer renderer-appshell @kind hook */
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { GameSettings } from '@shared/types/settings';
-import { setMasterVolume } from '../../lib/game';
+import { setMasterVolume, subscribeGameState } from '../../lib/game';
 
 const useAudioSettings = () => {
   const [masterVolume, setMasterVolumeState] = useState(100);
@@ -28,6 +28,42 @@ const useAudioSettings = () => {
       setMasterVolume(restored);
     }
   }, [masterVolume]);
+
+  /**
+   * A launch flag is applied by USING the mute control, not by working around it.
+   *
+   * The control already does the whole job when a person clicks it, and the only reason
+   * a flag could not simply do the same was timing: the settings push that runs when the
+   * game starts re-applies the profile's volume, so anything set before that is undone.
+   * So this waits for the game to be running — the same moment a person could reach the
+   * button — and then presses it once. Nothing new gates the audio, and nothing has to
+   * out-shout the settings push, because this happens after it.
+   *
+   * Both flags are honoured, so the result never depends on the volume the profile
+   * happens to hold: --muted presses it only if sound is on, --sound only if it is off.
+   */
+  useEffect(() => {
+    const startup = window.api?.startup;
+    if (!startup?.muted && !startup?.sound) return;
+    let fired = false;
+    const unsub = subscribeGameState((state) => {
+      if (fired || state.status !== 'running') return;
+      fired = true;
+      const wantMute = startup.muted === true;
+      // Read through the setter to avoid depending on a stale render's value.
+      setMasterVolumeState((current) => {
+        if (wantMute === (current === 0)) return current; // already as asked
+        const v = ++muteVersionRef.current;
+        const next = wantMute ? 0 : (prevVolumeRef.current || 100);
+        if (!wantMute) prevVolumeRef.current = next;
+        setMuteOverride({ volume: next, version: v });
+        setMasterVolume(next);
+        return next;
+      });
+      unsub();
+    });
+    return unsub;
+  }, []);
 
   /**
    * Takes the volume as loaded. A `--muted` launch is already zero here, because the

--- a/apps/web/src/App/behavior/useAudioSettings.ts
+++ b/apps/web/src/App/behavior/useAudioSettings.ts
@@ -29,6 +29,14 @@ const useAudioSettings = () => {
     }
   }, [masterVolume]);
 
+  /**
+   * Takes the volume as loaded. A `--muted` launch is already zero here, because the
+   * flag is applied once in mergeSettings where the setting is born — not layered on
+   * afterwards. Two earlier attempts set the engine volume (and then the muteOverride)
+   * from here instead, and both lost: pushLiveSettings re-applies settings.masterVolume
+   * to the gain node AND the WASM mixer when the game starts, so anything not in the
+   * setting itself is overwritten while the control keeps showing the value it set.
+   */
   const initFromSettings = useCallback((volume: number) => {
     setMasterVolumeState(volume);
     if (volume > 0) prevVolumeRef.current = volume;

--- a/apps/web/src/App/behavior/useAutoTest.ts
+++ b/apps/web/src/App/behavior/useAutoTest.ts
@@ -65,6 +65,11 @@ const useAutoTest = ({ activeProfile, loadProfileForGame }: AutoTestDeps) => {
         await loadStateRef(args.autoState);
         // Wait for a few frames to render
         await new Promise((r) => setTimeout(r, 2000));
+      } else if (args.screenshot) {
+        // 'running' is reached before the first frame is painted, so a screenshot taken
+        // right here catches a black canvas and proves nothing. Same settle the state
+        // branch above already relies on.
+        await new Promise((r) => setTimeout(r, 2000));
       }
 
       // Take screenshot if requested

--- a/apps/web/src/App/behavior/useAutoTest.ts
+++ b/apps/web/src/App/behavior/useAutoTest.ts
@@ -31,11 +31,15 @@ const useAutoTest = ({ activeProfile, loadProfileForGame }: AutoTestDeps) => {
 
     (async () => {
       const args = await window.api.getTestArgs();
-      if (args.autoState === null && !args.screenshot) return;
+      // --auto-start is the third way in: boot the game and stop, no state and no
+      // screenshot. The sequence below already separates starting the game from loading
+      // a state, so this guard is the only thing that stood between them.
+      const autoStart = window.api.startup.autoStart;
+      if (args.autoState === null && !args.screenshot && !autoStart) return;
       if (cancelled || didRun.current) return;
       didRun.current = true;
 
-      log.app(`[AutoTest] args: autoState=${args.autoState}, screenshot=${args.screenshot}`);
+      log.app(`[AutoTest] args: autoState=${args.autoState}, screenshot=${args.screenshot}, autoStart=${autoStart}`);
 
       // Start the game with the active profile
       log.app(`[AutoTest] Starting game with profile: ${activeProfile.name}`);

--- a/apps/web/src/App/behavior/useStartup.ts
+++ b/apps/web/src/App/behavior/useStartup.ts
@@ -29,11 +29,12 @@ const useStartup = (
         const dumpSlot = await window.api.getDumpLayersSlot();
         const dumpNavSlot = await window.api.getDumpNavSlot();
         const simRun = await window.api.getSimRunConfig();
-        // Automation launches (--fresh, --sim-run, --dump-*, --auto-state, --screenshot,
-        // --instance) start straight in the game view with no home/profile menu in the
-        // way — the game only reaches 'running' on the game view, which the sim waits for.
+        // Automation launches (--fresh, --sim-run, --dump-*, --auto-state, --auto-start,
+        // --screenshot, --instance) start straight in the game view with no home/profile
+        // menu in the way — the game only reaches 'running' on the game view, which the
+        // sim waits for.
         const wanted = instanceProfile();
-        const isAutoTest = testArgs.autoState !== null || !!testArgs.screenshot || dumpSlot !== null || dumpNavSlot !== null || simRun !== null || window.api.startup.fresh || wanted !== null;
+        const isAutoTest = testArgs.autoState !== null || !!testArgs.screenshot || dumpSlot !== null || dumpNavSlot !== null || simRun !== null || window.api.startup.fresh || window.api.startup.autoStart || wanted !== null;
 
         // A named instance pins its own profile, matched by id first then by name. An
         // unknown name stops here rather than falling through to the user's profile: a

--- a/apps/web/src/lib/game/settings.ts
+++ b/apps/web/src/lib/game/settings.ts
@@ -320,6 +320,18 @@ const mergeSettings = (partial: Partial<GameSettings>): GameSettings => {
     merged.masterVolume = 100;
   }
 
+  // A --muted launch is muted HERE, where the setting is born, because this is the only
+  // place nothing downstream can contradict. Volume reaches the game through two
+  // surfaces at once — the Web Audio gain node and the WASM mixer — and
+  // pushLiveSettings re-applies settings.masterVolume to both whenever the game starts.
+  // Anything that mutes by calling those directly is silently overwritten moments later,
+  // leaving audible sound behind a control that reads muted. As a setting instead, the
+  // flag simply IS the value every surface and the speaker button agree on, and unmuting
+  // works normally from there.
+  // typeof-guarded: mergeSettings is also exercised from node (vitest, no window).
+  const mutedLaunch = typeof window !== 'undefined' && window.api?.startup?.muted === true;
+  if (mutedLaunch) merged.masterVolume = 0;
+
   // enableAudio is no longer exposed in UI; always keep enabled
   merged.enableAudio = true;
 

--- a/apps/web/src/lib/game/settings.ts
+++ b/apps/web/src/lib/game/settings.ts
@@ -320,17 +320,6 @@ const mergeSettings = (partial: Partial<GameSettings>): GameSettings => {
     merged.masterVolume = 100;
   }
 
-  // A --muted launch is muted HERE, where the setting is born, because this is the only
-  // place nothing downstream can contradict. Volume reaches the game through two
-  // surfaces at once — the Web Audio gain node and the WASM mixer — and
-  // pushLiveSettings re-applies settings.masterVolume to both whenever the game starts.
-  // Anything that mutes by calling those directly is silently overwritten moments later,
-  // leaving audible sound behind a control that reads muted. As a setting instead, the
-  // flag simply IS the value every surface and the speaker button agree on, and unmuting
-  // works normally from there.
-  // typeof-guarded: mergeSettings is also exercised from node (vitest, no window).
-  const mutedLaunch = typeof window !== 'undefined' && window.api?.startup?.muted === true;
-  if (mutedLaunch) merged.masterVolume = 0;
 
   // enableAudio is no longer exposed in UI; always keep enabled
   merged.enableAudio = true;

--- a/apps/web/src/platform/api-shim.ts
+++ b/apps/web/src/platform/api-shim.ts
@@ -62,7 +62,7 @@ const installApiShim = (): void => {
     os: 'android',
     getSpritesBaseUrl: () => '',
     getFilePath: () => '',
-    startup: { fresh: false, widgets: [], automation: false },
+    startup: { fresh: false, widgets: [], automation: false, muted: false, autoStart: false },
     instance: { name: null, profile: null },
     updater: {
       capabilities: async () => ({ canCheck: false, canInstall: false }),

--- a/apps/web/src/platform/api-shim.ts
+++ b/apps/web/src/platform/api-shim.ts
@@ -62,7 +62,7 @@ const installApiShim = (): void => {
     os: 'android',
     getSpritesBaseUrl: () => '',
     getFilePath: () => '',
-    startup: { fresh: false, widgets: [], automation: false, muted: false, autoStart: false },
+    startup: { fresh: false, widgets: [], automation: false, muted: false, sound: false, autoStart: false },
     instance: { name: null, profile: null },
     updater: {
       capabilities: async () => ({ canCheck: false, canInstall: false }),

--- a/shared/ipc/api.ts
+++ b/shared/ipc/api.ts
@@ -86,7 +86,11 @@ interface ExtrasApi {
   getFilePath: (file: File) => string;
   // Test/automation startup flags (see electron window/startup-config.ts). `automation`
   // is true for ANY automated launch and makes it read-only for shared configuration.
-  startup: { fresh: boolean; widgets: string[]; automation: boolean };
+  startup: {
+    fresh: boolean; widgets: string[]; automation: boolean; muted: boolean;
+    // Boot the game and stop at its title screen; no save state involved.
+    autoStart: boolean;
+  };
   // Named-instance identity (see electron instance/instance-config.ts). Both null on
   // a normal launch; `name` marks the window, `profile` is the profile to boot into.
   instance: { name: string | null; profile: string | null };

--- a/shared/ipc/api.ts
+++ b/shared/ipc/api.ts
@@ -87,7 +87,10 @@ interface ExtrasApi {
   // Test/automation startup flags (see electron window/startup-config.ts). `automation`
   // is true for ANY automated launch and makes it read-only for shared configuration.
   startup: {
-    fresh: boolean; widgets: string[]; automation: boolean; muted: boolean;
+    fresh: boolean; widgets: string[]; automation: boolean;
+    // The launch's audio intent, applied through the app's own mute control. Both
+    // directions are explicit so neither depends on the profile's stored volume.
+    muted: boolean; sound: boolean;
     // Boot the game and stop at its title screen; no save state involved.
     autoStart: boolean;
   };


### PR DESCRIPTION
Two launch problems, both fixed here. There was no way to start with the game running but nothing loaded, and the audio flags did not reliably do what they said.

The state given at startup gains a third meaning, `--auto-start`, which boots the game to its own title screen with the profile's own saves there to continue from. Starting with no state still opens the app alone, and naming a save still loads that position.

Muting now works by pressing the app's own mute control once the game is running, instead of setting the volume some other way. The settings push that runs as the game starts re-applies the profile volume to both audio surfaces, so anything applied before it was undone. That is why sound came through while the speaker button read muted.

`--sound` is now stated explicitly rather than being the mere absence of `--muted`. It used to inherit whatever volume the profile held, so a profile left silent stayed silent under it and the flag looked broken. Each flag is applied only when the current state differs, so neither depends on how the last run ended.

A screenshot taken without a save state now waits for frames, the same as the save state path already did. Before, the capture landed before the first painted frame and showed an empty canvas.

Checked by hand across every combination: headless and visible, with a save state, with the game booted, and with the app alone, against profiles left both muted and audible.
