### PR TITLE
Reset the sprite setting when a sprite is deleted

### DIFF
--- a/apps/web/src/lib/game/player-sheet/delete-sprite.ts
+++ b/apps/web/src/lib/game/player-sheet/delete-sprite.ts
@@ -1,0 +1,45 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Delete a sprite from the library and drop it from every profile that had it selected.
+ *
+ * A profile's `linkSprite` is only a file name, so removing the file on its own leaves a
+ * dangling selection: the boot path logs "not found" and quietly falls back to the stock
+ * sheet, which reads as the setting having changed itself. Putting the setting back to its
+ * default at delete time keeps the profile honest about what will actually happen, and a
+ * running game still wearing the deleted sheet is returned to stock in the same breath.
+ *
+ * Every profile is checked, not just the active one, because the library is global: a
+ * sprite deleted here may be selected by profiles that are not loaded right now, and they
+ * would each hit the same dangling selection on their next boot.
+ */
+import { deleteLinkSprite } from '@app/lib/storage/link-sprites-store';
+import { listProfiles, readConfig, writeConfig } from '@app/lib/storage/profile-store';
+import { getProfileId } from '../wasm-bridge';
+import { setLinkSpriteData } from '../lifecycle';
+import { clearPlayerSprite } from '../player-sprite';
+
+/** Deletes the file, then clears the selection wherever it pointed. Returns those profile ids. */
+const deleteSprite = async (name: string): Promise<string[]> => {
+  await deleteLinkSprite(name);
+
+  const profiles = await listProfiles();
+  const cleared: string[] = [];
+  for (const profile of profiles) {
+    const config = await readConfig(profile.id);
+    if (!config || config.linkSprite !== name) continue;
+    await writeConfig(profile.id, { ...config, linkSprite: null });
+    cleared.push(profile.id);
+  }
+
+  // Only the active profile's selection is the one the core is actually wearing, so the
+  // live restore is gated on it having been among those cleared.
+  const active = getProfileId();
+  if (active && cleared.includes(active)) {
+    setLinkSpriteData(null);
+    clearPlayerSprite();
+  }
+
+  return cleared;
+};
+
+export { deleteSprite };

--- a/apps/web/src/ui/domains/app/views/PlayerSpriteStudio/PlayerSpriteStudio.tsx
+++ b/apps/web/src/ui/domains/app/views/PlayerSpriteStudio/PlayerSpriteStudio.tsx
@@ -70,7 +70,8 @@ const PlayerSpriteStudio = (props: PlayerSpriteStudioProps) => {
   }, [library]);
 
   const handleDelete = useCallback((name: string) => {
-    onDeleteConfirm('Delete player sprite', `Delete "${name}"? This cannot be undone.`, async () => {
+    const message = `Delete "${name}"? Any profile using it goes back to the original sprite. This cannot be undone.`;
+    onDeleteConfirm('Delete player sprite', message, async () => {
       if (draft.draft?.file === name) draft.close();
       await library.remove(name);
     });

--- a/apps/web/src/ui/domains/app/views/PlayerSpriteStudio/behavior/useSpriteLibrary.ts
+++ b/apps/web/src/ui/domains/app/views/PlayerSpriteStudio/behavior/useSpriteLibrary.ts
@@ -9,8 +9,9 @@
  */
 import { useState, useEffect, useCallback } from 'react';
 import {
-  listLinkSprites, importLinkSprite, deleteLinkSprite, spriteStem,
+  listLinkSprites, importLinkSprite, spriteStem,
 } from '@app/lib/storage/link-sprites-store';
+import { deleteSprite } from '@app/lib/game/player-sheet/delete-sprite';
 import { loadSheet } from '@app/lib/game/player-sheet/load-sheet';
 import { renderThumbnail } from '@app/lib/game/player-sheet/thumbnail';
 import { isRspName } from '@app/lib/game/rsp';
@@ -64,8 +65,10 @@ const useSpriteLibrary = () => {
     return { success: true, message: `Imported ${spriteStem(result.name ?? name)}` };
   }, [refresh]);
 
+  // Deleting also puts the selection back to default on any profile that pointed at it,
+  // so no profile is left naming a sprite that no longer exists.
   const remove = useCallback(async (name: string) => {
-    await deleteLinkSprite(name);
+    await deleteSprite(name);
     await refresh();
   }, [refresh]);
 


### PR DESCRIPTION
Follow up to #154. Deleting a sprite left any profile that had it selected pointing at a file that was gone. It fell back to the original sprite at boot anyway, so nothing broke, but the setting still named the deleted sprite and looked like it had changed itself.

- clears the selection on every profile that used it, not just the active one
- puts the running game back to the stock sheet if it was wearing it
- the confirm now says that's going to happen