### PR TITLE
feat(msu): title reset, bed stop path, chance layers and a music debugger

### DIFF
--- a/apps/desktop/electron/profiles/ipc-handlers.ts
+++ b/apps/desktop/electron/profiles/ipc-handlers.ts
@@ -1,6 +1,6 @@
 /* @layer electron-main @kind logic */
 import { handle } from '../lib/ipc/handle';
-import type { Profile } from '@shared/types/profile';
+import type { Profile, ProfilePatch } from '@shared/types/profile';
 import { listProfiles, createProfile, loadProfile, updateProfile, deleteProfile } from './store';
 import { loadAppState, saveAppState } from './app-state';
 
@@ -40,12 +40,16 @@ const registerProfileHandlers = (): void => {
     }
   });
 
-  handle('profiles:update', async (_event, id: string, patch: Partial<Profile>) => {
+  // A patch distinguishes three things, and the middle one used to be unreachable: a key that is
+  // ABSENT leaves the field alone, a key holding NULL clears it, and a key holding a value sets it.
+  // Clearing was written as `undefined`, which is indistinguishable from absent once the patch has
+  // crossed the IPC boundary — so picking "None" for a pack or language silently kept the old one.
+  handle('profiles:update', async (_event, id: string, patch: ProfilePatch) => {
     const profile = await loadProfile(id);
     if (!profile) return null;
-    if (patch.name !== undefined) profile.name = patch.name;
-    if (patch.language !== undefined) profile.language = patch.language;
-    if (patch.msuPack !== undefined) profile.msuPack = patch.msuPack;
+    if (patch.name != null) profile.name = patch.name;
+    if (patch.language !== undefined) profile.language = patch.language ?? undefined;
+    if (patch.msuPack !== undefined) profile.msuPack = patch.msuPack ?? undefined;
     await updateProfile(profile);
     return profile;
   });

--- a/apps/web/src/App/behavior/buildChromeProps.ts
+++ b/apps/web/src/App/behavior/buildChromeProps.ts
@@ -56,6 +56,7 @@ const buildChromeProps = (deps: ChromePropsDeps): TitleBarProps => {
     onShowConnectionDebug: () => widgets.toggle('navigation'),
     onToggleDataset: () => widgets.toggle('dataset'),
     onToggleSimulator: () => widgets.toggle('simulator'),
+    onToggleMusic: () => widgets.toggle('music'),
     onShowShadowEditor: handleShowShadowEditor,
     onShowAbout: () => nav.setActivePage('about'),
     onShowBugReport: () => setShowBugReportDialog(true),

--- a/apps/web/src/App/behavior/load-profile-helpers.ts
+++ b/apps/web/src/App/behavior/load-profile-helpers.ts
@@ -5,13 +5,9 @@ import type { mergeSettings } from '../../lib/game/settings';
 import { log } from '../../lib/log-bus';
 import { readInputProfiles } from '@app/lib/storage/profile-data-store';
 import { updateActiveInputProfileId } from '@app/lib/storage/profile-store';
-import * as msuStore from '@app/lib/storage/msu-store';
 import { readSpriteAsZspr } from '@app/lib/game/player-sheet/load-sheet';
 import type { InputProfile } from '@shared/types/controls';
-import { detectMsuPackProfile, resolveMsuPlayback } from '@shared/features/msu-auto-config';
-import { effectivePackManifest } from '@shared/storage/msu-classic-manifest';
-import { liveSettingsNow } from '@app/lib/game/live-settings';
-import { startMsuSession, stopMsuSession } from '@app/lib/game/msu-session';
+import { loadMsuPack } from '@app/lib/game/msu-pack-loader';
 
 type Settings = ReturnType<typeof mergeSettings>;
 
@@ -30,80 +26,6 @@ const loadInputProfile = async (profileId: string, settings: Settings) => {
     }
   } catch {
     /* no saved profiles — InputManager stays on keyboard default */
-  }
-};
-
-/**
- * Hands the profile's music pack to the audio engine. Nothing is preloaded: the engine reads
- * and decodes a track the first time the game asks for it, so assigning a multi-gigabyte pack
- * no longer costs anything at boot.
- */
-/** One group's effective volume: the slider when independent mix is on, full passthrough when off. */
-const groupVolume = (s: Settings, read: (s: Settings) => number): number =>
-  (s.perGroupVolume ? read(s) : 100);
-
-const loadMsuPack = async (profile: Profile, settings: Settings) => {
-  stopMsuSession();
-  if (!profile.msuPack) return;
-  const packName = profile.msuPack;
-
-  try {
-    const tracks = await msuStore.getMsuTrackList(packName);
-    const manifest = await msuStore.readMsuManifest(packName);
-    // A pack with no manifest is a classic one: its numbered files become one layer each.
-    const audioFiles = manifest ? await msuStore.listMsuAudioFiles(packName) : [];
-    if (!manifest && tracks.length === 0) {
-      log.app(`[MSU] Pack "${packName}" has no playable tracks`);
-      return;
-    }
-
-    const plan = resolveMsuPlayback(settings, detectMsuPackProfile(tracks, manifest !== null));
-    // In Auto these were derived from the pack; write them back so the boot INI, the settings UI
-    // and the audio device all agree with what is actually going to play.
-    settings.enableMSU = plan.resolved.enableMSU;
-    settings.audioFreq = plan.resolved.audioFreq;
-    settings.audioChannels = plan.resolved.audioChannels;
-    settings.audioSamples = plan.resolved.audioSamples;
-
-    if (!plan.enabled) {
-      log.app(`[MSU] Replacement music off for this profile`);
-      return;
-    }
-    log.app(`[MSU] Resolved '${plan.resolved.enableMSU}' @ ${plan.resolved.audioFreq}Hz, ${plan.resolved.audioChannels}ch, buffer ${plan.resolved.audioSamples}`);
-
-    const live = (): Settings => liveSettingsNow() ?? settings;
-    startMsuSession({
-      manifest: effectivePackManifest(packName, manifest, tracks),
-      isDeluxe: plan.isDeluxe,
-      loadBytes: async (fileName) => {
-        try {
-          const buffer = await msuStore.readMsuTrackFile(packName, fileName);
-          return new Uint8Array(buffer);
-        } catch {
-          return null;
-        }
-      },
-      // Every callback reads the settings AS THEY ARE, not as they were when the profile
-      // loaded: these closures live for the whole session, and a captured snapshot would pin
-      // the sliders to their boot-time values. The load-time object is only the fallback for
-      // the moments before the first live push.
-      //
-      // Music volume only takes effect once the independent-mix toggle is on, matching the
-      // sound chip's own behavior — otherwise replacement music would obey a slider the
-      // original music ignores. Effects and the bed read their sliders on the same terms.
-      musicVolume: () => groupVolume(live(), (s) => (s.musicMuted ? 0 : s.musicVolume)),
-      sfxVolume: () => groupVolume(live(), (s) => (s.sfxMuted ? 0 : s.sfxVolume)),
-      ambientVolume: () => groupVolume(live(), (s) => (s.ambientMuted ? 0 : s.ambientVolume)),
-      resumeEnabled: () => live().resumeMSU,
-      // Vanilla Safe already stops the session from starting at all (resolveMsuPlayback), but a
-      // gate handed to the core is worth denying twice rather than relying on that.
-      replaceAmbient: settings.packReplaceAmbient && !settings.vanillaSafe,
-      replaceSfx: settings.packReplaceSfx && !settings.vanillaSafe,
-    });
-    log.app(`[MSU] Pack "${packName}" ready — ${manifest ? `${manifest.tracks.length} authored tracks, ${audioFiles.length} files` : `${tracks.length} tracks`}${plan.isDeluxe ? ', extended numbering' : ''}`);
-  } catch (err) {
-    log.error(`[MSU] Failed to prepare pack: ${err instanceof Error ? err.message : err}`);
-    stopMsuSession();
   }
 };
 

--- a/apps/web/src/lib/game/bridge/host-gates.ts
+++ b/apps/web/src/lib/game/bridge/host-gates.ts
@@ -16,6 +16,9 @@ const HOST_GATE_EXTERNAL_AMBIENT = 4;
 // One bit for both effect channels: a pack claims individual ids per channel, so the two are
 // never armed separately — the claim masks are what decide which sounds the host takes over.
 const HOST_GATE_EXTERNAL_SFX = 8;
+// Diagnostics: report every sound the game raises, claimed or not, without moving any of them
+// off the sound chip. Never on in normal play — see setSoundTrace.
+const HOST_GATE_SOUND_TRACE = 16;
 
 let word = 0;
 
@@ -54,7 +57,23 @@ const setExternalAmbient = (on: boolean): void => setBit(HOST_GATE_EXTERNAL_AMBI
 /** The same for both effect channels, which share one bit — see the constant above. */
 const setExternalSfx = (on: boolean): void => setBit(HOST_GATE_EXTERNAL_SFX, on);
 
+/**
+ * Turn the sound trace on. Purely observational: it changes which sounds are REPORTED, never
+ * which of them the chip still plays, so a traced session sounds exactly like an untraced one.
+ */
+const setSoundTrace = (on: boolean): void => setBit(HOST_GATE_SOUND_TRACE, on);
+
 /** A fresh core starts with every gate clear; drop the mirror so it cannot go stale. */
 const resetHostGates = (): void => { word = 0; };
 
-export { setSimulatorSupport, setExternalMusic, setExternalAmbient, setExternalSfx, resetHostGates };
+/**
+ * Push the mirror onto the core as it is, dedupe or not. A bit set BEFORE the module existed —
+ * a debugger opened ahead of the game — was mirrored but never delivered, and setBit's dedupe
+ * would then treat every later arming of it as already done. Call once the module is installed.
+ */
+const reassertHostGates = (): void => { if (word !== 0) push(); };
+
+export {
+  setSimulatorSupport, setExternalMusic, setExternalAmbient, setExternalSfx, setSoundTrace,
+  resetHostGates, reassertHostGates,
+};

--- a/apps/web/src/lib/game/lifecycle.ts
+++ b/apps/web/src/lib/game/lifecycle.ts
@@ -12,7 +12,7 @@ import { getModule, setModule, setProfileId, getProfileId, setState, setInput, g
 import { startSramSync, stopSramSync } from './sram-sync';
 import { startAutoSave, stopAutoSave, saveOnQuit } from './auto-save';
 import { resetMasterVolume } from './audio-volume';
-import { resetHostGates } from './bridge/host-gates';
+import { reassertHostGates, resetHostGates } from './bridge/host-gates';
 import { reassertLiveFlagsAfterLoad } from './live-settings';
 import { initTrackerBridge, destroyTrackerBridge } from './tracker';
 import { initTransitionEventsBridge, destroyTransitionEventsBridge } from './events/transition-events';
@@ -204,6 +204,9 @@ const startGame = async (canvas: HTMLCanvasElement, assetData: Uint8Array, confi
     });
 
     setModule(module);
+    // Gate bits armed while no module existed (a debugger opened before the game) were mirrored
+    // but never delivered; the core has just booted with every gate clear, so send them now.
+    reassertHostGates();
     setProfileId(profileId ?? null);
     // Debug-only handle for devtools inspection; the canonical module ref is
     // wasm-bridge's `currentModule` (set via setModule above) — never read this in code.

--- a/apps/web/src/lib/game/live-settings-keys.ts
+++ b/apps/web/src/lib/game/live-settings-keys.ts
@@ -100,6 +100,10 @@ const LIVE_SETTINGS: ReadonlySet<keyof GameSettings> = new Set([
   // same as those settings do on their own.
   // Player sprite sheet (swapped in place via WasmApplyPlayerSpriteFile)
   'linkSprite',
+  // Replacement-music position handling. Both are read by the running engine on every music
+  // event rather than captured at session start, so a change applies to the very next one.
+  'resumeMSU',
+  'resetMSUAtTitle',
 ]);
 
 export { LIVE_SETTINGS };

--- a/apps/web/src/lib/game/msu-pack-loader.ts
+++ b/apps/web/src/lib/game/msu-pack-loader.ts
@@ -1,0 +1,116 @@
+/* @layer bridge-wasm @kind logic */
+/**
+ * Starting, stopping and re-starting the replacement-audio session for a profile.
+ *
+ * Lives here rather than beside the other profile-load helpers because it is not app-shell work:
+ * it reads storage and drives the engine, with no React in it, and the Data Manager has to be able
+ * to re-run it when someone changes the pack on a profile that is already playing.
+ */
+import type { mergeSettings } from './settings';
+import { log } from '../log-bus';
+import * as msuStore from '@app/lib/storage/msu-store';
+import { listProfiles, readConfig } from '@app/lib/storage/profile-store';
+import { detectMsuPackProfile, resolveMsuPlayback } from '@shared/features/msu-auto-config';
+import { effectivePackManifest } from '@shared/storage/msu-classic-manifest';
+import { liveSettingsNow } from './live-settings';
+import { startMsuSession, stopMsuSession } from './msu-session';
+import { mergeSettings as merge } from './settings';
+
+type Settings = ReturnType<typeof mergeSettings>;
+
+/**
+ * The profile the live session belongs to. A pack change for any OTHER profile is a stored edit
+ * that takes effect the next time that profile is loaded, and must not disturb what is playing.
+ */
+let sessionProfileId: string | null = null;
+
+/**
+ * Hands the profile's music pack to the audio engine. Nothing is preloaded: the engine reads
+ * and decodes a track the first time the game asks for it, so assigning a multi-gigabyte pack
+ * no longer costs anything at boot.
+ */
+/** One group's effective volume: the slider when independent mix is on, full passthrough when off. */
+const groupVolume = (s: Settings, read: (s: Settings) => number): number =>
+  (s.perGroupVolume ? read(s) : 100);
+
+const loadMsuPack = async (profile: Profile, settings: Settings) => {
+  stopMsuSession();
+  sessionProfileId = profile.id;
+  if (!profile.msuPack) return;
+  const packName = profile.msuPack;
+
+  try {
+    const tracks = await msuStore.getMsuTrackList(packName);
+    const manifest = await msuStore.readMsuManifest(packName);
+    // A pack with no manifest is a classic one: its numbered files become one layer each.
+    const audioFiles = manifest ? await msuStore.listMsuAudioFiles(packName) : [];
+    if (!manifest && tracks.length === 0) {
+      log.app(`[MSU] Pack "${packName}" has no playable tracks`);
+      return;
+    }
+
+    const plan = resolveMsuPlayback(settings, detectMsuPackProfile(tracks, manifest !== null));
+    // In Auto these were derived from the pack; write them back so the boot INI, the settings UI
+    // and the audio device all agree with what is actually going to play.
+    settings.enableMSU = plan.resolved.enableMSU;
+    settings.audioFreq = plan.resolved.audioFreq;
+    settings.audioChannels = plan.resolved.audioChannels;
+    settings.audioSamples = plan.resolved.audioSamples;
+
+    if (!plan.enabled) {
+      log.app(`[MSU] Replacement music off for this profile`);
+      return;
+    }
+    log.app(`[MSU] Resolved '${plan.resolved.enableMSU}' @ ${plan.resolved.audioFreq}Hz, ${plan.resolved.audioChannels}ch, buffer ${plan.resolved.audioSamples}`);
+
+    const live = (): Settings => liveSettingsNow() ?? settings;
+    startMsuSession({
+      manifest: effectivePackManifest(packName, manifest, tracks),
+      isDeluxe: plan.isDeluxe,
+      loadBytes: async (fileName) => {
+        try {
+          const buffer = await msuStore.readMsuTrackFile(packName, fileName);
+          return new Uint8Array(buffer);
+        } catch {
+          return null;
+        }
+      },
+      // Every callback reads the settings AS THEY ARE, not as they were when the profile
+      // loaded: these closures live for the whole session, and a captured snapshot would pin
+      // the sliders to their boot-time values. The load-time object is only the fallback for
+      // the moments before the first live push.
+      //
+      // Music volume only takes effect once the independent-mix toggle is on, matching the
+      // sound chip's own behavior — otherwise replacement music would obey a slider the
+      // original music ignores. Effects and the bed read their sliders on the same terms.
+      musicVolume: () => groupVolume(live(), (s) => (s.musicMuted ? 0 : s.musicVolume)),
+      sfxVolume: () => groupVolume(live(), (s) => (s.sfxMuted ? 0 : s.sfxVolume)),
+      ambientVolume: () => groupVolume(live(), (s) => (s.ambientMuted ? 0 : s.ambientVolume)),
+      resumeEnabled: () => live().resumeMSU,
+      resetAtTitle: () => live().resetMSUAtTitle,
+      // Vanilla Safe already stops the session from starting at all (resolveMsuPlayback), but a
+      // gate handed to the core is worth denying twice rather than relying on that.
+      replaceAmbient: settings.packReplaceAmbient && !settings.vanillaSafe,
+      replaceSfx: settings.packReplaceSfx && !settings.vanillaSafe,
+    });
+    log.app(`[MSU] Pack "${packName}" ready — ${manifest ? `${manifest.tracks.length} authored tracks, ${audioFiles.length} files` : `${tracks.length} tracks`}${plan.isDeluxe ? ', extended numbering' : ''}`);
+  } catch (err) {
+    log.error(`[MSU] Failed to prepare pack: ${err instanceof Error ? err.message : err}`);
+    stopMsuSession();
+  }
+};
+
+/**
+ * Re-run the pack for a profile whose assignment just changed, so the change is audible now
+ * instead of at the next boot. A no-op for any profile that is not the one currently playing.
+ */
+const reloadMsuForProfile = async (profileId: string): Promise<boolean> => {
+  if (sessionProfileId !== profileId) return false;
+  const profile = (await listProfiles()).find((p) => p.id === profileId);
+  if (!profile) return false;
+  const saved = await readConfig(profileId);
+  await loadMsuPack(profile, merge((saved ?? {}) as Parameters<typeof merge>[0]));
+  return true;
+};
+
+export { loadMsuPack, reloadMsuForProfile, groupVolume };

--- a/apps/web/src/lib/game/msu-session.ts
+++ b/apps/web/src/lib/game/msu-session.ts
@@ -9,7 +9,7 @@
  */
 import type { MsuPackManifest, MsuResumeState } from '@shared/types/msu-manifest';
 import { createMsuEngine } from '../msu/engine';
-import type { MsuEngine } from '../msu/engine';
+import type { ChannelReport, MsuChannelName, MsuEngine } from '../msu/engine';
 import type { LoadBytes } from '../msu/track-loader';
 import { getMasterAudioTarget } from './audio-volume';
 import { announceCoreMusic } from './bridge/announce-music';
@@ -29,6 +29,8 @@ interface MsuSessionOptions {
   /** The bed's own slider — a storm sits under quiet music without touching either. */
   ambientVolume: () => number;
   resumeEnabled: () => boolean;
+  /** Whether returning to the title forgets those positions, so the next run starts clean. */
+  resetAtTitle: () => boolean;
   /**
    * Whether the pack may replace the ambient bed and the sound effects. Read once, here, because
    * the claim masks and gate bits are published to the core at session start — flipping either
@@ -70,7 +72,9 @@ const build = (options: MsuSessionOptions): boolean => {
     sfxVolume: options.sfxVolume,
     ambientVolume: options.ambientVolume,
     resumeEnabled: options.resumeEnabled,
+    resetAtTitle: options.resetAtTitle,
     onError: (message) => log.error(`[MSU] ${message}`),
+    onReset: () => log.app('[MSU] Back at the title — bed and effects stopped, positions cleared'),
     onTrack: (trackNum, layerCount, resumed) =>
       log.app(`[MSU] Track ${trackNum} playing — ${layerCount} layer(s)${resumed ? ', resumed' : ''}`),
     onAmbient: (soundId, layerCount, resumed) =>
@@ -146,7 +150,11 @@ const msuRestore = (state: MsuResumeState | null): void => { engine?.restore(sta
 
 const msuSyncVolume = (): void => { engine?.syncVolume(); };
 
+/** One channel's live state, for the music debugger's meters. Null when silent or no session. */
+const msuChannelReport = (name: MsuChannelName): ChannelReport | null =>
+  engine?.reportChannel(name) ?? null;
+
 const isMsuSessionActive = (): boolean => engine !== null;
 
-export { startMsuSession, stopMsuSession, msuSnapshot, msuRestore, msuSyncVolume, isMsuSessionActive };
+export { startMsuSession, stopMsuSession, msuSnapshot, msuRestore, msuSyncVolume, msuChannelReport, isMsuSessionActive };
 export type { MsuSessionOptions };

--- a/apps/web/src/lib/game/music-debug.ts
+++ b/apps/web/src/lib/game/music-debug.ts
@@ -1,0 +1,159 @@
+/* @layer bridge-wasm @kind logic */
+/**
+ * The music debugger's data: every sound event in one ordered feed, with running counts.
+ *
+ * Three sources land here. The core's sound trace reports every id the game raises — claimed or
+ * not, so the feed shows what the chip is playing next to what the pack replaced. The core's
+ * music trace does the same for the music-control port, fades included, even when no pack owns
+ * music. The engine's debug bus adds the one thing neither can see: chance rolls, where a layer
+ * decided not to sound at all.
+ *
+ * The core-side gate costs host-calls while armed, so it is armed only while a debugger is
+ * actually watching (`setMusicDebugArmed`); the engine's bus is free and always on.
+ */
+import { SOUND_CHANNELS } from '../msu/sound-claim';
+import { subscribeMsuDebug } from '../msu/debug-bus';
+import { setSoundTrace } from './bridge/host-gates';
+import { subscribeGameState } from './wasm-bridge';
+
+/** Who produced (or suppressed) the sound: the pack's engine, the sound chip, or a lost roll. */
+type MusicDebugOwner = 'pack' | 'chip' | 'skipped';
+
+interface MusicDebugEvent {
+  id: number;
+  /** Wall-clock ms, for the feed's timestamps. */
+  at: number;
+  channel: 'music' | 'ambient' | 'sfx1' | 'sfx2';
+  /** One human-readable line: what was raised or decided. */
+  detail: string;
+  owner: MusicDebugOwner;
+}
+
+interface MusicDebugCounter {
+  key: string;
+  channel: string;
+  label: string;
+  raised: number;
+  pack: number;
+  chip: number;
+  skipped: number;
+  lastAt: number;
+}
+
+const MAX_EVENTS = 120;
+
+/** The game's fade bytes, named the way the disassembly names them. */
+const MUSIC_CODES: Record<number, string> = {
+  0xf0: 'pause', 0xf1: 'fade out', 0xf2: 'duck', 0xf3: 'full volume',
+};
+
+let nextId = 0;
+let events: MusicDebugEvent[] = [];
+const counters = new Map<string, MusicDebugCounter>();
+const listeners = new Set<() => void>();
+
+const notify = (): void => { listeners.forEach((listener) => listener()); };
+
+const push = (event: Omit<MusicDebugEvent, 'id' | 'at'>): void => {
+  events = [...events.slice(-(MAX_EVENTS - 1)), { ...event, id: nextId++, at: Date.now() }];
+};
+
+const count = (key: string, channel: string, label: string, owner: MusicDebugOwner): void => {
+  const row = counters.get(key)
+    ?? { key, channel, label, raised: 0, pack: 0, chip: 0, skipped: 0, lastAt: 0 };
+  row.raised += 1;
+  if (owner === 'pack') row.pack += 1;
+  else if (owner === 'chip') row.chip += 1;
+  else row.skipped += 1;
+  row.lastAt = Date.now();
+  counters.set(key, row);
+};
+
+const hex = (id: number): string => `0x${id.toString(16).padStart(2, '0')}`;
+
+declare global {
+  interface Window {
+    /** The core's sound trace: every raise on the three sound ports, with its claim verdict. */
+    __onSoundTrace?: (channel: number, id: number, pan: number, claimed: number) => void;
+    /** The core's music trace: every accepted music-control write, and who owns music. */
+    __onMusicTrace?: (ctrl: number, module: number, external: number) => void;
+  }
+}
+
+window.__onSoundTrace = (channel, id, pan, claimed) => {
+  const name = SOUND_CHANNELS[channel] ?? 'sfx1';
+  const owner: MusicDebugOwner = claimed ? 'pack' : 'chip';
+  const panNote = pan ? ` pan ${hex(pan)}` : '';
+  push({ channel: name, detail: `${hex(id)}${panNote}`, owner });
+  count(`${name}:${id}`, name, hex(id), owner);
+  notify();
+};
+
+window.__onMusicTrace = (ctrl, module, external) => {
+  const owner: MusicDebugOwner = external ? 'pack' : 'chip';
+  const label = MUSIC_CODES[ctrl] ?? `track ${ctrl}`;
+  push({ channel: 'music', detail: `${label} (module ${module})`, owner });
+  count(`music:${ctrl}`, 'music', label, owner);
+  notify();
+};
+
+subscribeMsuDebug((event) => {
+  const channel = event.channel as MusicDebugEvent['channel'];
+  const outcome = event.passed ? 'played' : 'skipped';
+  push({
+    channel,
+    detail: `roll ${event.chance}% → ${outcome} — ${event.layerName}`,
+    owner: event.passed ? 'pack' : 'skipped',
+  });
+  count(`roll:${event.channel}:${event.programId}:${event.layerId}`, channel,
+    `${event.layerName} @${event.chance}%`, event.passed ? 'pack' : 'skipped');
+  notify();
+});
+
+/**
+ * Whether a debugger wants the traces on. Kept here rather than trusting the gate mirror: every
+ * game boot starts from a cleared gate word (resetGame wipes the mirror, then the core comes up
+ * with nothing set), so an arming made before or across a boot has to be applied AGAIN once the
+ * new core is running. The subscription below does that for as long as a debugger is armed.
+ */
+let armed = false;
+
+subscribeGameState((state) => {
+  if (state.status === 'running' && armed) setSoundTrace(true);
+});
+
+/** Arm or disarm the core-side traces. The feed keeps whatever it has already collected. */
+const setMusicDebugArmed = (on: boolean): void => {
+  armed = on;
+  setSoundTrace(on);
+};
+
+const clearMusicDebug = (): void => {
+  events = [];
+  counters.clear();
+  notify();
+};
+
+const subscribeMusicDebug = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+};
+
+/** Stable between notifications, so useSyncExternalStore sees one snapshot per change. */
+const getMusicDebugEvents = (): MusicDebugEvent[] => events;
+
+let countersSnapshot: MusicDebugCounter[] = [];
+let countersDirtyAt = -1;
+const getMusicDebugCounters = (): MusicDebugCounter[] => {
+  if (countersDirtyAt !== nextId) {
+    countersDirtyAt = nextId;
+    countersSnapshot = [...counters.values()].sort((a, b) => b.lastAt - a.lastAt);
+  }
+  return countersSnapshot;
+};
+
+export {
+  setMusicDebugArmed, clearMusicDebug, subscribeMusicDebug,
+  getMusicDebugEvents, getMusicDebugCounters,
+};
+export type { MusicDebugEvent, MusicDebugCounter, MusicDebugOwner };

--- a/apps/web/src/lib/game/settings.ts
+++ b/apps/web/src/lib/game/settings.ts
@@ -92,6 +92,7 @@ const DEFAULT_SETTINGS: GameSettings = {
   msuConfigMode: 'auto',
   enableMSU: 'false',
   resumeMSU: true,
+  resetMSUAtTitle: true,
   packReplaceAmbient: true,
   packReplaceSfx: true,
 

--- a/apps/web/src/lib/log-bus.ts
+++ b/apps/web/src/lib/log-bus.ts
@@ -40,15 +40,19 @@ const emit = (channel: LogChannel, level: LogLevel, message: string): void => {
     }
   }
 
-  // Dev-only: mirror into the native console so main-process file logging
+  // Mirrored into the native console so main-process file logging
   // (apps/desktop/electron/lib/dev-file-logger.ts) captures this app's own
   // structured log channels too, not just ad-hoc console.* calls.
-  if (import.meta.env.DEV) {
-    const line = `[${channel}] ${message}`;
-    if (level === 'error') console.error(line);
-    else if (level === 'warn') console.warn(line);
-    else console.log(line);
-  }
+  //
+  // Unconditional on purpose. This used to be behind `import.meta.env.DEV`, which is decided when
+  // the bundle is BUILT, while the file logger on the other side is attached on `is.dev`, which is
+  // decided when the app RUNS. Any unpackaged run of a production bundle therefore opened the log
+  // files and then wrote no channel line to them at all, which is the one case a crash log is for.
+  // Nothing consumes the console in a packaged build, so mirroring there costs a call and no more.
+  const line = `[${channel}] ${message}`;
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.log(line);
 };
 
 const log = {

--- a/apps/web/src/lib/msu/channels/active-layers.ts
+++ b/apps/web/src/lib/msu/channels/active-layers.ts
@@ -9,6 +9,7 @@
  */
 import type { LayerResume, MsuLayer } from '@shared/types/msu-manifest';
 import { createScheduler } from '../schedulers/create-scheduler';
+import { publishMsuDebug } from '../debug-bus';
 import type { LoadedLayer } from '../track-loader';
 import { MSU1_SAMPLE_RATE } from '../decode/parse-msu1';
 import { createVoice } from '../voice';
@@ -22,19 +23,40 @@ import type { ActiveLayer, ChannelResume, LayerReport, SoundProgram } from './ch
  */
 type ResumeFor = (layer: MsuLayer, fileCount: number) => LayerResume | null;
 
+/**
+ * Whether this start of the layer sounds at all. `chance` absent, or any value at or above 100,
+ * always sounds — which is every layer authored before the field existed. Every actual roll is
+ * published to the debug bus: a lost roll starts nothing, so this is the only record of it.
+ */
+const layerSounds = (channel: string, programId: number, layer: MsuLayer): boolean => {
+  const chance = layer.chance;
+  if (chance === undefined || chance >= 100) return true;
+  const passed = chance > 0 && Math.random() * 100 < chance;
+  publishMsuDebug({
+    kind: 'roll', channel, programId,
+    layerId: layer.id, layerName: layer.name, chance, passed,
+  });
+  return passed;
+};
+
 const startLayers = (params: {
   ctx: BaseAudioContext;
   destination: AudioNode;
+  /** The channel these layers sound on — carried only so a chance roll can name it. */
+  channel: string;
   program: SoundProgram;
   loaded: LoadedLayer[];
   elapsedSeconds: () => number;
   resumeFor: ResumeFor;
 }): ActiveLayer[] => {
-  const { ctx, destination, program, loaded, elapsedSeconds, resumeFor } = params;
+  const { ctx, destination, channel, program, loaded, elapsedSeconds, resumeFor } = params;
   const layers: ActiveLayer[] = [];
 
   for (const entry of loaded) {
     const layer = program.layers[entry.layerIndex];
+    // A thinned layer is skipped outright rather than started silent: a scheduler that is never
+    // created cannot hold a voice, keep a timer, or turn up in the studio's readout as sounding.
+    if (!layerSounds(channel, program.id, layer)) continue;
     // Volume first, then the layer's effects, then the channel: the chain is where one recording
     // becomes its indoor or distant version, so it sits on the layer and not on the channel.
     const effects = buildEffectChain(ctx, destination, layer.effects);

--- a/apps/web/src/lib/msu/channels/additive-channel.ts
+++ b/apps/web/src/lib/msu/channels/additive-channel.ts
@@ -85,6 +85,7 @@ const createAdditiveChannel = (options: ChannelOptions): SoundChannelApi => {
     const startedAt = ctx.currentTime;
     const layers = startLayers({
       ctx,
+      channel: name,
       destination: out,
       program,
       loaded,
@@ -143,6 +144,8 @@ const createAdditiveChannel = (options: ChannelOptions): SoundChannelApi => {
     // Effects are deliberately not part of a save's audio position.
     snapshot: () => null,
     restore: () => {},
+    // Nothing is remembered here, so there is never anything to forget.
+    forget: () => {},
     report,
     stop,
     dispose,

--- a/apps/web/src/lib/msu/channels/channel.type.ts
+++ b/apps/web/src/lib/msu/channels/channel.type.ts
@@ -121,6 +121,11 @@ interface SoundChannelApi {
   snapshot: () => ChannelResume | null;
   /** Pick playback up from a snapshot. A no-op on an additive channel: effects are not resumed. */
   restore: (state: ChannelResume | null) => void;
+  /**
+   * Drop every remembered position, so the next selection of any id starts it from the top.
+   * A no-op on an additive channel, which remembers nothing in the first place.
+   */
+  forget: () => void;
   report: () => ChannelReport | null;
   stop: () => void;
   dispose: () => void;

--- a/apps/web/src/lib/msu/channels/stateful-channel.ts
+++ b/apps/web/src/lib/msu/channels/stateful-channel.ts
@@ -67,6 +67,7 @@ const createStatefulChannel = (options: ChannelOptions): SoundChannelApi => {
     const startedAt = ctx.currentTime;
     const layers = startLayers({
       ctx,
+      channel: name,
       destination: fadeGain,
       program,
       loaded,
@@ -132,6 +133,13 @@ const createStatefulChannel = (options: ChannelOptions): SoundChannelApi => {
     void start(id, carried ?? (resumeEnabled?.() ? resumeById.get(id) ?? null : null));
   };
 
+  /**
+   * Forget every position this channel has recorded. What is sounding now is left alone — this
+   * only decides where the NEXT selection of an id begins, which is what makes a fresh run start
+   * its music at the top rather than halfway through the last one.
+   */
+  const forget = (): void => { resumeById.clear(); };
+
   const restore = (state: ChannelResume | null): void => {
     generation += 1;
     stopActive();
@@ -173,6 +181,7 @@ const createStatefulChannel = (options: ChannelOptions): SoundChannelApi => {
     activeId: () => active?.id ?? null,
     snapshot,
     restore,
+    forget,
     report,
     stop,
     dispose,

--- a/apps/web/src/lib/msu/debug-bus.ts
+++ b/apps/web/src/lib/msu/debug-bus.ts
@@ -1,0 +1,44 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * The engine's own diagnostic feed — the decisions no live report can show.
+ *
+ * A channel report says what IS sounding; the core's sound trace says what the game RAISED. The
+ * gap between them is what the engine decided in between, and the chance roll is exactly that:
+ * a layer that rolled against its odds and lost never starts, so it appears in neither. Without
+ * this feed a 10% thunder looks identical to a broken one.
+ *
+ * Kept outside React and always on: publishing to nobody is a no-op, so the engine posts
+ * unconditionally and only a mounted debugger ever hears it.
+ */
+
+interface MsuRollEvent {
+  kind: 'roll';
+  /** The channel the program sounds on — 'music', 'ambient', 'sfx1' or 'sfx2'. */
+  channel: string;
+  /** The program the layer belongs to: track number or sound id. */
+  programId: number;
+  layerId: string;
+  layerName: string;
+  /** The authored odds, 1-100. */
+  chance: number;
+  passed: boolean;
+}
+
+type MsuDebugEvent = MsuRollEvent;
+type MsuDebugListener = (event: MsuDebugEvent) => void;
+
+const listeners = new Set<MsuDebugListener>();
+
+const publishMsuDebug = (event: MsuDebugEvent): void => {
+  for (const listener of listeners) {
+    try { listener(event); } catch { /* a bad listener must never break playback */ }
+  }
+};
+
+const subscribeMsuDebug = (listener: MsuDebugListener): (() => void) => {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+};
+
+export { publishMsuDebug, subscribeMsuDebug };
+export type { MsuDebugEvent, MsuRollEvent };

--- a/apps/web/src/lib/msu/engine.ts
+++ b/apps/web/src/lib/msu/engine.ts
@@ -18,6 +18,7 @@ import { SOUND_CHANNELS } from './sound-claim';
 import type { LayerReport } from './channel';
 import type { LoadBytes } from './track-loader';
 import { applyFade, isFadeControl } from './fade';
+import { createTitleReset } from './title-reset';
 
 interface MsuEngineOptions {
   ctx: BaseAudioContext;
@@ -41,7 +42,14 @@ interface MsuEngineOptions {
    * Omitted for one-off uses like previewing a track, which should always start clean.
    */
   resumeEnabled?: () => boolean;
+  /**
+   * Whether reaching the title screen forgets those positions again, so the opening plays with
+   * its animation and the next run starts its music from the top. Read per event, same as above.
+   */
+  resetAtTitle?: () => boolean;
   onError?: (message: string) => void;
+  /** Reported when a return to the title actually dropped something. */
+  onReset?: () => void;
   /** Reports each track that starts, for diagnostics — how many layers actually decoded. */
   onTrack?: (trackNum: number, layerCount: number, resumed: boolean) => void;
   /** The same, for the ambient bed. Effects are far too frequent to report one at a time. */
@@ -58,7 +66,8 @@ interface TrackReport {
 const createMsuEngine = (options: MsuEngineOptions) => {
   const {
     ctx, destination, manifest, loadBytes, isDeluxe,
-    musicVolume, sfxVolume, ambientVolume, resumeEnabled, onError, onTrack, onAmbient,
+    musicVolume, sfxVolume, ambientVolume, resumeEnabled, resetAtTitle, onError, onReset,
+    onTrack, onAmbient,
   } = options;
 
   const readSfxVolume = sfxVolume ?? musicVolume;
@@ -82,6 +91,7 @@ const createMsuEngine = (options: MsuEngineOptions) => {
   const music = channels.music;
   const ambient = channels.ambient;
   const all = [music, ambient, channels.sfx1, channels.sfx2];
+  const titleReset = createTitleReset(channels, resetAtTitle, onReset);
 
   /**
    * The game's music-control byte. Values below 0xf0 select a track (0 = silence), 0xf1..0xf3
@@ -92,7 +102,9 @@ const createMsuEngine = (options: MsuEngineOptions) => {
   // would make it skip the re-select that is the only thing that brings the sound back.
   let fadedToZero = false;
 
-  const onMusicCtrl = (ctrl: number, _module: number, entrance: number, overworldArea: number): void => {
+  const onMusicCtrl = (ctrl: number, module: number, entrance: number, overworldArea: number): void => {
+    // Ahead of the select below, so the track this event starts is the one that begins fresh.
+    titleReset(module);
     if (isFadeControl(ctrl)) {
       if (ctrl === 0xf1) fadedToZero = true;
       if (ctrl === 0xf3) fadedToZero = false;

--- a/apps/web/src/lib/msu/title-reset.ts
+++ b/apps/web/src/lib/msu/title-reset.ts
@@ -1,0 +1,70 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Putting replacement audio back to nothing once the game is at its title.
+ *
+ * Two things go wrong when a run's audio survives into the next one. Positions: resuming exists
+ * for a run in progress, and carried across runs it starts the opening in the middle of itself
+ * instead of with its animation. And the bed: the game ends a run by reloading its sound chip's
+ * song bank wholesale, which stops the chip's own ambience without ever raising the "no bed" id
+ * a host would hear, so a storm that was playing when the player quit keeps raining over the
+ * title with nothing left to stop it.
+ *
+ * Reaching a title module is the one unambiguous signal that no run is in progress. The modules
+ * are set by the game, so a save-and-quit, a game over taken back to the file screen and a hard
+ * reset all arrive here without this having to recognise each path separately.
+ */
+import type { MsuChannelName, SoundChannelApi } from './channel';
+
+/**
+ * The modules with no run behind them. Numbers are the core's own dispatch order
+ * (`kMainRouting`), the same set `lib/game/ui-bridge-parser.ts` reads as the `title` UI mode.
+ */
+const TITLE_MODULES: ReadonlySet<number> = new Set([
+  0,  // Module00_Intro — the opening animation
+  1,  // Module01_FileSelect
+  2,  // Module02_CopyFile
+  3,  // Module03_KILLFile
+  4,  // Module04_NameFile
+  20, // Module14_Attract — the legend demo the title loops into
+]);
+
+/**
+ * The channels silenced outright on the way in. Music is deliberately absent: every path to the
+ * title fades it out first (`Death_Func31` and `FadeMusicAndResetSRAMMirror` both write the fade
+ * byte in the frame they set the module), so cutting it here would replace that fade with a
+ * click. The bed and the effects get no such courtesy from the game and have to be cut.
+ */
+const SILENCED: readonly MsuChannelName[] = ['ambient', 'sfx1', 'sfx2'];
+
+const isTitleModule = (module: number): boolean => TITLE_MODULES.has(module);
+
+/**
+ * A reset pass to run on each music event, given the module it was reported from.
+ *
+ * Silencing happens once, on the way in. Forgetting happens on every title event instead: the
+ * title loops into its attract demo and back, and clearing only on the way in would let the
+ * second pass through that loop resume the first pass's music.
+ */
+const createTitleReset = (
+  channels: Record<MsuChannelName, SoundChannelApi>,
+  enabled?: () => boolean,
+  onReset?: () => void,
+) => {
+  const all = Object.values(channels);
+  const silenced = SILENCED.map((name) => channels[name]);
+  let wasTitle = false;
+
+  return (module: number): void => {
+    const title = isTitleModule(module);
+    const entering = title && !wasTitle;
+    wasTitle = title;
+    if (!title || !(enabled?.() ?? false)) return;
+    if (entering) {
+      silenced.forEach((channel) => channel.stop());
+      onReset?.();
+    }
+    all.forEach((channel) => channel.forget());
+  };
+};
+
+export { TITLE_MODULES, SILENCED, isTitleModule, createTitleReset };

--- a/apps/web/src/lib/storage/profile-store.ts
+++ b/apps/web/src/lib/storage/profile-store.ts
@@ -4,7 +4,7 @@
  * FileStore. Same surface the renderer previously called on window.api, now
  * routed through the platform layer so it works on desktop and mobile alike.
  */
-import type { Profile, AppState } from '@shared/types/profile';
+import type { Profile, ProfilePatch, AppState } from '@shared/types/profile';
 import * as store from '@shared/storage/profiles';
 import { getPlatform } from '@app/platform/get-platform';
 import { isAutomationLaunch } from '@app/lib/instance';
@@ -14,7 +14,7 @@ const files = () => getPlatform().files;
 const listProfiles = (): Promise<Profile[]> => store.listProfiles(files());
 const createProfile = (name: string, romFile: string, language?: string, msuPack?: string): Promise<Profile> =>
   store.createProfile(files(), name, romFile, language, msuPack);
-const updateProfile = (id: string, patch: Partial<Profile>): Promise<Profile | null> => store.updateProfile(files(), id, patch);
+const updateProfile = (id: string, patch: ProfilePatch): Promise<Profile | null> => store.updateProfile(files(), id, patch);
 const deleteProfile = (id: string): Promise<void> => store.deleteProfile(files(), id);
 // app.json decides which profile opens by default, and it is shared by every launch.
 // loadProfileForGame() writes it on each run, so ANY automated launch — not only a named

--- a/apps/web/src/ui/design-system/composites/Widget/Widget.constants.ts
+++ b/apps/web/src/ui/design-system/composites/Widget/Widget.constants.ts
@@ -87,6 +87,15 @@ const WIDGET_DEFINITIONS: WidgetDefinition[] = [
     requiresSetting: 'cheatsEnabled',
   },
   {
+    id: 'music',
+    label: 'Music Debugger',
+    defaultVisibility: 'game-only' as WidgetVisibility,
+    defaultSide: 'right' as SnapSide,
+    defaultDockedSize: 360,
+    defaultFloatingSize: { width: 380, height: 560 },
+    devOnly: true,
+  },
+  {
     id: 'simulator',
     label: 'Simulator',
     defaultVisibility: 'game-only' as WidgetVisibility,

--- a/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
+++ b/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { Box, Image } from '@ds/primitives';
 import { WidgetManager, useWidgetLayout } from '@ds/composites/Widget';
 import { Dialog } from '@ds/composites/Dialog';
-import { InventoryWidgetContent, InventoryWidgetSettings, ChecksWidgetContent, LogsWidgetContent, DebugWidgetContent, NavigationWidgetContent, LiveDataInspectorContent, CheatsWidgetContent, SimulatorWidgetContent } from '@domains/widgets';
+import { InventoryWidgetContent, InventoryWidgetSettings, ChecksWidgetContent, LogsWidgetContent, DebugWidgetContent, NavigationWidgetContent, LiveDataInspectorContent, CheatsWidgetContent, SimulatorWidgetContent, MusicWidgetContent } from '@domains/widgets';
 import { loadTrackerStateBlob, saveTrackerStateBlob } from '@app/lib/tracker-state-io';
 import { primeLiveSettings } from '@app/lib/game';
 import { useExclusiveInsetsStore } from '@app/stores/exclusive-insets-store';
@@ -188,6 +188,7 @@ const AppMain = () => {
             dataset: <LiveDataInspectorContent />,
             cheats: <CheatsWidgetContent />,
             simulator: <SimulatorWidgetContent />,
+            music: <MusicWidgetContent />,
           }}
         </WidgetManager>
 

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/LayerEditor/behavior/layer-ops.ts
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/LayerEditor/behavior/layer-ops.ts
@@ -37,11 +37,15 @@ const MODE_LABELS: Record<PlayModeKind, string> = {
   once: 'Once', loop: 'Loop', random: 'Random', interval: 'Interval',
 };
 
-const createLayer = (existing: MsuLayer[]): MsuLayer => ({
+/**
+ * A new layer, in the mode its channel can actually end in. An effect channel gets `once`: it is
+ * fired at a moment and is over, and a loop there would still be playing long after that moment.
+ */
+const createLayer = (existing: MsuLayer[], oneShot = false): MsuLayer => ({
   id: newId(),
   name: `Layer ${existing.length + 1}`,
   files: [],
-  mode: DEFAULT_MODES.loop,
+  mode: oneShot ? DEFAULT_MODES.once : DEFAULT_MODES.loop,
   volume: 100,
 });
 

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/LayerEditor/behavior/useLayerEditor.ts
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/LayerEditor/behavior/useLayerEditor.ts
@@ -39,7 +39,9 @@ const useLayerEditor = (params: LayerEditorState) => {
     setError(null);
   }, []);
 
-  const addLayer = useCallback(() => { mutate((current) => [...current, createLayer(current)]); }, [mutate]);
+  const addLayer = useCallback(() => {
+    mutate((current) => [...current, createLayer(current, target.oneShot)]);
+  }, [mutate, target.oneShot]);
 
   const removeLayer = useCallback((id: string) => {
     mutate((current) => current.filter((layer) => layer.id !== id));

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/LayerEditor/sub-components/LayerCard/LayerCard.tsx
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/LayerEditor/sub-components/LayerCard/LayerCard.tsx
@@ -75,6 +75,22 @@ const LayerCard = (props: LayerCardProps) => {
         onChange={(volume) => onChange({ volume })}
       />
 
+      {/* Rolled each time the layer starts, so on a one-shot effect this is a per-trigger chance.
+          The game raises some effects on a fixed cycle, which a real recording turns into a
+          metronome; thinning them here keeps them tied to the moment the game means. */}
+      <Slider
+        label="Chance"
+        description="How often this layer actually sounds when it starts. 100% is every time."
+        value={layer.chance ?? 100}
+        min={1}
+        max={100}
+        step={1}
+        disabled={disabled}
+        showValue
+        formatValue={(value) => `${value}%`}
+        onChange={(chance) => onChange({ chance: chance >= 100 ? undefined : chance })}
+      />
+
       <PlayModeFields
         mode={layer.mode}
         layerId={layer.id}

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/behavior/layer-target.ts
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/msu/behavior/layer-target.ts
@@ -20,6 +20,13 @@ interface LayerTarget {
   label: string;
   read: (manifest: MsuPackManifest) => MsuLayer[];
   write: (base: MsuPackManifest, layers: MsuLayer[]) => MsuPackManifest;
+  /**
+   * True where the game fires this as a one-shot: the two effect channels. A looping layer there
+   * has nothing to end it, so it plays until the pack is unloaded — which reads as a sound that
+   * follows the player around, long after the moment that raised it. Music and the bed are the
+   * opposite: they are meant to keep going.
+   */
+  oneShot: boolean;
 }
 
 const trackTarget = (trackNum: number): LayerTarget => ({
@@ -27,6 +34,7 @@ const trackTarget = (trackNum: number): LayerTarget => ({
   label: `slot ${trackNum}`,
   read: (manifest) => layersOfTrack(manifest, trackNum),
   write: (base, layers) => withTrackLayers(base, trackNum, layers),
+  oneShot: false,
 });
 
 const soundTarget = (channel: SoundChannel, soundId: number): LayerTarget => ({
@@ -34,6 +42,7 @@ const soundTarget = (channel: SoundChannel, soundId: number): LayerTarget => ({
   label: soundTitle(channel, soundId),
   read: (manifest) => layersOfSound(manifest, channel, soundId),
   write: (base, layers) => withSoundLayers(base, channel, soundId, layers),
+  oneShot: channel !== 'ambient',
 });
 
 export { trackTarget, soundTarget };

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/ProfileDetailPanel.tsx
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/ProfileDetailPanel.tsx
@@ -11,6 +11,7 @@ import { Select } from '../../../../../../design-system/primitives/Select';
 import { Button } from '../../../../../../design-system/primitives/Button';
 import { formatRelativeTime } from '../../../../../../../utils';
 import { updateProfile } from '../../../../../../../lib/storage/profile-store';
+import { reloadMsuForProfile } from '@app/lib/game/msu-pack-loader';
 import { languageLabel } from '../language-names';
 
 const IL: Record<string, CSSProperties> = {
@@ -47,7 +48,7 @@ const ProfileDetailPanel = (props: ProfileDetailPanelProps) => {
           <Select
             value={profile.language || ''}
             onChange={async (val) => {
-              await window.api.updateProfile(profile.id, { language: val || undefined });
+              await updateProfile(profile.id, { language: val || null });
               onRefresh();
             }}
             options={[
@@ -62,7 +63,10 @@ const ProfileDetailPanel = (props: ProfileDetailPanelProps) => {
           <Select
             value={profile.msuPack || ''}
             onChange={async (val) => {
-              await window.api.updateProfile(profile.id, { msuPack: val || undefined });
+              await updateProfile(profile.id, { msuPack: val || null });
+              // Audible now rather than at the next boot. A no-op unless this profile is the one
+              // currently playing, so editing another profile's pack never disturbs it.
+              await reloadMsuForProfile(profile.id);
               onRefresh();
             }}
             options={[

--- a/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/settings-sections.ts
+++ b/apps/web/src/ui/domains/app/views/DataManager/sub-components/profile-manager/settings-sections.ts
@@ -46,6 +46,7 @@ const SETTINGS_SECTIONS: Array<{ title: string; keys: Array<{ key: string; label
       { key: 'msuConfigMode', label: 'MSU Configuration', format: (v) => v === 'manual' ? 'Manual' : 'Auto' },
       { key: 'enableMSU', label: 'MSU Audio', format: (v) => v === 'false' || !v ? 'Off' : String(v) },
       { key: 'resumeMSU', label: 'Resume MSU' },
+      { key: 'resetMSUAtTitle', label: 'Reset MSU at Title' },
       { key: 'audioFreq', label: 'Audio Frequency', format: (v) => `${v ?? 44100} Hz` },
       { key: 'audioChannels', label: 'Audio Channels', format: (v) => v === 1 ? 'Mono' : 'Stereo' },
       { key: 'audioSamples', label: 'Audio Samples', format: (v) => String(v ?? 2048) },

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/audio-settings-controls.tsx
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/audio-settings-controls.tsx
@@ -149,7 +149,7 @@ const renderControl = (
 };
 
 /** The switches that only mean something while a pack is playing at all. */
-const PACK_DEPENDENT_KEYS = ['resumeMSU', 'packReplaceAmbient', 'packReplaceSfx'];
+const PACK_DEPENDENT_KEYS = ['resumeMSU', 'resetMSUAtTitle', 'packReplaceAmbient', 'packReplaceSfx'];
 
 const isDisabled = (key: string, settings: GameSettings): boolean => {
   // Only Manual mode's own switch can turn these off: in Auto, whether a pack plays is decided

--- a/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/audio-settings-sections.ts
+++ b/apps/web/src/ui/domains/app/views/ProfileHub/sub-components/audio-settings-sections.ts
@@ -43,6 +43,7 @@ const SECTIONS: Section[] = [
           { key: 'msuConfigMode', label: 'Configuration', description: 'Auto reads the assigned pack and sets its format, sample rate, channels and buffer to match. Manual unlocks all of them.', keywords: 'auto manual automatic config msu pack' },
           { key: 'enableMSU', label: 'Pack Format', description: 'MSU, Deluxe, OPUZ or Deluxe OPUZ — read from the pack in Auto, chosen by hand in Manual. Packs are imported and assigned in the Data Manager.', keywords: 'msu music cd replacement deluxe opuz pack format' },
           { key: 'resumeMSU', label: 'Resume Tracks', description: 'Returning to an area picks its music up where it left off instead of restarting. Save states remember the position too.', keywords: 'resume position continue' },
+          { key: 'resetMSUAtTitle', label: 'Reset At Title Screen', description: 'Reaching the title screen forgets every remembered position, so the opening plays from its start alongside the animation and a new run begins with fresh music rather than picking up the last one midway.', keywords: 'reset title intro restart new game fresh resume position' },
         ],
       },
       {

--- a/apps/web/src/ui/domains/app/views/TitleBar/TitleBar.tsx
+++ b/apps/web/src/ui/domains/app/views/TitleBar/TitleBar.tsx
@@ -47,6 +47,7 @@ const TitleBar = (props: TitleBarProps) => {
     onShowConnectionDebug,
     onToggleDataset,
     onToggleSimulator,
+    onToggleMusic,
     onShowShadowEditor,
     onShowAbout,
     onShowBugReport,
@@ -127,7 +128,7 @@ const TitleBar = (props: TitleBarProps) => {
   const menuItems = buildTitleBarMenuItems({
     closeMenu, win, activeProfile, gameRunning,
     onShowProfile, onToggleSaveStates, onShowDataManager, onToggleInventory, onToggleChecks,
-    onToggleCheats, onShowLogs, onToggleDebug, onShowConnectionDebug, onToggleDataset, onToggleSimulator,
+    onToggleCheats, onShowLogs, onToggleDebug, onShowConnectionDebug, onToggleDataset, onToggleSimulator, onToggleMusic,
     onShowInputTester, onShowSpriteDebug, onShowDataInspector, onShowShadowEditor, onCheckForUpdates, onShowCredits, onShowDesignGallery, onShowAbout,
     widgetVisibility, developerToolsEnabled,
   });

--- a/apps/web/src/ui/domains/app/views/TitleBar/TitleBar.type.ts
+++ b/apps/web/src/ui/domains/app/views/TitleBar/TitleBar.type.ts
@@ -21,6 +21,7 @@ interface TitleBarProps {
   onShowConnectionDebug: () => void;
   onToggleDataset: () => void;
   onToggleSimulator: () => void;
+  onToggleMusic: () => void;
   onShowShadowEditor: () => void;
   onShowAbout: () => void;
   onShowBugReport: () => void;

--- a/apps/web/src/ui/domains/app/views/TitleBar/behavior/title-bar-menu.ts
+++ b/apps/web/src/ui/domains/app/views/TitleBar/behavior/title-bar-menu.ts
@@ -10,7 +10,7 @@ type MenuItems = Parameters<typeof DropdownMenu>[0]['items'];
 type MenuBuilderDeps = Pick<TitleBarProps,
   'activeProfile' | 'gameRunning' | 'onShowProfile' | 'onToggleSaveStates' | 'onShowDataManager'
   | 'onToggleInventory' | 'onToggleChecks' | 'onToggleCheats' | 'onShowLogs' | 'onToggleDebug'
-  | 'onShowConnectionDebug' | 'onToggleDataset' | 'onToggleSimulator' | 'onShowInputTester' | 'onShowSpriteDebug' | 'onShowDataInspector'
+  | 'onShowConnectionDebug' | 'onToggleDataset' | 'onToggleSimulator' | 'onToggleMusic' | 'onShowInputTester' | 'onShowSpriteDebug' | 'onShowDataInspector'
   | 'onShowShadowEditor' | 'onCheckForUpdates' | 'onShowCredits' | 'onShowDesignGallery' | 'onShowAbout'
   | 'widgetVisibility' | 'developerToolsEnabled'
 > & { closeMenu: () => void; win: WindowControlsPort };
@@ -19,7 +19,7 @@ const buildTitleBarMenuItems = (deps: MenuBuilderDeps): MenuItems => {
   const {
     closeMenu, win, activeProfile, gameRunning,
     onShowProfile, onToggleSaveStates, onShowDataManager, onToggleInventory, onToggleChecks,
-    onToggleCheats, onShowLogs, onToggleDebug, onShowConnectionDebug, onToggleDataset, onToggleSimulator,
+    onToggleCheats, onShowLogs, onToggleDebug, onShowConnectionDebug, onToggleDataset, onToggleSimulator, onToggleMusic,
     onShowInputTester, onShowSpriteDebug, onShowDataInspector, onShowShadowEditor, onCheckForUpdates, onShowCredits, onShowDesignGallery, onShowAbout,
     widgetVisibility = {}, developerToolsEnabled = false,
   } = deps;
@@ -33,6 +33,7 @@ const buildTitleBarMenuItems = (deps: MenuBuilderDeps): MenuItems => {
     { key: 'navigation', icon: '🔗', label: 'Location & Navigation', checked: widgetVisibility.navigation, onClick: () => { closeMenu(); onShowConnectionDebug(); } },
     { key: 'dataset', icon: '📊', label: 'Live Data Inspector', checked: widgetVisibility.dataset, onClick: () => { closeMenu(); onToggleDataset(); } },
     { key: 'simulator', icon: '🤖', label: 'Simulator', checked: widgetVisibility.simulator, onClick: () => { closeMenu(); onToggleSimulator(); } },
+    { key: 'music', icon: '🎵', label: 'Music Debugger', checked: widgetVisibility.music, onClick: () => { closeMenu(); onToggleMusic(); } },
   ].filter((item) => developerToolsEnabled || !getWidgetDefinition(item.key)?.devOnly);
 
   return [

--- a/apps/web/src/ui/domains/widgets/index.ts
+++ b/apps/web/src/ui/domains/widgets/index.ts
@@ -6,3 +6,4 @@ export { DebugWidgetContent } from './debug';
 export { NavigationWidgetContent, LiveDataInspectorContent } from './navigation';
 export { CheatsWidgetContent } from './cheats';
 export { SimulatorWidgetContent } from './simulator';
+export { MusicWidgetContent } from './music';

--- a/apps/web/src/ui/domains/widgets/music/MusicWidget.css
+++ b/apps/web/src/ui/domains/widgets/music/MusicWidget.css
@@ -1,0 +1,85 @@
+/* @layer renderer-widgets @kind style */
+
+/* Same rhythm as the Game State widget: padded column of sections, inset row groups inside. */
+.music-widget {
+  height: 100%;
+  overflow-y: auto;
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.music-widget__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.music-widget__section--feed {
+  flex: 1;
+  min-height: 160px;
+}
+
+.music-widget__rows {
+  display: flex;
+  flex-direction: column;
+  background: var(--c-inset);
+  border: 1px solid var(--c-hairline);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+.music-widget__rows--scroll {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.music-widget__rows .stat-row {
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.music-widget__rows .stat-row:nth-child(even) {
+  background: var(--c-hover);
+}
+
+/* The studio's readout carries its own margins for the slot list; here it sits in a gap. */
+.music-widget .preview-readout {
+  margin: 0;
+}
+
+.music-widget__feed {
+  flex: 1;
+  min-height: 0;
+}
+
+.music-event {
+  display: grid;
+  grid-template-columns: auto auto auto 1fr;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.music-event:nth-child(even) {
+  background: var(--c-hover);
+}
+
+.music-event__time {
+  color: var(--c-text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.music-event__channel {
+  color: var(--c-text-dim);
+  min-width: 4em;
+}
+
+.music-event__detail {
+  color: var(--c-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/apps/web/src/ui/domains/widgets/music/MusicWidget.tsx
+++ b/apps/web/src/ui/domains/widgets/music/MusicWidget.tsx
@@ -1,0 +1,52 @@
+/* @layer renderer-widgets @kind component */
+/**
+ * The music debugger: everything the game's audio is doing, live, in one place.
+ *
+ * Three sections answer three different questions. LIVE is the engine's own state — every session
+ * channel with the studio's meters, progress, loops, waits and fades included. COUNTS turns the
+ * feed into rates, which is what makes a probability layer testable: authored odds against
+ * measured odds, on one line. EVENTS is the feed of raises and rolls, each tagged MSU / CHIP /
+ * SKIP, so a stray sound names the exact id and owner.
+ *
+ * Mounting the widget arms the core-side traces; closing it disarms them. While armed the traces
+ * are purely observational — nothing about what actually plays changes.
+ */
+import { Box, Button, EmptyState, SectionHeader } from '@ds/primitives';
+import { useLiveChannels } from './behavior/useLiveChannels';
+import { useMusicDebugData } from './behavior/useMusicDebugData';
+import { ChannelLive } from './sub-components/ChannelLive';
+import { CounterTable } from './sub-components/CounterTable';
+import { EventFeed } from './sub-components/EventFeed';
+import './MusicWidget.css';
+
+const MusicWidgetContent = () => {
+  const { channels, sessionActive } = useLiveChannels();
+  const { events, counters, clear } = useMusicDebugData();
+
+  return (
+    <Box className="music-widget">
+      <Box className="music-widget__section">
+        <SectionHeader title="Replacement audio" subtitle="What the pack's engine is playing right now" />
+        {sessionActive
+          ? channels.map((channel) => <ChannelLive key={channel.name} channel={channel} />)
+          : <EmptyState message="No music pack session — the sound chip owns everything." />}
+      </Box>
+
+      <Box className="music-widget__section">
+        <SectionHeader
+          title="Counts"
+          subtitle="Raises per sound, and rolls per chance layer"
+          action={<Button variant="ghost" size="sm" onClick={clear}>Clear</Button>}
+        />
+        <CounterTable counters={counters} />
+      </Box>
+
+      <Box className="music-widget__section music-widget__section--feed">
+        <SectionHeader title="Events" subtitle="Every raise the core reported, and every roll the engine decided" />
+        <EventFeed events={events} />
+      </Box>
+    </Box>
+  );
+};
+
+export { MusicWidgetContent };

--- a/apps/web/src/ui/domains/widgets/music/behavior/useLiveChannels.ts
+++ b/apps/web/src/ui/domains/widgets/music/behavior/useLiveChannels.ts
@@ -1,0 +1,64 @@
+/* @layer renderer-widgets @kind hook */
+/**
+ * A frame-rate feed of every session channel, for the debugger's meters.
+ *
+ * The same store-per-readout arrangement the studio's preview uses, one per channel: the poll
+ * runs on animation frames, each store deduplicates to the precision its meters actually draw,
+ * and only the readout that changed redraws. The key is the CHANNEL name, not the sounding id,
+ * so one readout per channel stays subscribed across track changes instead of unmounting at
+ * exactly the moment worth watching.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import type { MsuChannelName } from '@app/lib/msu/engine';
+import { isMsuSessionActive, msuChannelReport } from '@app/lib/game/msu-session';
+import { createPreviewReportStore } from '@domains/app/views/DataManager/sub-components/msu/behavior/preview-report-store';
+import type { PreviewReportStore } from '@domains/app/views/DataManager/sub-components/msu/behavior/preview-report-store';
+
+const CHANNELS: readonly MsuChannelName[] = ['music', 'ambient', 'sfx1', 'sfx2'];
+
+const CHANNEL_TITLES: Record<MsuChannelName, string> = {
+  music: 'Music', ambient: 'Ambient bed', sfx1: 'Effects 1', sfx2: 'Effects 2',
+};
+
+interface LiveChannel {
+  name: MsuChannelName;
+  title: string;
+  store: PreviewReportStore;
+}
+
+/** How many trigger sets are sounding at once, plus which program id the channel is on. */
+const detailOf = (id: number, setCount: number): string =>
+  setCount > 1 ? `id 0x${id.toString(16)} · ${setCount} overlapping` : `id 0x${id.toString(16)}`;
+
+const useLiveChannels = () => {
+  const channels = useMemo<LiveChannel[]>(() => CHANNELS.map((name) => ({
+    name, title: CHANNEL_TITLES[name], store: createPreviewReportStore(),
+  })), []);
+  // The session comes and goes with the profile and the pack, usually after this widget is
+  // already mounted, so it is polled with the channels rather than read once.
+  const [sessionActive, setSessionActive] = useState(isMsuSessionActive);
+
+  useEffect(() => {
+    let frame = 0;
+    const poll = (): void => {
+      setSessionActive(isMsuSessionActive());
+      for (const channel of channels) {
+        const report = msuChannelReport(channel.name);
+        channel.store.publish(report === null ? null : {
+          key: channel.name,
+          elapsedSeconds: report.elapsedSeconds,
+          layers: report.layers,
+          detail: detailOf(report.id, report.setCount),
+        });
+      }
+      frame = requestAnimationFrame(poll);
+    };
+    frame = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(frame);
+  }, [channels]);
+
+  return { channels, sessionActive };
+};
+
+export { useLiveChannels };
+export type { LiveChannel };

--- a/apps/web/src/ui/domains/widgets/music/behavior/useMusicDebugData.ts
+++ b/apps/web/src/ui/domains/widgets/music/behavior/useMusicDebugData.ts
@@ -1,0 +1,26 @@
+/* @layer renderer-widgets @kind hook */
+/**
+ * The widget's window onto the music-debug feed: arms the core-side traces while mounted, and
+ * reads the event list and the counters through useSyncExternalStore so a burst of events is one
+ * render, not one per event.
+ */
+import { useEffect, useSyncExternalStore } from 'react';
+import {
+  clearMusicDebug, getMusicDebugCounters, getMusicDebugEvents,
+  setMusicDebugArmed, subscribeMusicDebug,
+} from '@app/lib/game/music-debug';
+
+const useMusicDebugData = () => {
+  // Armed exactly while a debugger is watching: the trace costs a host-call per sound.
+  useEffect(() => {
+    setMusicDebugArmed(true);
+    return () => { setMusicDebugArmed(false); };
+  }, []);
+
+  const events = useSyncExternalStore(subscribeMusicDebug, getMusicDebugEvents);
+  const counters = useSyncExternalStore(subscribeMusicDebug, getMusicDebugCounters);
+
+  return { events, counters, clear: clearMusicDebug };
+};
+
+export { useMusicDebugData };

--- a/apps/web/src/ui/domains/widgets/music/index.ts
+++ b/apps/web/src/ui/domains/widgets/music/index.ts
@@ -1,0 +1,2 @@
+/* @layer renderer-widgets @kind barrel */
+export { MusicWidgetContent } from './MusicWidget';

--- a/apps/web/src/ui/domains/widgets/music/sub-components/ChannelLive.tsx
+++ b/apps/web/src/ui/domains/widgets/music/sub-components/ChannelLive.tsx
@@ -1,0 +1,27 @@
+/* @layer renderer-widgets @kind component */
+/**
+ * One channel's live block: the studio's own meter readout when something is sounding, a named
+ * "silent" row when nothing is. The silent row matters here in a way it does not in the studio —
+ * a debugger's question is as often "why is this channel NOT playing" as what it is playing.
+ */
+import { Badge, Box, StatRow } from '@ds/primitives';
+import { PreviewReadout } from '@domains/app/views/DataManager/sub-components/msu/PreviewReadout';
+import { usePreviewReport } from '@domains/app/views/DataManager/sub-components/msu/behavior/usePreviewReport';
+import type { LiveChannel } from '../behavior/useLiveChannels';
+
+const ChannelLive = (props: { channel: LiveChannel }) => {
+  const { channel } = props;
+  const report = usePreviewReport(channel.store, channel.name);
+
+  if (report === null) {
+    return (
+      <Box className="music-widget__rows">
+        <StatRow label={channel.title} value={<Badge variant="neutral">silent</Badge>} />
+      </Box>
+    );
+  }
+
+  return <PreviewReadout store={channel.store} previewKey={channel.name} label={channel.title} />;
+};
+
+export { ChannelLive };

--- a/apps/web/src/ui/domains/widgets/music/sub-components/CounterTable.tsx
+++ b/apps/web/src/ui/domains/widgets/music/sub-components/CounterTable.tsx
@@ -1,0 +1,33 @@
+/* @layer renderer-widgets @kind component */
+/**
+ * Running totals per sound and per roll, most recent first — the "how often" answer the feed's
+ * single lines cannot give. A chance layer reads directly as tried-versus-played, so 10% authored
+ * odds landing at 3 of 31 is visible as exactly that.
+ */
+import { Box, EmptyState, StatRow } from '@ds/primitives';
+import type { MusicDebugCounter } from '@app/lib/game/music-debug';
+
+/** How the row's raises split. A roll row reads played/skipped; a sound row reads MSU/chip. */
+const splitOf = (row: MusicDebugCounter): string => {
+  if (row.skipped > 0 || row.key.startsWith('roll:')) {
+    const percent = row.raised > 0 ? Math.round((row.pack / row.raised) * 100) : 0;
+    return `${row.pack}/${row.raised} played (${percent}%)`;
+  }
+  if (row.pack > 0 && row.chip === 0) return `${row.raised}× MSU`;
+  if (row.chip > 0 && row.pack === 0) return `${row.raised}× chip`;
+  return `${row.pack}× MSU, ${row.chip}× chip`;
+};
+
+const CounterTable = (props: { counters: MusicDebugCounter[] }) => {
+  const { counters } = props;
+  if (counters.length === 0) return <EmptyState message="Nothing counted yet." />;
+  return (
+    <Box className="music-widget__rows music-widget__rows--scroll">
+      {counters.map((row) => (
+        <StatRow key={row.key} label={`${row.channel} · ${row.label}`} value={splitOf(row)} mono />
+      ))}
+    </Box>
+  );
+};
+
+export { CounterTable };

--- a/apps/web/src/ui/domains/widgets/music/sub-components/EventFeed.tsx
+++ b/apps/web/src/ui/domains/widgets/music/sub-components/EventFeed.tsx
@@ -1,0 +1,48 @@
+/* @layer renderer-widgets @kind component */
+/**
+ * The rolling feed: every raise the core reported and every roll the engine decided, newest at
+ * the bottom, each line tagged with who produced it. This is the ground truth for "what just
+ * made that sound" — a CHIP line during a storm names the exact id to claim.
+ */
+import { useEffect, useRef } from 'react';
+import { Badge, Box, EmptyState, ScrollArea, Text } from '@ds/primitives';
+import type { BadgeVariant } from '@ds/primitives/Badge/Badge.type';
+import type { MusicDebugEvent, MusicDebugOwner } from '@app/lib/game/music-debug';
+
+const OWNER_LABELS: Record<MusicDebugOwner, string> = { pack: 'MSU', chip: 'CHIP', skipped: 'SKIP' };
+const OWNER_VARIANTS: Record<MusicDebugOwner, BadgeVariant> = {
+  pack: 'success', chip: 'warning', skipped: 'neutral',
+};
+
+const timeOf = (at: number): string => {
+  const date = new Date(at);
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  return `${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};
+
+const EventFeed = (props: { events: MusicDebugEvent[] }) => {
+  const { events } = props;
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [events]);
+
+  if (events.length === 0) return <EmptyState message="No sound events yet — play, or make some noise." />;
+
+  return (
+    <ScrollArea className="music-widget__rows music-widget__feed">
+      {events.map((event) => (
+        <Box key={event.id} className="music-event">
+          <Text className="music-event__time">{timeOf(event.at)}</Text>
+          <Badge variant={OWNER_VARIANTS[event.owner]}>{OWNER_LABELS[event.owner]}</Badge>
+          <Text className="music-event__channel">{event.channel}</Text>
+          <Text className="music-event__detail">{event.detail}</Text>
+        </Box>
+      ))}
+      <Box ref={bottomRef} />
+    </ScrollArea>
+  );
+};
+
+export { EventFeed };

--- a/core/game-hooks/game_hooks.h
+++ b/core/game-hooks/game_hooks.h
@@ -226,6 +226,15 @@ void GameHook_SetDeluxeEntrances(int index, uint32 bits);
 // the chip's own resumed copy — the two would otherwise sound together. Call with the APU locked.
 void GameHook_AmbientAfterLoad(uint8 last_ambient);
 
+// Marks the ambient clear the hook layer is about to raise as OURS, so the report below skips it.
+//
+// The clear id does two unrelated jobs. The game raises it to mean "the bed ends here", which the
+// host has to hear. The hook layer raises the SAME id to silence the chip's copy of a bed it just
+// handed to the host — and if the host heard that one it would stop the bed it was just given, which
+// is precisely how a state load came to restore its music and its thunder but no rain. One flag,
+// consumed by the next report, keeps the two apart.
+void GameHook_MarkSelfRaisedAmbientClear(void);
+
 // Whether |track|, after the host's remapping, is the music already playing: 1/0, or -1 when the
 // host cannot say and the caller should use the vanilla compare.
 int GameHook_MusicIsPlayingRemapped(uint8 track);
@@ -263,5 +272,10 @@ bool GameHook_Sound(int channel, uint8 raw);
 
 // Whether the host claims |id| on |channel|. The predicate alone — no report, no gate check.
 bool GameHook_SoundClaimed(int channel, uint8 id);
+
+// Diagnostics only: report one raise to the host's sound trace, gated on kHostGate_SoundTrace.
+// Never changes what plays. GameHook_Sound calls it for every raise it sees; the after-load bed
+// report calls it itself because it never goes through GameHook_Sound.
+void GameHook_TraceSound(int channel, uint8 id, uint8 pan, bool claimed);
 
 #endif // GAME_HOOKS_H

--- a/core/game-hooks/host_gates.h
+++ b/core/game-hooks/host_gates.h
@@ -28,6 +28,9 @@ enum {
   kHostGate_ExternalMusic = 2,
   kHostGate_ExternalAmbient = 4,
   kHostGate_ExternalSfx = 8,
+  // Diagnostics only: report EVERY sound the game raises, claimed or not, without changing which
+  // of them the chip still plays. Off, not one extra host-call is made.
+  kHostGate_SoundTrace = 16,
 };
 
 extern uint32 g_host_gates[kHostGateWordCount];

--- a/core/game-hooks/music_hooks.c
+++ b/core/game-hooks/music_hooks.c
@@ -27,6 +27,17 @@ static int EffectiveEntrance(void) {
 }
 
 void GameHook_MusicCtrl(uint8 music_ctrl) {
+  // Diagnostics first, and independent of who owns music: the debugger wants every control write,
+  // including the ones the chip is about to play itself. Reports whether the host owns music so
+  // the feed can say which player this write went to. Zero host-calls while the gate is off.
+  if (HostGate(kHostGate_SoundTrace)) {
+    EM_ASM({
+      if (typeof window !== 'undefined' && window.__onMusicTrace) {
+        window.__onMusicTrace($0, $1, $2);
+      }
+    }, music_ctrl, main_module_index, GameHook_MusicExternal() ? 1 : 0);
+  }
+
   // Off by default: makes zero host-calls until the host claims music.
   if (!GameHook_MusicExternal())
     return;
@@ -92,8 +103,11 @@ void GameHook_MusicAnnounce(void) {
   // The id the game is playing as ambience. A claimed one is diverted to the host, and the game
   // is asked to raise the clear so the chip's own copy stops; an unclaimed one no-ops here, which
   // is right — the chip is already producing it.
-  if (sound_effect_ambient_last != 0 && GameHook_Sound(kSoundChannel_Ambient, sound_effect_ambient_last))
+  if (sound_effect_ambient_last != 0 && GameHook_Sound(kSoundChannel_Ambient, sound_effect_ambient_last)) {
+    // Ours, not the game's — the host must not hear it and stop the bed it was just handed.
+    GameHook_MarkSelfRaisedAmbientClear();
     sound_effect_ambient = kAmbientClearId;
+  }
   ZeldaApuUnlock();
 }
 
@@ -184,6 +198,11 @@ void GameHook_AmbientAfterLoad(uint8 last_ambient) {
   // state with no bed, or with one the pack has nothing for, has to stop whatever the host was
   // playing, or the old state's rain keeps falling in the new state's silence.
   uint8 id = last_ambient & 0x3f;
+  // Traced like any other raise: this is the one report that does not pass through GameHook_Sound,
+  // and a debugger that missed the bed a state load restored would be lying about the loudest
+  // thing in the room.
+  GameHook_TraceSound(kSoundChannel_Ambient, id, last_ambient & 0xc0,
+                      GameHook_SoundClaimed(kSoundChannel_Ambient, id));
   EM_ASM({
     if (typeof window !== 'undefined' && window.__onGameSound) {
       window.__onGameSound($0, $1, $2);
@@ -192,8 +211,11 @@ void GameHook_AmbientAfterLoad(uint8 last_ambient) {
   // A claimed bed is the host's to produce, so the chip's restored copy stops — by asking the
   // game to raise the clear, since the snapshot restored the chip mid-note. An unclaimed one is
   // the chip's, and the report above already stopped the host's.
-  if (id != 0 && GameHook_SoundClaimed(kSoundChannel_Ambient, id))
+  if (id != 0 && GameHook_SoundClaimed(kSoundChannel_Ambient, id)) {
+    // Ours, same as the announce path above.
+    GameHook_MarkSelfRaisedAmbientClear();
     sound_effect_ambient = kAmbientClearId;
+  }
 }
 
 // ─── Music at a respawn ───

--- a/core/game-hooks/sound_hooks.c
+++ b/core/game-hooks/sound_hooks.c
@@ -45,6 +45,28 @@ bool GameHook_SoundClaimed(int channel, uint8 id) {
   return (s_claim[channel][(id & 0x3f) >> 5] & (1u << (id & 31))) != 0;
 }
 
+// Set when the hook layer itself raises the ambient clear, cleared by the report that consumes it.
+// See GameHook_MarkSelfRaisedAmbientClear in game_hooks.h for why the two clears must not be confused.
+static bool s_self_raised_clear;
+
+void GameHook_MarkSelfRaisedAmbientClear(void) {
+  s_self_raised_clear = true;
+}
+
+// Diagnostics: every raise, claimed or not, with no say in what the chip does with it. The trace is
+// deliberately separate from the report below so that turning it on cannot move a single sound from
+// the chip to the host — an instrument that changes what it measures is worse than none. Exported
+// so the one report that bypasses GameHook_Sound (the bed re-raised after a state load) can trace too.
+void GameHook_TraceSound(int channel, uint8 id, uint8 pan, bool claimed) {
+  if (!HostGate(kHostGate_SoundTrace))
+    return;
+  EM_ASM({
+    if (typeof window !== 'undefined' && window.__onSoundTrace) {
+      window.__onSoundTrace($0, $1, $2, $3);
+    }
+  }, channel, id, pan, claimed ? 1 : 0);
+}
+
 bool GameHook_Sound(int channel, uint8 raw) {
   // Id 0 is the game's "nothing to play" write, which every frame without a sound effect makes.
   // There is no sound there to replace, and the port still needs it to clear the previous one.
@@ -56,13 +78,30 @@ bool GameHook_Sound(int channel, uint8 raw) {
   if ((unsigned)channel >= (unsigned)kSoundChannel_Count)
     return false;
 
+  uint8 id = raw & 0x3f;
+  bool claimed = (s_claim[channel][id >> 5] & (1u << (id & 31))) != 0;
+  GameHook_TraceSound(channel, id, raw & 0xc0, claimed);
+
   // Off by default: makes zero host-calls until the host claims this channel's sounds.
   if (!HostGate(kSoundChannelGate[channel]))
     return false;
 
-  uint8 id = raw & 0x3f;
-  if (!(s_claim[channel][id >> 5] & (1u << (id & 31))))
-    return false;
+  // The ambient channel is STATEFUL on the host: a bed loops until something replaces it, so the id
+  // that ENDS one has to arrive as surely as the id that starts it. The game ends a bed by raising
+  // its own "no bed" id, which no pack authors — so a claim-only report never delivers it and the
+  // rain outlives the storm. Report every ambient id, and return the claim unchanged so an unclaimed
+  // bed still reaches the chip and plays there exactly as before.
+  //
+  // The one exception is the clear this hook layer raised itself, to silence the chip after handing
+  // a bed over. Delivering that would cancel the bed we just handed over.
+  bool report = claimed;
+  if (channel == kSoundChannel_Ambient && !claimed) {
+    report = !s_self_raised_clear;
+  }
+  if (channel == kSoundChannel_Ambient)
+    s_self_raised_clear = false;
+  if (!report)
+    return claimed;
 
   EM_ASM({
     if (typeof window !== 'undefined' && window.__onGameSound) {
@@ -70,5 +109,5 @@ bool GameHook_Sound(int channel, uint8 raw) {
     }
   }, channel, id, raw & 0xc0);
 
-  return true;
+  return claimed;
 }

--- a/shared/features/vanilla-safe-settings.ts
+++ b/shared/features/vanilla-safe-settings.ts
@@ -22,6 +22,7 @@ const VANILLA_SAFE_LOCKED_SETTINGS: readonly string[] = [
   // Replacement soundtrack: serializeToIni emits MSU off and withholds the pack path.
   'enableMSU',
   'resumeMSU',
+  'resetMSUAtTitle',
   'packReplaceAmbient',
   'packReplaceSfx',
   // Custom player sheet: serializeToIni withholds LinkGraphics, and the override bit is masked.

--- a/shared/storage/profiles.ts
+++ b/shared/storage/profiles.ts
@@ -7,7 +7,7 @@
  * is read unchanged.
  */
 import type { FileStore } from '@shared/platform';
-import type { Profile, AppState } from '@shared/types/profile';
+import type { Profile, ProfilePatch, AppState } from '@shared/types/profile';
 
 const APP_STATE = 'app.json';
 const profileFile = (id: string): string => `profiles/${id}/profile.json`;
@@ -60,12 +60,12 @@ const createProfile = async (files: FileStore, name: string, romFile: string, la
   return profile;
 };
 
-const updateProfile = async (files: FileStore, id: string, patch: Partial<Profile>): Promise<Profile | null> => {
+const updateProfile = async (files: FileStore, id: string, patch: ProfilePatch): Promise<Profile | null> => {
   const profile = await loadProfile(files, id);
   if (!profile) return null;
-  if (patch.name !== undefined) profile.name = patch.name;
-  if (patch.language !== undefined) profile.language = patch.language;
-  if (patch.msuPack !== undefined) profile.msuPack = patch.msuPack;
+  if (patch.name != null) profile.name = patch.name;
+  if (patch.language !== undefined) profile.language = patch.language ?? undefined;
+  if (patch.msuPack !== undefined) profile.msuPack = patch.msuPack ?? undefined;
   await writeJson(files, profileFile(id), profile);
   return profile;
 };

--- a/shared/types/msu-manifest.ts
+++ b/shared/types/msu-manifest.ts
@@ -78,6 +78,18 @@ interface MsuLayer {
   /** 0-100, relative to the profile's music volume. */
   volume: number;
   /**
+   * How likely this layer is to sound at all, 1-100. Rolled once each time the layer STARTS, so
+   * on a one-shot effect it is a per-trigger chance and on a bed it decides whether that bed
+   * carries the layer this time round.
+   *
+   * The game raises some effects far more often than a replacement wants to be heard — the storm's
+   * thunder fires on a fixed frame cycle, which a real recording turns into a metronome. Thinning
+   * it here keeps the sound tied to the moment the game means it, which a free-running random
+   * layer cannot do. Absent means 100: every start sounds, the behaviour of every pack written
+   * before this existed.
+   */
+  chance?: number;
+  /**
    * Loop restart point, in samples at 44100 Hz. Carried through to the MSU-1 loop-point
    * field on export. Undefined = restart at the beginning.
    */

--- a/shared/types/profile.ts
+++ b/shared/types/profile.ts
@@ -10,8 +10,20 @@ interface Profile {
   automation?: boolean; // created by `wt new` for a named instance, not a person — safe to prune
 }
 
+/**
+ * A profile edit. Three cases, and the middle one used to be unreachable: an ABSENT key leaves the
+ * field alone, NULL clears it, a value sets it. Clearing was written as `undefined`, which is
+ * indistinguishable from absent once the patch has crossed a process boundary — so choosing "None"
+ * for a pack or a language silently kept whatever was already assigned.
+ */
+interface ProfilePatch {
+  name?: string;
+  language?: string | null;
+  msuPack?: string | null;
+}
+
 interface AppState {
   lastProfileId: string | null;
 }
 
-export type { AppState, Profile };
+export type { AppState, Profile, ProfilePatch };

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -166,6 +166,10 @@ interface GameSettings {
   // what each slot plays rather than one file per slot.
   enableMSU: 'false' | 'true' | 'deluxe' | 'opuz' | 'deluxe-opuz' | 'msul';
   resumeMSU: boolean;
+  // Whether reaching the title screen forgets every remembered position. Resuming is meant for a
+  // run in progress; carried across runs it starts the opening in the middle of itself instead of
+  // with its animation, and drops a fresh file into the last file's music.
+  resetMSUAtTitle: boolean;
   // A pack may replace the game's ambient beds and sound effects as well as its music. Each
   // group is its own switch because they are separate decisions: someone may want an authored
   // rain bed while keeping every native effect. Off means the core never even reports those


### PR DESCRIPTION
A batch of MSU work that started with the title screen resuming music mid-track and ended with a proper way to see what the audio is doing.

- New Reset At Title Screen setting (on by default). Returning to the title stops the bed and effects and forgets remembered positions, so the opening plays with its animation and a new run does not inherit the last one's music.
- The game's "no bed" id (ambient 5) now reaches the host, so a bed can actually stop. The hook layer's own clear, raised to silence the chip after a handover, is marked as ours so state loads keep their rain.
- Layers get a Chance (1-100), rolled each time the layer starts, with a slider in the studio. New layers on the effect channels default to Once, since a Loop there never ends.
- Music Debugger widget: live meters for all four channels, counts per sound id and per chance layer, and an event feed tagged MSU / CHIP / SKIP. Backed by a core-side trace behind its own host gate, off unless the widget is open, purely observational.
- A profile's MSU pack can be set to None (the clear was never applied on either update path) and a pack change is applied live.
- Log bus mirrors to the console in every unpackaged run, not only dev-server builds, so a crash log actually contains the app's own lines.

WASM rebuilt; save-state format unchanged.
