### PR TITLE
Add an Import Save button for raw SRAM files from other emulators

### DIFF
--- a/apps/web/src/ui/design-system/composites/Dialog/Dialog.tsx
+++ b/apps/web/src/ui/design-system/composites/Dialog/Dialog.tsx
@@ -13,6 +13,8 @@ const Dialog = (props: DialogProps) => {
     message,
     confirmLabel = 'Confirm',
     cancelLabel = 'Cancel',
+    confirmDisabled = false,
+    hideCancel = false,
     variant = 'default',
     onConfirm,
     onCancel,
@@ -23,8 +25,8 @@ const Dialog = (props: DialogProps) => {
 
   const actions = (
     <>
-      <Button variant="tertiary" onClick={onCancel}>{cancelLabel}</Button>
-      <Button ref={confirmRef} variant={variant === 'danger' ? 'danger' : 'primary'} onClick={onConfirm}>
+      {!hideCancel && <Button variant="tertiary" onClick={onCancel}>{cancelLabel}</Button>}
+      <Button ref={confirmRef} variant={variant === 'danger' ? 'danger' : 'primary'} onClick={onConfirm} disabled={confirmDisabled}>
         {confirmLabel}
       </Button>
     </>

--- a/apps/web/src/ui/design-system/composites/Dialog/Dialog.type.ts
+++ b/apps/web/src/ui/design-system/composites/Dialog/Dialog.type.ts
@@ -5,6 +5,8 @@
   message: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  confirmDisabled?: boolean;
+  hideCancel?: boolean;
   variant?: 'danger' | 'default';
   onConfirm: () => void;
   onCancel: () => void;

--- a/apps/web/src/ui/design-system/primitives/Toast/Toast.css
+++ b/apps/web/src/ui/design-system/primitives/Toast/Toast.css
@@ -2,12 +2,19 @@
 .toast-container {
   position: fixed;
   bottom: var(--space-lg);
-  right: var(--space-lg);
   display: flex;
   flex-direction: column-reverse;
   gap: var(--space-sm);
   pointer-events: none;
   z-index: var(--z-toast);
+}
+
+.toast-container--bottom-right {
+  right: var(--space-lg);
+}
+
+.toast-container--bottom-left {
+  left: var(--space-lg);
 }
 
 .toast {
@@ -40,6 +47,12 @@
   background: color-mix(in srgb, var(--c-info) 12%, var(--c-surface));
   border: 1px solid color-mix(in srgb, var(--c-info) 40%, transparent);
   color: var(--c-info);
+}
+
+.toast--success {
+  background: var(--c-green-dim);
+  border: 1px solid var(--c-green);
+  color: var(--c-green-bright);
 }
 
 .toast__message {

--- a/apps/web/src/ui/design-system/primitives/Toast/Toast.type.ts
+++ b/apps/web/src/ui/design-system/primitives/Toast/Toast.type.ts
@@ -1,5 +1,7 @@
 /* @layer renderer-components @kind types */
-type ToastVariant = 'danger' | 'warning' | 'info';
+type ToastVariant = 'danger' | 'warning' | 'info' | 'success';
+
+type ToastPosition = 'bottom-right' | 'bottom-left';
 
 interface ToastItem {
   id: string;
@@ -16,11 +18,13 @@ interface ToastProps {
 interface ToastContainerProps {
   toasts: ToastItem[];
   onDismiss: (id: string) => void;
+  position?: ToastPosition;
 }
 
 export type {
   ToastContainerProps,
   ToastItem,
+  ToastPosition,
   ToastProps,
   ToastVariant
 };

--- a/apps/web/src/ui/design-system/primitives/Toast/index.ts
+++ b/apps/web/src/ui/design-system/primitives/Toast/index.ts
@@ -1,4 +1,4 @@
 /* @layer renderer-components @kind barrel */
 export { Toast } from './Toast';
 export { ToastContainer } from './sub-components/ToastContainer';
-export type { ToastItem, ToastVariant, ToastProps, ToastContainerProps } from './Toast.type';
+export type { ToastItem, ToastVariant, ToastPosition, ToastProps, ToastContainerProps } from './Toast.type';

--- a/apps/web/src/ui/design-system/primitives/Toast/sub-components/ToastContainer.tsx
+++ b/apps/web/src/ui/design-system/primitives/Toast/sub-components/ToastContainer.tsx
@@ -4,13 +4,13 @@ import { Toast } from '../Toast';
 import type { ToastContainerProps } from '../Toast.type';
 
 const ToastContainer = (props: ToastContainerProps) => {
-  const { toasts, onDismiss } = props;
+  const { toasts, onDismiss, position = 'bottom-right' } = props;
 
   if (toasts.length === 0) return null;
 
   return (
     <Portal layer="toast">
-      <div className="toast-container">
+      <div className={`toast-container toast-container--${position}`}>
         {toasts.map((t) => (
           <Toast key={t.id} item={t} onDismiss={onDismiss} />
         ))}

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/HomeTab.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/HomeTab.tsx
@@ -6,6 +6,7 @@ import { HeroSaveCard } from '../../../compounds/HeroSaveCard';
 import { Box } from '../../../../../design-system/primitives/Box';
 import { Button } from '../../../../../design-system/primitives/Button';
 import { Text } from '../../../../../design-system/primitives/Text';
+import { ToastContainer } from '../../../../../design-system/primitives/Toast';
 import { formatRelativeTime } from './home-tab/home-tab-helpers';
 import { useHomeTabSaves } from './home-tab/useHomeTabSaves';
 import { HomeTabColumns } from './home-tab/HomeTabColumns';
@@ -19,7 +20,7 @@ const CAPITALIZE: CSSProperties = { textTransform: 'capitalize' };
 const HomeTab = (props: HomeTabProps) => {
   const { profileId, romFile, isGameRunning, onStartGame, lastPlayed, created, windowMode } = props;
   const saves = useHomeTabSaves({ profileId, isGameRunning, onStartGame });
-  const { heroSave, normalScreenshots, busyNormal, handleLoadNormal } = saves;
+  const { heroSave, normalScreenshots, busyNormal, handleLoadNormal, handleImportSram, toasts, dismissToast } = saves;
   const { storage, capabilities } = usePlatform();
 
   const handleOpenFolder = useCallback(async () => {
@@ -65,6 +66,16 @@ const HomeTab = (props: HomeTabProps) => {
             Open profile folder
           </Button>
         )}
+        <Button
+          variant="secondary"
+          size="sm"
+          className="home-tab__import-save-btn"
+          icon="📥"
+          onClick={() => void handleImportSram()}
+          title="Import a raw SRAM save (.srm) from another emulator"
+        >
+          Import save
+        </Button>
       </Box>
 
       {/* Hero card — last normal save */}
@@ -80,6 +91,7 @@ const HomeTab = (props: HomeTabProps) => {
 
       <HomeTabColumns saves={saves} isGameRunning={isGameRunning} />
       <HomeTabDialogs saves={saves} />
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-left" />
     </Box>
   );
 };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/HomeTabDialogs.css
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/HomeTabDialogs.css
@@ -1,0 +1,53 @@
+/* @layer renderer-components @kind style */
+
+.home-tab-dialogs__callout {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  line-height: var(--leading-tight);
+  margin: 0 0 var(--space-md);
+}
+
+.home-tab-dialogs__callout--ok {
+  background: var(--c-green-dim);
+  border: 1px solid var(--c-green);
+  color: var(--c-green-bright);
+}
+
+.home-tab-dialogs__callout--bad {
+  background: var(--c-danger-dim);
+  border: 1px solid var(--c-danger);
+  color: var(--c-danger);
+}
+
+.home-tab-dialogs__callout-icon {
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.home-tab-dialogs__warning {
+  margin: 0 0 var(--space-md);
+  color: var(--c-text);
+}
+
+.home-tab-dialogs__warning strong {
+  font-weight: var(--weight-semi);
+}
+
+.home-tab-dialogs__hint {
+  margin: 0 0 var(--space-sm);
+  color: var(--c-text-dim);
+  font-size: var(--text-sm);
+}
+
+.home-tab-dialogs__confirm-word {
+  font-family: var(--font-mono);
+  background: var(--c-gold-dim);
+  color: var(--c-gold-bright);
+  padding: 0.1em 0.5em;
+  border-radius: var(--radius-sm);
+  font-weight: var(--weight-medium);
+}

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/HomeTabDialogs.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/HomeTabDialogs.tsx
@@ -2,10 +2,18 @@
 /** Create / overwrite / delete confirmation dialogs for the Home tab. */
 import { Dialog } from '../../../../../../design-system/composites/Dialog';
 import { TextInput } from '../../../../../../design-system/primitives/TextInput';
+import { Text } from '../../../../../../design-system/primitives/Text';
+import { Box } from '../../../../../../design-system/primitives/Box';
 import type { HomeTabSaves } from './useHomeTabSaves';
+import { IMPORT_CONFIRM_WORD } from './useHomeTabSramImport';
+import './HomeTabDialogs.css';
 
 const HomeTabDialogs = ({ saves }: { saves: HomeTabSaves }) => {
-  const { dialog, setDialog, newSaveName, setNewSaveName, handleConfirmCreate, handleConfirmOverwrite, handleConfirmDelete } = saves;
+  const {
+    dialog, setDialog, newSaveName, setNewSaveName, importConfirmText, setImportConfirmText,
+    handleConfirmCreate, handleConfirmOverwrite, handleConfirmDelete,
+    handleCancelImportSram, handleConfirmImportSram,
+  } = saves;
   return (
     <>
       <Dialog
@@ -49,6 +57,53 @@ const HomeTabDialogs = ({ saves }: { saves: HomeTabSaves }) => {
         onConfirm={handleConfirmDelete}
         onCancel={() => setDialog({ type: null })}
       />
+
+      <Dialog
+        open={dialog.type === 'import-sram'}
+        title="Import Save"
+        message=""
+        confirmLabel="Import"
+        cancelLabel="Cancel"
+        confirmDisabled={importConfirmText.trim().toLowerCase() !== IMPORT_CONFIRM_WORD}
+        variant="danger"
+        onConfirm={handleConfirmImportSram}
+        onCancel={handleCancelImportSram}
+      >
+        <Box className="home-tab-dialogs__callout home-tab-dialogs__callout--ok">
+          <Text as="span" className="home-tab-dialogs__callout-icon">✓</Text>
+          <Text as="span">{dialog.detail}</Text>
+        </Box>
+        <Text as="p" className="home-tab-dialogs__warning">
+          Replace this profile's save with <Text as="strong">"{dialog.targetName}"</Text>? The current
+          in-game save is overwritten and this cannot be undone.
+        </Text>
+        <Text as="p" className="home-tab-dialogs__hint">
+          Type <Text as="code" className="home-tab-dialogs__confirm-word">{IMPORT_CONFIRM_WORD}</Text> to confirm.
+        </Text>
+        <TextInput
+          className="home-tab__import-confirm-input"
+          value={importConfirmText}
+          onChange={(e) => setImportConfirmText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && importConfirmText.trim().toLowerCase() === IMPORT_CONFIRM_WORD) handleConfirmImportSram(); }}
+          placeholder={IMPORT_CONFIRM_WORD}
+          autoFocus
+        />
+      </Dialog>
+
+      <Dialog
+        open={dialog.type === 'import-sram-invalid'}
+        title="Not a Valid Save"
+        message=""
+        confirmLabel="OK"
+        hideCancel
+        onConfirm={() => setDialog({ type: null })}
+        onCancel={() => setDialog({ type: null })}
+      >
+        <Box className="home-tab-dialogs__callout home-tab-dialogs__callout--bad">
+          <Text as="span" className="home-tab-dialogs__callout-icon">⚠</Text>
+          <Text as="span">{dialog.detail ?? 'That file is not a valid ALttP SRAM save.'}</Text>
+        </Box>
+      </Dialog>
     </>
   );
 };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/home-tab.type.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/home-tab.type.ts
@@ -17,9 +17,11 @@ interface SlotInfo {
 }
 
 interface DialogState {
-  type: 'overwrite' | 'delete' | 'create' | null;
+  type: 'overwrite' | 'delete' | 'create' | 'import-sram' | 'import-sram-invalid' | null;
   targetId?: string;
   targetName?: string;
+  pendingBytes?: Uint8Array;
+  detail?: string;
 }
 
 export type { HomeTabProps, SlotInfo, DialogState };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/sram-checksum.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/sram-checksum.ts
@@ -1,0 +1,32 @@
+/* @layer renderer-components @kind logic */
+/** Ports the game's own save-slot checksum (Intro_CheckCksum, core/zelda3/src/select_file.c:15)
+ *  so an imported SRAM file can be verified before it's ever loaded into the running core. */
+
+const SLOT_BYTES = 0x500;
+const SLOT_WORDS = 0x280;
+const BACKUP_OFFSET = 0xf00;
+const VALID_CHECKSUM = 0x5a5a;
+const SLOT_COUNT = 3;
+
+const slotChecksumValid = (bytes: Uint8Array, offset: number): boolean => {
+  let sum = 0;
+  for (let i = 0; i < SLOT_WORDS; i++) {
+    sum += bytes[offset + i * 2] | (bytes[offset + i * 2 + 1] << 8);
+  }
+  return (sum & 0xffff) === VALID_CHECKSUM;
+};
+
+// A slot counts as valid if either its primary copy or its 0xf00 backup checksums correctly —
+// the same fallback the game itself uses (Intro_ValidateSram).
+const validSramSlots = (bytes: Uint8Array): number[] => {
+  const slots: number[] = [];
+  for (let i = 0; i < SLOT_COUNT; i++) {
+    const base = i * SLOT_BYTES;
+    if (slotChecksumValid(bytes, base) || slotChecksumValid(bytes, base + BACKUP_OFFSET)) {
+      slots.push(i);
+    }
+  }
+  return slots;
+};
+
+export { validSramSlots };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/useHomeTabSaves.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/useHomeTabSaves.ts
@@ -1,6 +1,7 @@
 /* @layer renderer-components @kind hook */
 /** All Home-tab save/session state, data loading, and action handlers. */
 import { useState, useEffect, useCallback } from 'react';
+import { usePlatform } from '@app/platform';
 import type { NormalSaveInfo, AutoSaveInfo } from '@shared/types/saves';
 import type { PlaySession } from '@shared/types/session';
 import { saveState, loadState, captureStateBuffer, loadStateFromBuffer } from '../../../../../../../lib/game';
@@ -10,9 +11,13 @@ import * as savesStore from '@app/lib/storage/saves-store';
 import type { SlotInfo, DialogState } from './home-tab.type';
 import { QUICK_SAVE_SLOTS, defaultSaveName, ensureGameRunning, captureCanvasScreenshot } from './home-tab-helpers';
 import { fetchQuickSlots, fetchNormalSaves, fetchAutoSaves } from './home-tab-data';
+import { useHomeTabToasts } from './useHomeTabToasts';
+import { useHomeTabSramImport } from './useHomeTabSramImport';
 
 const useHomeTabSaves = (params: { profileId: string; isGameRunning: boolean; onStartGame: () => void }) => {
   const { profileId, isGameRunning, onStartGame } = params;
+  const { filePicker } = usePlatform();
+  const { toasts, showToast, dismissToast } = useHomeTabToasts();
 
   const [slots, setSlots] = useState<SlotInfo[]>(() =>
     Array.from({ length: QUICK_SAVE_SLOTS }, (_, i) => ({ slot: i, timestamp: null, screenshot: null }))
@@ -27,6 +32,9 @@ const useHomeTabSaves = (params: { profileId: string; isGameRunning: boolean; on
   const [sessions, setSessions] = useState<PlaySession[]>([]);
   const [dialog, setDialog] = useState<DialogState>({ type: null });
   const [newSaveName, setNewSaveName] = useState('');
+  const {
+    importConfirmText, setImportConfirmText, handleImportSram, handleCancelImportSram, handleConfirmImportSram,
+  } = useHomeTabSramImport({ profileId, filePicker, dialog, setDialog, showToast });
 
   const loadQuickSlots = async () => { const d = await fetchQuickSlots(profileId); if (d) setSlots(d); };
   const loadNormalSaves = async () => {
@@ -154,10 +162,11 @@ const useHomeTabSaves = (params: { profileId: string; isGameRunning: boolean; on
 
   return {
     slots, busySlot, normalSaves, normalScreenshots, busyNormal, autoSaves, autoScreenshots, busyAuto, sessions,
-    dialog, setDialog, newSaveName, setNewSaveName, heroSave,
+    dialog, setDialog, newSaveName, setNewSaveName, heroSave, toasts, dismissToast,
+    importConfirmText, setImportConfirmText,
     handleQuickSave, handleQuickLoad, handleCreateNormalSave, handleConfirmCreate, handleLoadNormal,
     handleOverwriteNormal, handleConfirmOverwrite, handleDeleteNormal, handleConfirmDelete, handleRenameNormal,
-    handleLoadAuto, handleDeleteAuto,
+    handleLoadAuto, handleDeleteAuto, handleImportSram, handleCancelImportSram, handleConfirmImportSram,
   };
 };
 

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/useHomeTabSramImport.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/useHomeTabSramImport.ts
@@ -1,0 +1,75 @@
+/* @layer renderer-components @kind hook */
+/** Picking, validating, and importing a raw SRAM save into this profile's sram.dat. */
+import { useState, useCallback } from 'react';
+import type { FilePickerPort } from '@shared/platform';
+import * as savesStore from '@app/lib/storage/saves-store';
+import { log } from '../../../../../../../lib/log-bus';
+import type { DialogState } from './home-tab.type';
+import { validSramSlots } from './sram-checksum';
+
+const SRAM_BYTES = 8192; // core/zelda3/src/zelda_rtl.c:1345 — the cartridge's fixed SRAM size
+const IMPORT_CONFIRM_WORD = 'import'; // typed, not the filename — a deliberate action, not a memory test
+
+const useHomeTabSramImport = (params: {
+  profileId: string;
+  filePicker: FilePickerPort;
+  dialog: DialogState;
+  setDialog: (dialog: DialogState) => void;
+  showToast: (message: string) => void;
+}) => {
+  const { profileId, filePicker, dialog, setDialog, showToast } = params;
+  const [importConfirmText, setImportConfirmText] = useState('');
+
+  const handleImportSram = useCallback(async () => {
+    const picked = await filePicker.pickFile({ extensions: ['srm', 'sav', 'dat'] });
+    if (!picked) return;
+
+    if (picked.bytes.byteLength !== SRAM_BYTES) {
+      setDialog({
+        type: 'import-sram-invalid',
+        targetName: picked.name,
+        detail: `"${picked.name}" is ${picked.bytes.byteLength} bytes — a raw SRAM save is always exactly ${SRAM_BYTES} bytes.`,
+      });
+      return;
+    }
+
+    const validSlots = validSramSlots(picked.bytes);
+    if (validSlots.length === 0) {
+      setDialog({
+        type: 'import-sram-invalid',
+        targetName: picked.name,
+        detail: `"${picked.name}" is the right size, but none of its 3 save slots pass the game's own checksum — this isn't a valid ALttP save file.`,
+      });
+      return;
+    }
+
+    setImportConfirmText('');
+    setDialog({
+      type: 'import-sram',
+      targetName: picked.name,
+      pendingBytes: picked.bytes,
+      detail: `Verified: ${validSlots.length} of 3 save slot(s) pass the game's checksum.`,
+    });
+  }, [filePicker, setDialog]);
+
+  const handleCancelImportSram = useCallback(() => {
+    setDialog({ type: null });
+    setImportConfirmText('');
+  }, [setDialog]);
+
+  const handleConfirmImportSram = useCallback(async () => {
+    const { pendingBytes, targetName } = dialog;
+    setDialog({ type: null });
+    setImportConfirmText('');
+    if (!pendingBytes) return;
+    await savesStore.writeSram(profileId, pendingBytes.buffer as ArrayBuffer);
+    log.app(`Imported SRAM save from "${targetName}" — takes effect next time this profile loads`);
+    showToast(`Save imported from "${targetName}"`);
+  }, [profileId, dialog, setDialog, showToast]);
+
+  return {
+    importConfirmText, setImportConfirmText, handleImportSram, handleCancelImportSram, handleConfirmImportSram,
+  };
+};
+
+export { useHomeTabSramImport, IMPORT_CONFIRM_WORD };

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/useHomeTabToasts.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/home-tab/useHomeTabToasts.ts
@@ -1,0 +1,24 @@
+/* @layer renderer-components @kind hook */
+/** Local toast queue for the Home tab, separate from ProfileHub's own so the two
+ *  unrelated features never share mutable state. */
+import { useState, useCallback } from 'react';
+import type { ToastItem, ToastVariant } from '@ds/primitives/Toast';
+
+const TOAST_DURATION_MS = 4000;
+
+const useHomeTabToasts = () => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const showToast = useCallback((message: string, variant: ToastVariant = 'success') => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setToasts((prev) => [...prev, { id, message, variant, duration: TOAST_DURATION_MS }]);
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { toasts, showToast, dismissToast };
+};
+
+export { useHomeTabToasts };


### PR DESCRIPTION
## Summary
- Adds an "Import save" button on the profile Home tab, next to "Open profile folder", to bring in a raw SRAM battery-save (e.g. a Snes9x `.srm`) from another emulator.
- The picked file is verified against the game's own save-slot checksum (`Intro_CheckCksum`) before anything is written — a clear dialog either confirms it's a real save (type "import" to proceed) or explains why it isn't, with no import path offered.
- A toast confirms once the write completes.
- Reuses existing primitives rather than adding new ones: `Dialog` gained a disableable confirm button and a single-action mode, `Toast` gained a success variant and a second corner position.

## Test plan
- [x] Verified in a worktree: valid save shows the checksum-verified confirm dialog, wrong-size and checksum-failing files show the "Not a Valid Save" dialog, successful import shows a toast.
- [x] Checksum port cross-checked in Node against a real save file and deliberately corrupted variants.
- [x] `npm run analyze:ci` — 0 violations across all 14 changed files.
- [x] `npx tsc --noEmit` — no new errors (one pre-existing, unrelated vault-dataset error).