### PR TITLE
Add an always illuminate dark room cheat

### DIFF
--- a/apps/web/src/lib/game/cheats.ts
+++ b/apps/web/src/lib/game/cheats.ts
@@ -124,6 +124,19 @@ const cheatSetIgnoreCollision = (on: boolean): void => {
 
 const getIgnoreCollisionEnabled = (): boolean => ignoreCollisionEnabled;
 
+// ─── Lighting ───
+
+// Same local-state reasoning as ignore-collision above: the widget's toggle reads this instead of
+// polling the module. The core applies it on the next frame boundary, not at this call.
+let illuminateDarkRoomsEnabled = false;
+
+const cheatSetIlluminateDarkRooms = (on: boolean): void => {
+  illuminateDarkRoomsEnabled = on;
+  voidCall('WasmCheatSetIlluminateDarkRooms', numArgs(on ? 1 : 0));
+};
+
+const getIlluminateDarkRoomsEnabled = (): boolean => illuminateDarkRoomsEnabled;
+
 // ─── Combat ───
 
 const cheatKillAllEnemies = (): void => voidCall('WasmCheatKillAllEnemies');
@@ -136,5 +149,5 @@ const cheatSetExtraArmorPct = (pct: number): void =>
 
 const cheatStartTrace = (frames = 120): void => voidCall('WasmCheatStartTrace', numArgs(frames));
 
-export { BottleContents, cheatGiveItem, cheatTriggerCheck, cheatTriggerNpcCheck, cheatSetHealth, cheatSetMaxHealth, cheatSetRupees, cheatSetBombs, cheatSetArrows, cheatRefillMagic, cheatFillBottle, cheatSetIgnoreCollision, getIgnoreCollisionEnabled, cheatKillAllEnemies, cheatSetDamageMultiplier, cheatSetExtraArmorPct, cheatStartTrace };
+export { BottleContents, cheatGiveItem, cheatTriggerCheck, cheatTriggerNpcCheck, cheatSetHealth, cheatSetMaxHealth, cheatSetRupees, cheatSetBombs, cheatSetArrows, cheatRefillMagic, cheatFillBottle, cheatSetIgnoreCollision, getIgnoreCollisionEnabled, cheatSetIlluminateDarkRooms, getIlluminateDarkRoomsEnabled, cheatKillAllEnemies, cheatSetDamageMultiplier, cheatSetExtraArmorPct, cheatStartTrace };
 export type { BottleContentsValue };

--- a/apps/web/src/lib/game/index.ts
+++ b/apps/web/src/lib/game/index.ts
@@ -23,6 +23,7 @@ export {
   cheatGiveItem, cheatTriggerCheck, cheatTriggerNpcCheck,
   cheatSetHealth, cheatSetMaxHealth, cheatSetRupees, cheatSetBombs, cheatSetArrows, cheatRefillMagic,
   cheatFillBottle, cheatSetIgnoreCollision, getIgnoreCollisionEnabled,
+  cheatSetIlluminateDarkRooms, getIlluminateDarkRoomsEnabled,
   cheatKillAllEnemies, cheatSetDamageMultiplier, cheatSetExtraArmorPct,
   cheatStartTrace,
   BottleContents,

--- a/apps/web/src/ui/domains/widgets/cheats/tabs/MechanicsTab.tsx
+++ b/apps/web/src/ui/domains/widgets/cheats/tabs/MechanicsTab.tsx
@@ -1,6 +1,7 @@
 /* @layer renderer-widgets @kind component */
 /**
- * MechanicsTab — Kill enemies, damage multiplier, extra armor reduction, ignore collision.
+ * MechanicsTab — Kill enemies, damage multiplier, extra armor reduction, ignore collision,
+ * dark-room lighting.
  */
 import { useState } from 'react';
 import { Box, Text, Button } from '../../../../design-system/primitives';
@@ -8,6 +9,7 @@ import { Toggle } from '../../../../design-system/primitives/Toggle';
 import {
   cheatKillAllEnemies, cheatSetDamageMultiplier, cheatSetExtraArmorPct,
   cheatSetIgnoreCollision, getIgnoreCollisionEnabled,
+  cheatSetIlluminateDarkRooms, getIlluminateDarkRoomsEnabled,
 } from '../../../../../lib/game';
 
 const DAMAGE_OPTIONS = [
@@ -31,6 +33,7 @@ const MechanicsTab = () => {
   const [damageMult, setDamageMult] = useState(1);
   const [extraArmor, setExtraArmor] = useState(0);
   const [ignoreCollision, setIgnoreCollision] = useState(getIgnoreCollisionEnabled());
+  const [illuminate, setIlluminate] = useState(getIlluminateDarkRoomsEnabled());
 
   const handleDamage = (value: number) => {
     setDamageMult(value);
@@ -47,12 +50,20 @@ const MechanicsTab = () => {
     cheatSetIgnoreCollision(on);
   };
 
+  const handleIlluminate = (on: boolean) => {
+    setIlluminate(on);
+    cheatSetIlluminateDarkRooms(on);
+  };
+
   return (
     <Box className="cheats-tab-mechanics">
       <Box className="cheats-section">
         <Box className="cheats-section__title">Mechanics</Box>
         <Box className="cheats-row">
           <Toggle label="Ignore movement restriction/collision" checked={ignoreCollision} onChange={handleIgnoreCollision} />
+        </Box>
+        <Box className="cheats-row">
+          <Toggle label="Always illuminate dark room" checked={illuminate} onChange={handleIlluminate} />
         </Box>
       </Box>
 

--- a/core/game-hooks/cheat_lighting.c
+++ b/core/game-hooks/cheat_lighting.c
@@ -1,0 +1,62 @@
+/* @layer core-game-hooks @kind native */
+#include "game_hooks_internal.h"
+
+// ─── Always Illuminate Dark Rooms ───
+//
+// A dark room only lights up around the player when the game decides the lamp is in use, and the
+// single thing that decision turns on is whether the item is owned: Hud_RestoreTorchBackground
+// (hud.c) sets hdr_dungeon_dark_with_lantern and puts the mask layer on the subscreen, and bails
+// out first thing if link_item_torch is clear. So the cheat is not a light of its own, it is that
+// same pair of bytes asserted without the item. Everything downstream, the mask positioning, the
+// color math, the transitions, is the vanilla path and never learns the difference.
+//
+// The writes go through ZeldaWriteCheatByte for the same reason the walk-through-walls byte does:
+// these live in WRAM, a save-state load overwrites them wholesale, and only a recorded write keeps
+// a replay reproducing frame for frame. Re-asserting every frame is what makes the cheat survive a
+// load with no "reapply on restore" special case anywhere.
+
+static bool g_wanted_illuminate;
+
+static bool IlluminateArmed(void) {
+  // No category bit of its own: lighting is not collision, items, stats or combat, so this tests
+  // the master cheat switch directly, the same choice WasmCheatStartTrace makes. Vanilla Safe
+  // strips that switch on the way into WRAM, so it disarms this too.
+  return (enhanced_features3 & kFeatures3_CheatsEnabled) != 0 && g_wanted_illuminate;
+}
+
+// Whether this frame's cone state is ours to drive at all. Player in control of a dark indoor room,
+// no torch lit (a lit torch lights the whole room, which is the game's own reason to drop the cone),
+// and crucially no lamp owned: with the item the game already does the right thing every frame and
+// fighting it could only ever make things worse. That last clause is also what makes the disarm
+// safe, since a cone standing in a lampless dark room can only be one we raised.
+static bool ConeIsOurs(void) {
+  return main_module_index == MODULE_DUNGEON && submodule_index == 0
+      && dung_want_lights_out != 0 && dung_num_lit_torches == 0 && link_item_torch == 0;
+}
+
+void CheatLighting_Sync(void) {
+  if (!ConeIsOurs())
+    return;
+  if (IlluminateArmed()) {
+    ZeldaWriteCheatByte(0x458, 1);  // hdr_dungeon_dark_with_lantern
+    // bg2 property 2 is the one dark-room flavor the game leaves the subscreen alone for.
+    if (dung_hdr_bg2_properties != 2)
+      ZeldaWriteCheatByte(0x1D, 1);  // TS_copy
+  } else if (hdr_dungeon_dark_with_lantern) {
+    ZeldaWriteCheatByte(0x458, 0);
+    if (dung_hdr_bg2_properties != 2)
+      ZeldaWriteCheatByte(0x1D, 0);
+  }
+}
+
+// ─── WASM Export ───
+
+// Arm/disarm lighting dark rooms without the lamp. Sets the wanted state only, never pokes WRAM:
+// CheatLighting_Sync() above is the single writer, so the cheat applies on the next frame boundary
+// and a save-state load can never leave it half-applied.
+EMSCRIPTEN_KEEPALIVE
+void WasmCheatSetIlluminateDarkRooms(int on) {
+  if (!(enhanced_features3 & kFeatures3_CheatsEnabled)) return;
+  g_wanted_illuminate = on != 0;
+  printf("[Cheat] SetIlluminateDarkRooms: %d\n", g_wanted_illuminate);
+}

--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -114,6 +114,13 @@ void HudOverride_Sync(void);
 
 void HudOverride_Restore(void);
 
+// ─── Dark-room lighting cheat (cheat_lighting.c) ───
+
+// Re-assert (or take back down) the lamp cone in a dark room the player has no lamp for. Runs every
+// frame after SyncGateWords/SyncCheatWram, and is a no-op unless the cheat is armed or a cone it
+// raised is still standing.
+void CheatLighting_Sync(void);
+
 // ─── Receive counters (receive_counters.c) ───
 
 // Tally an item grant against its call site, so a check granted twice is visible rather than inferred.

--- a/core/wasm-build/build.mjs
+++ b/core/wasm-build/build.mjs
@@ -51,6 +51,7 @@ const hookSrcs = [
   'sim_queries', 'sim_triggers', 'item_overrides', 'check_triggers', 'ui_state', 'cheats', 'haptic_events',
   'player_sprite', 'transition_events', 'state_queries_combat', 'state_queries_oam',
   'host_gates', 'hud_override', 'running_man', 'music_hooks', 'sound_hooks', 'view_gates',
+  'cheat_lighting',
 ].map((f) => h(`${f}.c`));
 
 // Our Emscripten entry points (replace the native main.c). Resolved from this dir.

--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -1110,13 +1110,19 @@ static const CheatWramSlot kCheatWramSlots[] = {
 // clobber the byte and the very next frame writes it right back — nothing "reapplies cheats on load"
 // as a special case, because there is no load-specific code path here at all.
 static void SyncCheatWram(void) {
-  for (int i = 0; i < (int)(sizeof(kCheatWramSlots) / sizeof(kCheatWramSlots[0])); i++) {
-    uint8 *byte = &g_ram[kCheatWramSlots[i].addr];
-    uint8 wanted = kCheatWramSlots[i].wanted();
-    if (*byte == wanted) continue;
-    *byte = wanted;
-    StateRecorder_RecordPatchByte(&state_recorder, kCheatWramSlots[i].addr, byte, 1);
-  }
+  for (int i = 0; i < (int)(sizeof(kCheatWramSlots) / sizeof(kCheatWramSlots[0])); i++)
+    ZeldaWriteCheatByte(kCheatWramSlots[i].addr, kCheatWramSlots[i].wanted());
+}
+
+// The single write primitive every cheat-owned WRAM byte goes through, whether it comes from the
+// table above or from a hook that has to decide more than one byte at a time (game-hooks'
+// CheatLighting_Sync). Writes only on mismatch and records the patch, so a replay reproduces the
+// same bytes frame-for-frame and an unchanged byte costs nothing.
+void ZeldaWriteCheatByte(uint16 addr, uint8 value) {
+  uint8 *byte = &g_ram[addr];
+  if (*byte == value) return;
+  *byte = value;
+  StateRecorder_RecordPatchByte(&state_recorder, addr, byte, 1);
 }
 
 // Copy each changed gate word into WRAM, mirror it into the emulator's RAM, and record the patch in the
@@ -1192,6 +1198,8 @@ bool ZeldaRunFrame(int inputs) {
       SyncCheatWram();
       // Same ordering requirement: reads the HUD-override gate SyncGateWords() just latched.
       HudOverride_Sync();
+      // Same again: the dark-room lighting cheat tests the master cheat switch this frame.
+      CheatLighting_Sync();
     }
   }
 

--- a/core/zelda3/src/zelda_rtl.h
+++ b/core/zelda3/src/zelda_rtl.h
@@ -49,6 +49,8 @@ void ZeldaReset(bool preserve_sram);
 void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags);
 void ZeldaRunFrameInternal(uint16 input, int run_what);
 bool ZeldaRunFrame(int input_state);
+// Write one cheat-owned WRAM byte: on mismatch only, and recorded so a replay reproduces it.
+void ZeldaWriteCheatByte(uint16 addr, uint8 value);
 void LoadSongBank(const uint8 *p);
 void ZeldaApuLock();
 void ZeldaApuUnlock();


### PR DESCRIPTION
Adds a toggle in the Mechanics section of the cheat widget that lights dark rooms without owning the lamp.

Turns out the only thing gating the lit cone is the ownership check at the top of Hud_RestoreTorchBackground, so this is that same pair of bytes asserted without the item. Everything after it is the vanilla path.

- only acts in a lampless dark room with the player in control, so it can never fight the real lamp
- that also makes turning it off take the cone straight back down
- writes go through a new ZeldaWriteCheatByte pulled out of SyncCheatWram, so they are recorded for replays and survive a save state load
- gated on the master cheat switch like the trace cheat, no new category bit