### PR TITLE
Fix the overworld special areas rendering each other's terrain

### DIFF
--- a/core/zelda3/src/zelda_rtl.c
+++ b/core/zelda3/src/zelda_rtl.c
@@ -157,22 +157,20 @@ static uint16 g_ow_src_map16[0x1000];  // copy of dung_bg2 (64x64 map16) for the
 static int g_ow_src_xs, g_ow_src_xe, g_ow_src_ys, g_ow_src_ye, g_ow_src_area;
 
 // Blit one overworld area's map16 (64-wide) into the linear world buffer as map8 tiles, at tile offset
-// (offX, offY). Tiles falling outside the buffer are skipped (the caller clears it first for the gaps).
+// (offX, offY). The offset may be NEGATIVE (the map starts before the buffer), so the source range is
+// clamped up front rather than tested per cell; tiles outside the buffer are simply never visited, and
+// the caller clears the buffer first wherever gaps can remain.
 static void BlitAreaMap16(uint16 *world, int worldW, int worldH, const uint16 *map16,
                           int areaWt, int areaHt, int offX, int offY, const uint16 *map8) {
-  for (int ay = 0; ay < areaHt; ay++) {
-    int by = offY + ay;
-    if ((unsigned)by >= (unsigned)worldH)
-      continue;
+  int ay0 = IntMax(0, -offY), ay1 = IntMin(areaHt, worldH - offY);
+  int ax0 = IntMax(0, -offX), ax1 = IntMin(areaWt, worldW - offX);
+  for (int ay = ay0; ay < ay1; ay++) {
     const uint16 *m16row = map16 + (size_t)(ay >> 1) * 64;
-    uint16 *dst = world + (size_t)by * worldW;
+    uint16 *dst = world + (size_t)(offY + ay) * worldW;
     int suby = ay & 1;
-    for (int ax = 0; ax < areaWt; ax++) {
-      int bx = offX + ax;
-      if ((unsigned)bx >= (unsigned)worldW)
-        continue;
+    for (int ax = ax0; ax < ax1; ax++) {
       const uint16 *s = map8 + (size_t)m16row[ax >> 1] * 4;  // 2x2 sub-tiles: TL=s[0] TR=s[1] BL=s[2] BR=s[3]
-      dst[bx] = s[suby * 2 + (ax & 1)];
+      dst[offX + ax] = s[suby * 2 + (ax & 1)];
     }
   }
 }
@@ -188,20 +186,28 @@ static void BuildOverworldWorldTilemap() {
   int h = (((int)ow_scroll_vars0.yend - originY) >> 3) + 32;
   w = IntMax(0, IntMin(w, kPpuWorldTiles));
   h = IntMax(0, IntMin(h, kPpuWorldTiles));
-  // dung_bg2 is a 64x64 map16 = at most 128x128 map8 tiles. The special overworld's scroll range
-  // overshoots that (yend 0x320 + the 256px view = 132 tile rows), and blitting the overshoot would read
-  // past the map16 (see the same note in BuildTransitionWorldTilemap), so only the real extent is blitted.
-  int bw = IntMin(w, 128), bh = IntMin(h, 128);
-  if (bw < w || bh < h)
+  // Where dung_bg2's tile (0,0) actually sits in world pixels. For a normal area that IS the scroll
+  // range's origin, but the overworld special areas pack several sub-locations into one map16 and give
+  // each its own camera bounds, so the two diverge there by whole screens. Blitting at (0,0) regardless
+  // made such a sub-location draw the tiles of whichever one sits at the map origin, while collision and
+  // every other lookup — which all go through this same origin — kept using the right ones.
+  int offX = ((((int)overworld_offset_base_x) << 3) - originX) >> 3;
+  int offY = (((int)overworld_offset_base_y) - originY) >> 3;
+  // dung_bg2 is a 64x64 map16 = 128x128 map8 tiles, and that is its whole extent: blitting further would
+  // read past it (the special overworld's scroll range alone reaches 132 tile rows).
+  int bw = 128, bh = 128;
+  if (offX > 0 || offY > 0 || offX + bw < w || offY + bh < h)
     memset(bg->world, 0, (size_t)w * h * sizeof(uint16));
-  BlitAreaMap16(bg->world, w, h, dung_bg2, bw, bh, 0, 0, GetMap16toMap8Table());
+  BlitAreaMap16(bg->world, w, h, dung_bg2, bw, bh, offX, offY, GetMap16toMap8Table());
   // Repeat the last real row over the vertical overshoot instead of leaving it a no-data gap. The camera
   // range genuinely allows one row more than the area owns: the bottom scanline samples vScroll + 224, so
   // at the range's lowest camera (yend) that is row 1024 of a 1024-row area. Left as a gap it rendered as
   // a hard coloured line across the foot of the screen; repeating the row above makes it continue the
   // terrain, which is what the hardware's overscan hid.
-  for (int ry = bh; ry < h; ry++)
-    memcpy(bg->world + (size_t)ry * w, bg->world + (size_t)(bh - 1) * w, (size_t)w * sizeof(uint16));
+  int lastRow = offY + bh - 1;
+  if (lastRow >= 0)
+    for (int ry = lastRow + 1; ry < h; ry++)
+      memcpy(bg->world + (size_t)ry * w, bg->world + (size_t)lastRow * w, (size_t)w * sizeof(uint16));
   bg->worldW = w, bg->worldH = h;
   // The overworld BG scroll wraps at the 1024px tilemap, so the PPU hScroll/vScroll carry only the low 10
   // bits. worldOff re-adds the 1024-aligned high part minus the area origin, so the fetch's local (x,y)


### PR DESCRIPTION
## Summary

The Master Sword grove and the Under the Bridge spot are two sub-locations of one overworld special area. They share a single 64x64 map16 and each carries its own camera bounds, so the resident map's origin and the scroll range's origin are different values there. Every normal area has them equal, which is why building the linear world tilemap at tile (0,0) of the buffer had worked everywhere else.

Under the bridge the scroll range starts at 0x100 while the map16 starts at 0, so the terrain was drawn 256px off and that spot rendered the pedestal grove's columns. Collision and the trigger tiles go through `overworld_offset_base_x/y`, which stayed correct, so the place walked like the bridge and looked like the grove.

- Blit at the real map origin, and let `BlitAreaMap16` take a negative offset by clamping the source range up front instead of testing every cell. Fewer iterations than the old per-cell guards.
- A normal area computes an offset of zero and renders exactly as before. A boot-frame pixel diff on a normal screen comes back at max delta 8, which is water animation phase only.
- Verified headlessly on the reported save: before, the pedestal and the grove floor; after, the sleeper by his campfire, his tent, the bridge pillars and the stepping stones.
- Gating: `BuildOverworldWorldTilemap` only runs when a wide, tall or locked view is active, so with extended rendering off none of this executes.

While I was in here I also measured the grove animals, since they looked like they were respawning endlessly. They are not: standing still after they scatter produces zero respawns in 25 seconds, and the same scripted walk gives 10 spawns at 16:9 against 14 on the stock 4:3 path. The churn is the original's own and slightly heavier there, so nothing in this PR changes it.

## Related issues

Closes #167
Closes #171

## Checklist

- [x] `npm run ci` passes locally (tsc, eslint, analyze, WASM export-drift)
- [x] Follows the [coding standards](../docs/contributing/coding-standards.md) (≤200 lines/file, arrow functions, exports at end, files tagged)
- [x] No copyrighted game assets, ROMs, or extracted data are committed
- [x] If C code under `core/` changed: `build.bat` and `Makefile` exports are in sync and the WASM was rebuilt
- [x] Relevant docs updated

## Notes for reviewers

One file, 25 lines. The only behavioural change is which columns of a shared map16 land in the wide-view buffer, and only for the areas where the two origins differ, which is the 4 special-area exits.
