### PR TITLE
Fix the lamp cone leaking into the widescreen margins

### DIFF
--- a/apps/web/src/lib/game/config.ts
+++ b/apps/web/src/lib/game/config.ts
@@ -26,7 +26,7 @@ ItemSwitchLR = 0
 TurnWhileDashing = 0
 CollectItemsWithSword = 0
 DisableLowHealthBeep = 0
-SkipIntroOnKeypress = 0
+SkipIntroOnKeypress = 1
 DisableTelepathy = 0
 `;
 

--- a/apps/web/src/lib/game/settings.ts
+++ b/apps/web/src/lib/game/settings.ts
@@ -67,7 +67,7 @@ const DEFAULT_SETTINGS: GameSettings = {
   collectItemsWithSword: false,
   breakPotsWithSword: false,
   disableLowHealthBeep: false,
-  skipIntroOnKeypress: false,
+  skipIntroOnKeypress: true,
   disableTelepathy: false,
   showMaxItemsInYellow: false,
   moreActiveBombs: false,

--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -61,6 +61,14 @@ uint8 GameHook_ApplyExtraArmor(uint8 dmg);
 // overwrites that byte along with the rest of WRAM) never leaves a stale value behind.
 uint8 GameHook_GetWantedIgnoreCollision(void);
 
+// ─── View gates (view_gates.c) ───
+
+// True while the lamp's light-cone mask is on the subscreen, so the extended view must collapse to
+// the base frame: the mask only covers 256 pixels and its tilemap wraps, so any extra width samples
+// a second, undarkened copy of the cone. Covers the room-transition frames where the game clears
+// hdr_dungeon_dark_with_lantern while the mask is still being drawn. Wide view only.
+bool GameHook_LightConeSuppressesExtraWidth(void);
+
 // ─── Custom player sprite sheets (player_sprite.c) ───
 
 // Overwrite the player gfx asset from a ZSPR sheet and take its palette into the PPU's private player

--- a/core/game-hooks/view_gates.c
+++ b/core/game-hooks/view_gates.c
@@ -1,0 +1,39 @@
+/* @layer core-game-hooks @kind native */
+#include "game_hooks_internal.h"
+
+// ─── Light-Cone Extra-Width Gate ───
+//
+// A dark room lit by the lamp draws its darkness with color math: the room is on the main
+// screen, an opaque mask sits on BG1 on the subscreen, and the fixed color is subtracted
+// everywhere the mask leaves transparent. The mask is a 256-wide construct on a tilemap that
+// wraps every 512 pixels, so it only ever covers the base 4:3 frame. Widen the view and the
+// margins sample the wrapped tilemap instead: a second, undarkened copy of the lit cone appears
+// at the far left (and past the right edge). ConfigurePpuSideSpace therefore keeps the extra
+// width at zero for as long as that mask is on screen.
+//
+// `hdr_dungeon_dark_with_lantern && TS_copy` describes the mask exactly while the player has
+// control, and nothing else here changes that. It is wrong during a room transition: Module07_02
+// clears the flag at subsubmodule 1 (Module07_02_01_LoadNextRoom) while the mask itself stays on
+// BG1 untouched until subsubmodule 3 turns the subscreen off, so the fade-out frames in between
+// re-open the margins under a mask that is still being drawn — the reported leak. The flag comes
+// back only at subsubmodule 12, once the destination room is up.
+//
+// Rather than restate when the game does and doesn't clear the flag, latch the answer from the
+// last frame the player had control and hold it for the transition: a transition that began under
+// the mask stays collapsed until the next room settles, whatever the flag does in between.
+static bool s_cone_held;
+
+bool GameHook_LightConeSuppressesExtraWidth(void) {
+  const bool live = hdr_dungeon_dark_with_lantern != 0 && TS_copy != 0;
+  // Only the indoor module's own sub-states are a transition. main_module_index (not the
+  // menu-remapped module the caller works with) is deliberate: the pause menu freezes the room
+  // behind it with the mask exactly as it was, so it must read as settled, not as in flight.
+  const bool in_transition = main_module_index == MODULE_DUNGEON && submodule_index != 0;
+  if (live || !in_transition) {
+    s_cone_held = live;
+    return live;
+  }
+  // Held only for the wide view, the one thing that can expose the wrapped mask. Without it this
+  // is the plain live test, so a 4:3 (or vertical-only) configuration behaves exactly as before.
+  return Wide_Active() && s_cone_held;
+}

--- a/core/wasm-build/build.mjs
+++ b/core/wasm-build/build.mjs
@@ -50,7 +50,7 @@ const hookSrcs = [
   'state_queries_room_objects', 'attr_grid_state', 'gated_empty', 'receive_counters',
   'sim_queries', 'sim_triggers', 'item_overrides', 'check_triggers', 'ui_state', 'cheats', 'haptic_events',
   'player_sprite', 'transition_events', 'state_queries_combat', 'state_queries_oam',
-  'host_gates', 'hud_override', 'running_man', 'music_hooks', 'sound_hooks',
+  'host_gates', 'hud_override', 'running_man', 'music_hooks', 'sound_hooks', 'view_gates',
 ].map((f) => h(`${f}.c`));
 
 // Our Emscripten entry points (replace the native main.c). Resolved from this dir.

--- a/core/zelda3/src/ending.c
+++ b/core/zelda3/src/ending.c
@@ -504,9 +504,22 @@ void Polyhedral_InitializeThread() {  // 89f7de
 }
 
 void Module00_Intro() {  // 8cc120
-  uint8 skip_at = enhanced_features0 & kFeatures0_SkipIntroOnKeypress ? 4 : 8;
+  static uint8 skip_pending;
+  bool skip_early = (enhanced_features0 & kFeatures0_SkipIntroOnKeypress) != 0;
+  // Submodule 2 is the earliest frame the sequence can be abandoned safely: the 1kb-block clear of
+  // WRAM and the tileset load both finish as submodule 1 ends. Vanilla waits for 8 instead, by
+  // which point the whole logo animation has played out.
+  uint8 skip_at = skip_early ? 2 : 8;
+  bool pressed = ((filtered_joypad_L & 0xc0 | filtered_joypad_H) & 0xd0) != 0;
 
-  if (submodule_index >= skip_at && ((filtered_joypad_L & 0xc0 | filtered_joypad_H) & 0xd0)) {
+  if (submodule_index == 0)
+    skip_pending = 0;
+  // Remembering the press means a button mashed during those first frames still counts, instead of
+  // being swallowed for landing a few frames before the skip became safe.
+  if (skip_early && pressed)
+    skip_pending = 1;
+  if ((skip_early ? skip_pending : pressed) && submodule_index >= skip_at) {
+    skip_pending = 0;
     FadeMusicAndResetSRAMMirror();
     return;
   }

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -415,8 +415,9 @@ static void ConfigurePpuSideSpace() {
       }
     }
   } else if (mod == 7) {
-    // indoors, except when the light cone is in use
-    if (!(hdr_dungeon_dark_with_lantern && TS_copy != 0)) {
+    // indoors, except when the light cone is in use — including the room-transition frames where the
+    // game has cleared hdr_dungeon_dark_with_lantern but the cone mask is still on the subscreen.
+    if (!GameHook_LightConeSuppressesExtraWidth()) {
       int qm = quadrant_fullsize_x >> 1;
       extra_left = IntMax(BG2HOFS_copy2 - room_bounds_x.v[qm], 0);
       extra_right = IntMax(room_bounds_x.v[qm + 2] - BG2HOFS_copy2, 0);

--- a/shared/features/feature-registry.ts
+++ b/shared/features/feature-registry.ts
@@ -437,7 +437,7 @@ const GAMEPLAY_FEATURES: FeatureDef[] = [
     origin: 'snesrev',
     flag: 'kFeatures0_SkipIntroOnKeypress',
     bit: 128,
-    default: false,
+    default: true,
     requires: [],
     affectsVanillaParity: true,
     live: true,


### PR DESCRIPTION
Two small fixes.

The dark room lamp cone was showing up again at the far left during a room transition. The mask that darkens the room only covers the base 256px frame and its tilemap wraps every 512px, so any extra width picks up a second undarkened copy of the cone. There is already a guard that collapses the view while the cone is up, but the game clears the dark-with-lantern flag at the start of a room transition while the mask is still being drawn, so the margins reopened for the fade out frames.

- latch the guard on the last frame the player had control, hold it until the next room settles
- only held when a wide view is on, so 4:3 behaves exactly as before
- intro skip now fires at submodule 2 instead of 8, so it actually skips the logo animation
- a press made before the skip is safe is remembered instead of dropped
- skip on keypress is on by default now