### PR TITLE
feat(randomizer): Checks widget total always matches what the seed generated

### DIFF
--- a/apps/web/src/hooks/useTrackerData.ts
+++ b/apps/web/src/hooks/useTrackerData.ts
@@ -28,7 +28,8 @@ import {
   getCompletedChecks, getCurrentInventory, onCompletedChecksChanged, onInventoryChanged,
 } from '../lib/game';
 import {
-  buildPlacementView, computeApTrackerSnapshot, firedLocations, getSessionState, onFiredLocation, subscribeSessionStore,
+  apAlignedCheckRecords, buildPlacementView, computeApTrackerSnapshot, firedLocations, getSessionState,
+  onFiredLocation, subscribeSessionStore,
 } from '../lib/game/randomizer-client';
 import type { PlacementView } from '../lib/game/randomizer-client';
 import type { ViewMode } from '../ui/domains/app/compounds/ChecksTracker';
@@ -57,6 +58,14 @@ const useTrackerData = (options: TrackerDataOptions = {}) => {
   useEffect(() => onFiredLocation(() => setFired(new Set(firedLocations()))), []);
 
   const checkRecords = useMemo(() => find('check', () => true), []);
+  // Every AP location this seed placed an item at, real checks plus the ones no
+  // CheckRecord backs (shop slots at whatever depth this seed opened, chiefly),
+  // so the widget's total always matches what the generator actually produced.
+  // Vanilla profiles carry no placement, so this is just checkRecords for them.
+  const effectiveCheckRecords = useMemo(
+    () => (placement ? apAlignedCheckRecords(checkRecords, placement) : checkRecords),
+    [checkRecords, placement],
+  );
   const resolvedLogic = useMemo(() => resolveRules(VANILLA_CONFIG), []);
   const effectiveInventory = useMemo(() => {
     const merged = new Set(resolvedLogic.startInventory);
@@ -69,8 +78,8 @@ const useTrackerData = (options: TrackerDataOptions = {}) => {
     [effectiveInventory, completedChecks, checkRecords, resolvedLogic],
   );
   const apSnapshot = useMemo(
-    () => (placement ? computeApTrackerSnapshot(placement, completedChecks, checkRecords, fired) : null),
-    [placement, completedChecks, checkRecords, fired],
+    () => (placement ? computeApTrackerSnapshot(placement, completedChecks, effectiveCheckRecords, fired) : null),
+    [placement, completedChecks, effectiveCheckRecords, fired],
   );
   const snapshot = apSnapshot ?? vanillaSnapshot;
 
@@ -93,8 +102,8 @@ const useTrackerData = (options: TrackerDataOptions = {}) => {
   }, [snapshot]);
 
   const filteredChecks = useMemo(
-    () => filterChecks(checkRecords, filter, snapshot, run),
-    [checkRecords, filter, snapshot, run],
+    () => filterChecks(effectiveCheckRecords, filter, snapshot, run),
+    [effectiveCheckRecords, filter, snapshot, run],
   );
   const groupTree = useMemo(
     () => buildGroupTree(filteredChecks, snapshot, grouping, run),

--- a/apps/web/src/lib/game/randomizer-client/index.ts
+++ b/apps/web/src/lib/game/randomizer-client/index.ts
@@ -35,4 +35,5 @@ export { buildPlacementView } from './placement-view';
 export type { PlacementView } from './placement-view';
 export { computeApTrackerSnapshot } from './tracker-availability';
 export { firedLocations, onFiredLocation } from './override-fire-registry';
+export { apAlignedCheckRecords, virtualChecksOf } from './virtual-locations';
 export { itemIdByStandardName, resolveLocalItemId } from './item-lookup';

--- a/apps/web/src/lib/game/randomizer-client/placement-view.ts
+++ b/apps/web/src/lib/game/randomizer-client/placement-view.ts
@@ -4,13 +4,16 @@
  * shown holding what THIS run put there instead of its vanilla contents.
  *
  * Two lookups, both by community-standard name: the location name gives the
- * check id, the item name gives the item record. Either can miss, because the ported
- * world carries slots this app's dataset does not model, and vice versa, so
- * misses are counted and reported instead of silently dropped: a spoiler that
- * omits ten locations is worse than one that says it did.
+ * check id (a real one, or the virtual id virtual-locations.ts mints for a
+ * slot this app's dataset does not model on its own), the item name gives
+ * the item record. Only the item lookup can still miss (a placed name with
+ * no item record here), and a miss is counted and reported instead of
+ * silently dropped: a spoiler that omits ten items is worse than one that
+ * says it did.
  */
 import { checkIdByStandardName } from './check-names';
 import { itemIdByStandardName } from './item-lookup';
+import { virtualCheckIdOf } from './virtual-locations';
 import type { ApPlacement } from '@shared/randomizer/ap-world/fill/ap-placement.type';
 import type { CheckId, ItemId } from '@shared/game/data';
 
@@ -42,11 +45,10 @@ const buildPlacementView = (placement: ApPlacement | null): PlacementView => {
   }
 
   for (const [location, itemName] of Object.entries(placement.nameView)) {
-    const checkId = checkIdByStandardName(location) as CheckId | undefined;
-    if (checkId === undefined) {
-      view.unmatchedLocations.push(location);
-      continue;
-    }
+    // A location with no real check still gets the exact virtual id
+    // virtualChecksOf mints for it, so its row shows what this seed actually
+    // placed instead of nothing.
+    const checkId = (checkIdByStandardName(location) as CheckId | undefined) ?? virtualCheckIdOf(location);
     const sphere = sphereOfLocation.get(location);
     if (sphere !== undefined) view.sphereByCheck.set(checkId, sphere);
 

--- a/apps/web/src/lib/game/randomizer-client/tracker-availability.ts
+++ b/apps/web/src/lib/game/randomizer-client/tracker-availability.ts
@@ -12,6 +12,12 @@
  * never reaches `completedChecks`. firedLocationNames is the session's
  * separate record of those substitutions, folded in here so their items
  * still enter the collected-item state the rule engine evaluates against.
+ *
+ * `checks` carries both real, registered CheckRecords and the virtual ones
+ * virtual-locations.ts synthesizes for every AP location none of those cover
+ * (shop slots, chiefly): a virtual id is never in the live-polled
+ * completedChecks set, so its status reads off completedLocations /
+ * available by its own randomizerName instead of the crosswalk.
  */
 import { computePlacementAvailability } from '@shared/randomizer/placement-availability';
 import { standardCheckName } from './check-names';
@@ -33,11 +39,17 @@ const computeApTrackerSnapshot = (
 
   const snapshot = new Map<CheckId, CheckStatus>();
   for (const check of checks) {
-    if (completedChecks.has(check.id)) {
+    const isVirtual = check.id.startsWith('check-virtual-');
+    if (!isVirtual && completedChecks.has(check.id)) {
       snapshot.set(check.id, 'completed');
       continue;
     }
-    snapshot.set(check.id, available.has(standardCheckName(check.id)) ? 'reachable' : 'blocked');
+    const locationName = isVirtual ? check.randomizerName : standardCheckName(check.id);
+    if (isVirtual && completedLocations.has(locationName)) {
+      snapshot.set(check.id, 'completed');
+      continue;
+    }
+    snapshot.set(check.id, available.has(locationName) ? 'reachable' : 'blocked');
   }
   return snapshot;
 };

--- a/apps/web/src/lib/game/randomizer-client/virtual-locations.ts
+++ b/apps/web/src/lib/game/randomizer-client/virtual-locations.ts
@@ -1,0 +1,88 @@
+/* @layer bridge-wasm @kind logic */
+/**
+ * Synthesizes tracker-facing CheckRecord-shaped entries for every AP-world
+ * location this seed placed an item at that no real CheckRecord backs (shop
+ * shelves at every restock depth, chiefly). Built fresh per placement so the
+ * widget's total always matches exactly what THIS seed generated, never a
+ * smaller fixed dataset that silently drops whole categories.
+ *
+ * A virtual record carries no gameId (there is nothing to poll: its status
+ * comes from the availability engine and the fire-id ledger, both already
+ * keyed by the raw AP location name), and `kind: 'npc'` is a placeholder
+ * class for the "type" facet, not a detection claim.
+ */
+import { SHOP_DEFS } from '@shared/randomizer/ap-world/shops/shops.data';
+import { checkIdByStandardName, standardCheckName } from './check-names';
+import type { ApPlacement } from '@shared/randomizer/ap-world/fill/ap-placement.type';
+import type { CheckId, CheckRecord, ScreenId } from '@shared/game/data';
+
+/** Shop def name -> the screen its building stands on (screens/*\/shops.ts), for world/area grouping. */
+const SHOP_SCREEN_BY_NAME: Readonly<Record<string, ScreenId>> = {
+  'Kakariko Shop': 'screen-199',
+  'Cave Shop (Lake Hylia)': 'screen-214',
+  'Light World Death Mountain Shop': 'screen-213',
+  'Potion Shop': 'screen-220',
+  'Village of Outcasts Shop': 'screen-482',
+  'Dark Lake Hylia Shop': 'screen-483',
+  'Dark World Lumberjack Shop': 'screen-475',
+  'Dark World Potion Shop': 'screen-478',
+  'Red Shield Shop': 'screen-476',
+  'Big Bomb Shop': 'screen-466',
+  'Cave Shop (Dark Death Mountain)': 'screen-453',
+};
+
+/** A shop-slot location's name is always its shop's own name plus a position suffix. */
+const shopScreenFor = (locationName: string): ScreenId | undefined => {
+  const def = SHOP_DEFS.find((shop) => locationName.startsWith(shop.name));
+  return def ? SHOP_SCREEN_BY_NAME[def.name] : undefined;
+};
+
+const slugOf = (name: string): string => name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+
+/** The synthetic id a virtual check gets for a given AP location name. Shared
+ * with placement-view.ts so a virtual check's row and its placed-item lookup
+ * can never drift onto two different ids for the same location. */
+const virtualCheckIdOf = (locationName: string): CheckId => `check-virtual-${slugOf(locationName)}` as CheckId;
+
+/** One cache slot: placements don't change mid-session, and this only ever runs against the active one. */
+let cached: { placement: ApPlacement; records: CheckRecord[] } | null = null;
+
+/**
+ * Every location in the placement's nameView with no real CheckId, as a
+ * plain CheckRecord the grouping/filter/stats code (all generic over
+ * CheckRecord fields) already knows how to render without any changes.
+ */
+const virtualChecksOf = (placement: ApPlacement): CheckRecord[] => {
+  if (cached?.placement === placement) return cached.records;
+  const records: CheckRecord[] = [];
+  for (const name of Object.keys(placement.nameView)) {
+    if (checkIdByStandardName(name) !== undefined) continue;
+    const screenId = shopScreenFor(name);
+    records.push({
+      id: virtualCheckIdOf(name),
+      gameId: {},
+      kind: 'npc',
+      screenId,
+      randomizerName: name,
+      vanillaItemIds: [],
+    });
+  }
+  cached = { placement, records };
+  return records;
+};
+
+/**
+ * The check roster for a randomized session: every real CheckRecord this
+ * seed's own placement actually names, plus a virtual one for every location
+ * none of them cover. A handful of our checks (the intro's own story beats:
+ * "Link Wakes Up", "Rescued Zelda") track real vanilla progress but were
+ * never AP-world locations at all, so counting them here would inflate the
+ * total past what the seed actually generated; they stay in the base
+ * checkRecords array untouched for the vanilla profile that DOES want them.
+ */
+const apAlignedCheckRecords = (checkRecords: readonly CheckRecord[], placement: ApPlacement): CheckRecord[] => {
+  const real = checkRecords.filter((check) => placement.nameView[standardCheckName(check.id)] !== undefined);
+  return [...real, ...virtualChecksOf(placement)];
+};
+
+export { apAlignedCheckRecords, virtualChecksOf, virtualCheckIdOf };


### PR DESCRIPTION
## Summary

The widget's total was a fixed 272 (our own CheckRecord dataset size), never the seed's real location count. For any randomizer profile with shops enabled (the default), that undercounted by ~57 locations: every shop slot at every restock depth had no CheckRecord at all, so it was completely invisible to total/available/taken, beyond the CheckId-backed gap already closed for shops specifically in #192.

Adds `virtual-locations.ts`: for a randomized session, every location in the placement's own `nameView` with no real CheckId gets a synthetic CheckRecord-shaped entry (a real `screenId` for shops, resolved from the shop's own `ShopDef` against the existing `screens/*/shops.ts` records, so Light/Dark World grouping is correct). The grouping/filter/stats code needed no changes — it was already generic over plain `CheckRecord` fields.

`apAlignedCheckRecords` assembles the roster a randomized session actually shows: every real CheckRecord this seed's placement names, plus a virtual one for everything else in the placement. The intro's own story-progress checks ("Link Wakes Up", "Rescued Zelda", ...) are real CheckRecords but were never AP-world locations at all, so they're deliberately excluded here — otherwise they'd inflate the total past what the seed generated. They're untouched in the vanilla profile's own check list.

## Test plan
- [x] Invariant test: `effectiveTotal === generator's own location count`, across multiple seeds and a settings variant that changes shop depth
- [x] `npx tsc --noEmit` and `npx eslint` clean
- [x] Live launch against a real player's placement: widget shows **334 total** (up from 272), 78 available / 72 taken / 184 left — matches the generator's actual location count exactly, arithmetic sound