### PR TITLE
fix(randomizer): the pond delivers its locations, and every total agrees

### DIFF
--- a/apps/web/src/hooks/randomizer/pool-totals-model.ts
+++ b/apps/web/src/hooks/randomizer/pool-totals-model.ts
@@ -2,21 +2,26 @@
 /**
  * The pool accounting split for the fill bar: the items of the pool minus
  * the capacity upgrades and the filler are the items in pool, the upgrades
- * and the filler stand on their own, the fixed spots and the spots pass
- * through. Every input is the accounting's own number; this only takes the
- * two segments out of the pool count so the four fill the spots exactly.
+ * and the filler stand on their own, the fixed spots, the prizes and the
+ * events pass through. Every input is the accounting's own number; this
+ * only takes the two segments out of the pool count so the six segments
+ * fill every location of the world exactly, the same total the Checks
+ * widget shows.
  */
 import type { PoolAccounting } from '@shared/randomizer/ap-world/pool/pool-accounting';
 import type { PoolFillTotals } from '@domains/app/compounds/PoolFillBar';
 
 const poolTotalsOf = (accounting: PoolAccounting): PoolFillTotals => {
-  const { items, spots, fixed, filler, upgrades } = accounting;
+  const {
+    items, fixed, filler, upgrades, prizes, events,
+  } = accounting;
   return {
     items: Math.max(0, items - upgrades - filler),
     upgrades,
     filler,
     fixed,
-    spots,
+    prizes,
+    events,
   };
 };
 

--- a/apps/web/src/lib/game/randomizer-client/virtual-locations.ts
+++ b/apps/web/src/lib/game/randomizer-client/virtual-locations.ts
@@ -9,12 +9,21 @@
  * A virtual record carries no gameId (there is nothing to poll: its status
  * comes from the availability engine and the fire-id ledger, both already
  * keyed by the raw AP location name), and `kind: 'npc'` is a placeholder
- * class for the "type" facet, not a detection claim.
+ * class for the "type" facet, not a detection claim. vanillaItemIds carries
+ * the real vanilla item where one exists (a shop shelf, a key-drop pot);
+ * a pure logic event (special-locations.data.ts) has none and is the only
+ * case the reward filter should read as "no reward". Everything else here
+ * still hands over a real item, so isGuaranteedReward says so even where
+ * there is no vanilla precedent to point vanillaItemIds at (a pond slot
+ * past the reference's two).
  */
 import { SHOP_DEFS } from '@shared/randomizer/ap-world/shops/shops.data';
+import { shopSlotLocationOf } from '@shared/randomizer/ap-world/shops/shop-slots';
+import { EVENT_LOCATIONS, KEY_DROP_LOCATIONS } from '@shared/randomizer/ap-world/special-locations.data';
 import { checkIdByStandardName, standardCheckName } from './check-names';
+import { itemIdByStandardName } from './item-lookup';
 import type { ApPlacement } from '@shared/randomizer/ap-world/fill/ap-placement.type';
-import type { CheckId, CheckRecord, ScreenId } from '@shared/game/data';
+import type { CheckId, CheckRecord, ItemId, ScreenId } from '@shared/game/data';
 
 /** Shop def name -> the screen its building stands on (screens/*\/shops.ts), for world/area grouping. */
 const SHOP_SCREEN_BY_NAME: Readonly<Record<string, ScreenId>> = {
@@ -38,6 +47,14 @@ const shopScreenFor = (locationName: string): ScreenId | undefined => {
 };
 
 const slugOf = (name: string): string => name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+
+/** A virtual location's own vanilla item, when it has one (a shop shelf or a key-drop pot). */
+const vanillaItemIdsOf = (name: string): ItemId[] => {
+  const standardName = shopSlotLocationOf(name)?.slot.vanillaItem ?? KEY_DROP_LOCATIONS.get(name);
+  if (standardName === undefined) return [];
+  const itemId = itemIdByStandardName(standardName);
+  return itemId !== undefined ? [itemId] : [];
+};
 
 /** The synthetic id a virtual check gets for a given AP location name. Shared
  * with placement-view.ts so a virtual check's row and its placed-item lookup
@@ -64,7 +81,8 @@ const virtualChecksOf = (placement: ApPlacement): CheckRecord[] => {
       kind: 'npc',
       screenId,
       randomizerName: name,
-      vanillaItemIds: [],
+      vanillaItemIds: vanillaItemIdsOf(name),
+      isGuaranteedReward: !EVENT_LOCATIONS.has(name),
     });
   }
   cached = { placement, records };

--- a/apps/web/src/ui/domains/app/compounds/PoolFillBar/PoolFillBar.css
+++ b/apps/web/src/ui/domains/app/compounds/PoolFillBar/PoolFillBar.css
@@ -1,9 +1,10 @@
 /* @layer renderer-components @kind style */
 
 /* The checks tracker's summary bar, read for a fill: a thin grey track of
-   every spot, filled left to right in placement order: items in pool,
-   upgrades, filler, then the spots settled before the shuffle. The legend
-   repeats each colour as a swatch beside its count. */
+   every location this seed generates, filled left to right in placement
+   order: items in pool, upgrades, filler, the spots settled before the
+   shuffle, the boss prizes, then the reward-less events. The legend repeats
+   each colour as a swatch beside its count. */
 
 .pool-fill {
   display: flex;
@@ -74,11 +75,19 @@
 .pool-fill__seg--fixed,
 .pool-fill__swatch--fixed { background: var(--c-danger); }
 
+.pool-fill__seg--prizes,
+.pool-fill__swatch--prizes { background: var(--c-info); }
+
+.pool-fill__seg--events,
+.pool-fill__swatch--events { background: var(--c-border-strong); }
+
 .pool-fill__count--items { color: var(--c-green); }
 .pool-fill__count--upgrades { color: var(--c-upgrade); }
 .pool-fill__count--filler { color: var(--c-warning); }
 .pool-fill__count--fixed { color: var(--c-danger); }
-.pool-fill__count--spots { color: var(--c-text); }
+.pool-fill__count--prizes { color: var(--c-info); }
+.pool-fill__count--events { color: var(--c-text-muted); }
+.pool-fill__count--total { color: var(--c-text); }
 
 .pool-fill__error {
   font-family: var(--font-mono);

--- a/apps/web/src/ui/domains/app/compounds/PoolFillBar/PoolFillBar.tsx
+++ b/apps/web/src/ui/domains/app/compounds/PoolFillBar/PoolFillBar.tsx
@@ -1,33 +1,37 @@
 /* @layer renderer-components @kind component */
 /**
- * The pool against the spots of the world as one segmented bar: the checks
- * tracker's summary bar, read for a fill. The track is every spot; it fills
- * left to right with the items in the pool (green), the capacity upgrades
- * (purple), the filler (yellow) and the spots settled before the shuffle
- * (red); whatever stays bare has nothing. The legend under it is one entry
- * per colour, swatch, count and meaning. Bare: the totals arrive reconciled.
+ * The pool against every location of the world as one segmented bar: the
+ * checks tracker's summary bar, read for a fill. The track is every location
+ * this seed generates, the same total the Checks widget shows; it fills left
+ * to right with the items in the pool (green), the capacity upgrades
+ * (purple), the filler (yellow), the spots settled before the shuffle (red),
+ * the boss prizes (blue) and the reward-less events (grey). The legend under
+ * it is one entry per colour, swatch, count and meaning. Bare: the totals
+ * arrive reconciled.
  */
 import { Box, Text } from '@ds/primitives';
 import type { PoolFillBarProps, PoolFillTotals } from './PoolFillBar.type';
 import './PoolFillBar.css';
 
-type Segment = 'items' | 'upgrades' | 'filler' | 'fixed';
+type Segment = keyof PoolFillTotals;
 
 /** Placement order, left to right. */
-const SEGMENTS: readonly Segment[] = ['items', 'upgrades', 'filler', 'fixed'];
+const SEGMENTS: readonly Segment[] = ['items', 'upgrades', 'filler', 'fixed', 'prizes', 'events'];
 
-const LEGEND: readonly { key: keyof PoolFillTotals; label: string; title: string }[] = [
+const LEGEND: readonly { key: Segment; label: string; title: string }[] = [
   { key: 'items', label: 'items in pool', title: 'Items the shuffle places that are neither a capacity upgrade nor filler' },
   { key: 'upgrades', label: 'upgrades', title: 'Capacity upgrade items, each in a filler\'s place' },
   { key: 'filler', label: 'filler', title: 'Balance filler still in the pool' },
   { key: 'fixed', label: 'fixed', title: 'Spots settled before the shuffle' },
-  { key: 'spots', label: 'spots', title: 'Every spot an item can sit in, the full bar' },
+  { key: 'prizes', label: 'prizes', title: 'The ten boss-reward slots, pre-placed from their own fixed pool' },
+  { key: 'events', label: 'events', title: 'Pure logic locations: a check, but never a reward' },
 ];
 
-const widthOf = (totals: PoolFillTotals, count: number): string =>
-  totals.spots > 0 ? `${(count / totals.spots) * 100}%` : '0%';
+const totalOf = (totals: PoolFillTotals): number => SEGMENTS.reduce((sum, key) => sum + totals[key], 0);
 
-const Legend = ({ totals }: { totals: PoolFillTotals }) => (
+const widthOf = (total: number, count: number): string => (total > 0 ? `${(count / total) * 100}%` : '0%');
+
+const Legend = ({ totals, total }: { totals: PoolFillTotals; total: number }) => (
   <Box className="pool-fill__legend">
     {LEGEND.map((entry) => (
       <Text key={entry.key} className="pool-fill__stat" title={entry.title}>
@@ -36,6 +40,10 @@ const Legend = ({ totals }: { totals: PoolFillTotals }) => (
         <Box as="span" className="pool-fill__stat-label">{` ${entry.label}`}</Box>
       </Text>
     ))}
+    <Text className="pool-fill__stat" title="Every location this seed generates, the same total the Checks widget shows">
+      <Box as="span" className="pool-fill__count pool-fill__count--total">{total}</Box>
+      <Box as="span" className="pool-fill__stat-label">{' total'}</Box>
+    </Text>
   </Box>
 );
 
@@ -49,6 +57,7 @@ const PoolFillBar = (props: PoolFillBarProps) => {
       </Box>
     );
   }
+  const total = totalOf(totals);
   return (
     <Box className={classes}>
       <Box className="pool-fill__bar">
@@ -56,11 +65,11 @@ const PoolFillBar = (props: PoolFillBarProps) => {
           <Box
             key={segment}
             className={`pool-fill__seg pool-fill__seg--${segment}`}
-            style={{ width: widthOf(totals, totals[segment]) }}
+            style={{ width: widthOf(total, totals[segment]) }}
           />
         ))}
       </Box>
-      <Legend totals={totals} />
+      <Legend totals={totals} total={total} />
     </Box>
   );
 };

--- a/apps/web/src/ui/domains/app/compounds/PoolFillBar/PoolFillBar.type.ts
+++ b/apps/web/src/ui/domains/app/compounds/PoolFillBar/PoolFillBar.type.ts
@@ -1,12 +1,13 @@
 /* @layer renderer-components @kind types */
 
 /**
- * The pool against the spots of the world, already reconciled: every number
- * is a count of items or spots, and the four item counts together never
- * exceed the spots, the bar's full width.
+ * The pool against every location of the world, already reconciled: every
+ * number is a count of items or locations, and items + upgrades + filler +
+ * fixed + prizes + events together are exactly the bar's full width, the
+ * same total the Checks widget shows for this seed.
  */
 interface PoolFillTotals {
-  /** Items in the pool that are neither a capacity upgrade nor filler: progression, useful, dungeon items, prizes. */
+  /** Items in the pool that are neither a capacity upgrade nor filler: progression, useful, dungeon items. */
   items: number;
   /** Capacity upgrade items in the pool, each in a filler's place. */
   upgrades: number;
@@ -14,8 +15,10 @@ interface PoolFillTotals {
   filler: number;
   /** Spots settled before the shuffle: a locked vanilla item, the assured starting weapon. */
   fixed: number;
-  /** Every spot an item can sit in; the bar's full width, whatever stays bare has nothing. */
-  spots: number;
+  /** The ten boss-reward slots, pre-placed from their own fixed pool outside the general fill. */
+  prizes: number;
+  /** Pure logic locations (Ganon, Agahnim, the flute spot): a location, but never a reward. */
+  events: number;
 }
 
 interface PoolFillBarProps {

--- a/shared/game/data/record-codegen.ts
+++ b/shared/game/data/record-codegen.ts
@@ -121,7 +121,8 @@ const LOCATION_SPEC: FieldSpec<LocationRecord> = {
 
 const CHECK_FIELDS = [
   'id', 'gameId', 'kind', 'screenId', 'dungeonId', 'vanillaName', 'randomizerName',
-  'vanillaItemIds', 'tags', 'actorId', 'requirements', 'presence', 'visualNote', 'sourceFunc', 'review',
+  'vanillaItemIds', 'isGuaranteedReward', 'tags', 'actorId', 'requirements', 'presence', 'visualNote', 'sourceFunc',
+  'review',
 ] as const satisfies readonly (keyof CheckRecord)[];
 
 const ITEM_FIELDS = [

--- a/shared/game/data/records/checks/light-world/lake-hylia.ts
+++ b/shared/game/data/records/checks/light-world/lake-hylia.ts
@@ -19,6 +19,26 @@ const LW_LAKE_HYLIA_CHECKS: CheckRecord[] = [
     randomizerName: 'Lake Hylia Island',
     vanillaItemIds: ['item-024'],
   },
+  // The Happiness Pond's two counter-bump slots (sprite_main.c:11416
+  // Sprite_HappinessPond, dungeon_room_index 21 = the low byte of room
+  // 0x115); no chest/NPC table entry exists for either, so completion reads
+  // the save-block byte the purchase writes (variables.h:1103-1104).
+  {
+    id: 'check-273',
+    gameId: { bufferIndex: 23, compare: 'gte', value: 1 },
+    kind: 'npc',
+    screenId: 'screen-217',
+    randomizerName: 'Capacity Upgrade Left',
+    vanillaItemIds: ['item-132'],
+  },
+  {
+    id: 'check-274',
+    gameId: { bufferIndex: 24, compare: 'gte', value: 1 },
+    kind: 'npc',
+    screenId: 'screen-217',
+    randomizerName: 'Capacity Upgrade Right',
+    vanillaItemIds: ['item-129'],
+  },
 ];
 
 export { LW_LAKE_HYLIA_CHECKS };

--- a/shared/game/data/records/screens/light-world/fairy.ts
+++ b/shared/game/data/records/screens/light-world/fairy.ts
@@ -22,7 +22,7 @@ const LW_FAIRY_SCREENS: ScreenRecord[] = [
   },
   {
     id: 'screen-217',
-    gameId: { roomIndex: 279 },
+    gameId: { roomIndex: 277 },
     kind: 'interior',
     world: 'light',
     interiorKind: 'fairy',

--- a/shared/game/data/types/check.ts
+++ b/shared/game/data/types/check.ts
@@ -71,6 +71,13 @@ interface CheckRecord {
   vanillaName?: string;
   randomizerName: string;
   vanillaItemIds: ItemId[];
+  /**
+   * Set on a virtual location with no vanilla item of its own (a pond slot
+   * past the reference's two): true means the seed still hands over a real
+   * item here, so the reward filter must not read the empty vanillaItemIds
+   * as "no reward". Absent everywhere else; vanillaItemIds alone decides.
+   */
+  isGuaranteedReward?: boolean;
   /** The check's own content (key/big key/map/compass/boss item), as tag collection references. */
   tags?: readonly TagId[];
   /** The actor that grants this check (an NPC or a boss), joined on spriteType. */

--- a/shared/game/logic/queries/check-grouping/filter.ts
+++ b/shared/game/logic/queries/check-grouping/filter.ts
@@ -43,9 +43,9 @@ const filterChecks = (
   }
 
   if (filter.itemFilter === 'rewards') {
-    result = result.filter(c => c.vanillaItemIds.length > 0);
+    result = result.filter(c => c.vanillaItemIds.length > 0 || c.isGuaranteedReward === true);
   } else if (filter.itemFilter === 'non-rewards') {
-    result = result.filter(c => c.vanillaItemIds.length === 0);
+    result = result.filter(c => c.vanillaItemIds.length === 0 && c.isGuaranteedReward !== true);
   }
 
   if (filter.statusFilter && filter.statusFilter !== 'all' && statuses) {

--- a/shared/randomizer/ap-world/pool/pool-accounting.ts
+++ b/shared/randomizer/ap-world/pool/pool-accounting.ts
@@ -36,12 +36,16 @@ interface PoolAccounting {
   items: number;
   /** Spots settled before the shuffle: the locked vanilla items plus the assured starting weapon. */
   fixed: number;
+  /** The ten boss-reward slots: pre-placed from their own fixed pool, outside the general fill. */
+  prizes: number;
   /** Locations pre-placed with their vanilla item and excluded from the fill. */
   lockedVanilla: number;
   /** Filler items still in the global pool (what more upgrades could displace). */
   filler: number;
   /** The capacity families' items in the global pool: each one took a filler's place. */
   upgrades: number;
+  /** Pure logic locations (Ganon, Agahnim, the flute spot): a location, but never a reward. */
+  events: number;
 }
 
 /** The items the profile's family plans put in the pool, by name, the meter's row included. */
@@ -52,7 +56,8 @@ const accountingOf = (snapshot: RandomizerOptionsSnapshot, deliverable: Delivera
   const fillWorld = buildFillWorld(fillOptionsFromSnapshot(snapshot, deliverable, { pickWeapon: firstChoice }));
   const { world, pool } = fillWorld;
   const dungeon = [...pool.dungeonItems.values()].reduce((sum, items) => sum + items.length, 0);
-  const spots = [...world.locationsByName.values()].filter((location) => !location.event && !location.prize);
+  const allLocations = [...world.locationsByName.values()];
+  const spots = allLocations.filter((location) => !location.event && !location.prize);
   const planItems = planItemsOf(fillWorld);
   return {
     locations: world.locationsByName.size,
@@ -60,9 +65,11 @@ const accountingOf = (snapshot: RandomizerOptionsSnapshot, deliverable: Delivera
     open: fillEligibleLocations(fillWorld).length,
     items: pool.pool.length + dungeon,
     fixed: spots.filter((location) => world.placedItems.has(location.name)).length,
+    prizes: allLocations.filter((location) => location.prize).length,
     lockedVanilla: fillWorld.lockedVanilla.size,
     filler: fillerCountOf(pool.pool),
     upgrades: pool.pool.filter((name) => planItems.has(name)).length,
+    events: allLocations.filter((location) => location.event).length,
   };
 };
 


### PR DESCRIPTION
## Summary

- The Happiness Pond's two checks pointed at the wrong room and had never been created, so `isPondDeliverable` could never pass and the pond always contributed zero locations. Fixed the room number and added the two checks from the certification ledger's already-vetted data (closes #188).
- The creation screen's "In Pool" preview excluded boss prizes and events from its total while the Checks widget counted everything, so the two never agreed for the same settings. The preview now shows prizes and events as their own segments, so both totals match exactly.
- Shop, key-drop and pond checks were showing up under "non-reward" in the tracker filter since virtual checks always carried an empty `vanillaItemIds`. Only genuine logic events (no item, ever) read as non-reward now.

## Test plan

- [x] `npx tsc --noEmit` and `npx eslint .` clean
- [x] `npx vitest run tests/randomizer/` (126 tests) passes
- [x] Verified against a real generated placement: pond now delivers 10 locations, and `items+upgrades+filler+fixed+prizes+events` sums to the same total the Checks widget shows (334 for default settings)
- [x] Verified against issue #188's own reported seed and settings