### PR TITLE
feat(randomizer): add the 7 missing CheckRecords from the certification ledger

### DIFF
--- a/shared/game/data/records/checks/dark-world/dark-death-mountain.ts
+++ b/shared/game/data/records/checks/dark-world/dark-death-mountain.ts
@@ -67,6 +67,14 @@ const DW_DARK_DEATH_MOUNTAIN_CHECKS: CheckRecord[] = [
     randomizerName: 'Hookshot Cave - Bottom Left',
     vanillaItemIds: ['item-066'],
   },
+  {
+    id: 'check-272',
+    gameId: { owScreen: 74, mask: 64 },
+    kind: 'standing',
+    screenId: 'screen-270',
+    randomizerName: 'Bumper Cave Ledge',
+    vanillaItemIds: ['item-024'],
+  },
 ];
 
 export { DW_DARK_DEATH_MOUNTAIN_CHECKS };

--- a/shared/game/data/records/checks/dark-world/dark-north.ts
+++ b/shared/game/data/records/checks/dark-world/dark-north.ts
@@ -19,6 +19,38 @@ const DW_DARK_NORTH_CHECKS: CheckRecord[] = [
     randomizerName: 'Dark Blacksmith Ruins',
     vanillaItemIds: ['item-072'],
   },
+  {
+    id: 'check-271',
+    gameId: { roomId: 295, mask: 1024 },
+    kind: 'standing',
+    screenId: 'screen-468',
+    randomizerName: 'Peg Cave',
+    vanillaItemIds: ['item-024'],
+  },
+  // The cursed pond: same sprite and grant seam as Waterfall Fairy (check-021/022),
+  // one room over. Left/right share spriteType 114, disambiguated by room.
+  {
+    id: 'check-266',
+    gameId: {
+      bufferIndex: 22, mask: 32, flagType: 2, flagMask: 0, itemId: 3, spriteType: 114, postGfx: 0, room: 278,
+    },
+    kind: 'npc',
+    screenId: 'screen-484',
+    randomizerName: 'Pyramid Fairy - Left',
+    vanillaItemIds: ['item-004'],
+    sourceFunc: 'Sprite_WishPond3',
+  },
+  {
+    id: 'check-267',
+    gameId: {
+      bufferIndex: 22, mask: 64, flagType: 2, flagMask: 0, itemId: 59, spriteType: 114, postGfx: 0, room: 278,
+    },
+    kind: 'npc',
+    screenId: 'screen-484',
+    randomizerName: 'Pyramid Fairy - Right',
+    vanillaItemIds: ['item-060'],
+    sourceFunc: 'Sprite_WishPond3',
+  },
 ];
 
 export { DW_DARK_NORTH_CHECKS };

--- a/shared/game/data/records/checks/dark-world/village-of-outcasts.ts
+++ b/shared/game/data/records/checks/dark-world/village-of-outcasts.ts
@@ -23,6 +23,34 @@ const DW_VILLAGE_OF_OUTCASTS_CHECKS: CheckRecord[] = [
     visualNote: 'Sprite disappears (becomes tagalong)',
     sourceFunc: 'Smithy_Frog',
   },
+  {
+    id: 'check-268',
+    gameId: { roomId: 262, chestIndex: 0 },
+    kind: 'chest',
+    screenId: 'screen-473',
+    randomizerName: 'Brewery',
+    vanillaItemIds: ['item-043'],
+  },
+  {
+    id: 'check-269',
+    gameId: { roomId: 284, chestIndex: 0 },
+    kind: 'chest',
+    screenId: 'screen-471',
+    randomizerName: 'C-Shaped House',
+    vanillaItemIds: ['item-071'],
+  },
+  // Shares room 262 with Brewery on purpose: vanilla puts both in one underworld
+  // room, told apart by chest bit (0x10 vs 0x400), never aliasing each other.
+  // The top prize of the once-only minigame roll (OpenMiniGameChest).
+  {
+    id: 'check-270',
+    gameId: { roomId: 262, chestIndex: 6 },
+    kind: 'chest',
+    screenId: 'screen-470',
+    randomizerName: 'Chest Game',
+    vanillaItemIds: ['item-024'],
+    sourceFunc: 'OpenMiniGameChest',
+  },
 ];
 
 export { DW_VILLAGE_OF_OUTCASTS_CHECKS };


### PR DESCRIPTION
## Summary

64 of the AP randomizer's 324 placeable locations had no `CheckRecord`, so the app couldn't detect a player collecting from them. 56 were shop slots (fixed separately in #192 via a live SRAM sold-counter) and 1 (Capacity Upgrade Shop) is a pure logic event needing no record. The remaining **7** were real, ungated pickups with zero detection anywhere:

- **Peg Cave**, **Bumper Cave Ledge** — standing heart pieces
- **Brewery**, **C-Shaped House** — single-chest houses
- **Chest Game** — the minigame's once-only top prize (shares its underworld room with Brewery on purpose, told apart by chest bit)
- **Pyramid Fairy - Left / Right** — the cursed pond's two upgrade grants, the dark-world sibling of the already-shipped Waterfall Fairy pair

`shared/game/data/records/certification/ledger.json` already carried "accepted" ROM/decomp-cited fixes for all 7 (`check-266`..`check-272`), and two of the seven ids were already load-bearing in `randomizer-completion-bits.ts` and `scripted-override-key.ts` — the records themselves were simply never written. This adds them, verified against the ledger's own citations (chest-table address arithmetic, sprite grant sites, save-flag derivations).

## Test plan
- [x] All 7 round-trip through the AP-world name crosswalk (`checkIdByStandardName`) with no override table entry needed
- [x] `all('check').length === 272` (265 + 7)
- [x] `npx tsc --noEmit` and `npx eslint` clean
- [x] Live launch against a real player's placement: the "no certified physical path" plan errors for these 7 locations dropped from 7 to 0, and the Checks widget's available count rose from 15 to 28 on the same save