### PR TITLE
Rebuild the checks tracker on design-system parts

### DIFF
--- a/apps/web/src/hooks/useTrackerData.ts
+++ b/apps/web/src/hooks/useTrackerData.ts
@@ -42,7 +42,7 @@ interface TrackerDataOptions {
 const EMPTY_FILTER: FilterState = { searchQuery: '', activeFacets: [], tagMode: 'any' };
 
 const useTrackerData = (options: TrackerDataOptions = {}) => {
-  const { initialGrouping = ['world', 'dungeon'], initialViewMode = 'compact' } = options;
+  const { initialGrouping = ['world', 'dungeon'], initialViewMode = 'visual' } = options;
 
   const [inventory, setInventory] = useState<Set<ItemId>>(() => getCurrentInventory());
   const [completedChecks, setCompletedChecks] = useState<Set<CheckId>>(() => getCompletedChecks());

--- a/apps/web/src/ui/design-system/primitives/Button/Button.css
+++ b/apps/web/src/ui/design-system/primitives/Button/Button.css
@@ -147,3 +147,22 @@
 @keyframes btn-spin {
   to { transform: rotate(360deg); }
 }
+
+/* ─── Active / toggled-on (gold), wins over any variant ─── */
+.btn--active {
+  background: var(--c-selected);
+  border-color: var(--c-gold);
+  color: var(--c-gold-bright);
+}
+
+.btn--active:hover:not(:disabled) {
+  background: var(--c-gold-soft);
+  border-color: var(--c-gold-bright);
+  color: var(--c-gold-bright);
+}
+
+/* A small button's icon sits next to the label, so it takes the label's size. */
+.btn--sm .btn__icon {
+  width: auto;
+  font-size: inherit;
+}

--- a/apps/web/src/ui/design-system/primitives/Button/Button.tsx
+++ b/apps/web/src/ui/design-system/primitives/Button/Button.tsx
@@ -6,18 +6,19 @@ import { type ButtonVariant, type ButtonSize, type ButtonProps } from './Button.
 
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  const { variant = 'tertiary', size = 'md', fullWidth = false, icon, children, className = '', ...rest } = props;
+  const { variant = 'tertiary', size = 'md', fullWidth = false, active = false, icon, children, className = '', ...rest } = props;
 
   const cls = [
     'btn',
     `btn--${variant}`,
     `btn--${size}`,
     fullWidth && 'btn--full',
+    active && 'btn--active',
     className,
   ].filter(Boolean).join(' ');
 
   return (
-    <button ref={ref} className={cls} {...rest}>
+    <button ref={ref} className={cls} aria-pressed={active || undefined} {...rest}>
       {icon && <span className="btn__icon">{icon}</span>}
       {children}
     </button>

--- a/apps/web/src/ui/design-system/primitives/Button/Button.type.ts
+++ b/apps/web/src/ui/design-system/primitives/Button/Button.type.ts
@@ -9,6 +9,8 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   fullWidth?: boolean;
+  /** Toggled-on state, given the same gold treatment IconButton uses. */
+  active?: boolean;
   icon?: ReactNode;
 }
 

--- a/apps/web/src/ui/design-system/primitives/ProgressBar/ProgressBar.css
+++ b/apps/web/src/ui/design-system/primitives/ProgressBar/ProgressBar.css
@@ -26,3 +26,9 @@
 .progress-bar__fill--secondary {
   opacity: var(--opacity-faint);
 }
+
+/* A secondary with a colour of its own is a second reading, not a faded first one. */
+.progress-bar[data-secondary-variant] .progress-bar__fill--secondary { opacity: 1; }
+.progress-bar[data-secondary-variant='gold'] .progress-bar__fill--secondary { background: var(--c-gold); }
+.progress-bar[data-secondary-variant='green'] .progress-bar__fill--secondary { background: var(--c-green); }
+.progress-bar[data-secondary-variant='danger'] .progress-bar__fill--secondary { background: var(--c-danger); }

--- a/apps/web/src/ui/design-system/primitives/ProgressBar/ProgressBar.tsx
+++ b/apps/web/src/ui/design-system/primitives/ProgressBar/ProgressBar.tsx
@@ -5,12 +5,13 @@ import type { ProgressBarProps } from './ProgressBar.type';
 const pct = (value: number, max: number): string => `${Math.max(0, Math.min(100, (value / max) * 100))}%`;
 
 const ProgressBar = (props: ProgressBarProps) => {
-  const { value, max = 100, variant = 'gold', secondaryValue, live = false, className = '' } = props;
+  const { value, max = 100, variant = 'gold', secondaryValue, secondaryVariant, live = false, className = '' } = props;
   return (
     <div
       className={`progress-bar${className ? ` ${className}` : ''}`}
       data-variant={variant}
       data-live={live ? 'yes' : undefined}
+      data-secondary-variant={secondaryVariant}
     >
       {secondaryValue != null && (
         <div className="progress-bar__fill progress-bar__fill--secondary" style={{ width: pct(secondaryValue, max) }} />

--- a/apps/web/src/ui/design-system/primitives/ProgressBar/ProgressBar.type.ts
+++ b/apps/web/src/ui/design-system/primitives/ProgressBar/ProgressBar.type.ts
@@ -8,6 +8,12 @@ interface ProgressBarProps {
   /** Optional second (lighter) fill behind the main one, e.g. reachable-vs-done. */
   secondaryValue?: number;
   /**
+   * Colours the secondary fill in its own right, for a bar whose two parts mean
+   * two different things (done vs. reachable) instead of one thing at two
+   * strengths. Omitted, the secondary keeps the main colour, faded.
+   */
+  secondaryVariant?: ProgressVariant;
+  /**
    * Set for a bar whose value is sampled continuously, not changed now and then. The fill
    * eases towards a new width by default, which reads well for an occasional jump and badly for a
    * live one: re-targeting the same transition every animation frame leaves the fill perpetually

--- a/apps/web/src/ui/design-system/primitives/SegmentedControl/SegmentedControl.tsx
+++ b/apps/web/src/ui/design-system/primitives/SegmentedControl/SegmentedControl.tsx
@@ -61,6 +61,8 @@ const SegmentedControl = <T extends string = string>(props: SegmentedControlProp
             type="button"
             role="radio"
             aria-checked={value === opt.value}
+            aria-label={opt.title}
+            title={opt.title}
             className={`segmented__btn ${value === opt.value ? 'segmented__btn--active' : ''}`}
             onClick={() => {
               const outcome = resolveClick(opt.value, value, onDeselect !== undefined);

--- a/apps/web/src/ui/design-system/primitives/SegmentedControl/SegmentedControl.type.ts
+++ b/apps/web/src/ui/design-system/primitives/SegmentedControl/SegmentedControl.type.ts
@@ -1,7 +1,12 @@
 /* @layer renderer-components @kind types */
-﻿interface SegmentOption<T extends string = string> {
+﻿import type { ReactNode } from 'react';
+
+interface SegmentOption<T extends string = string> {
   value: T;
-  label: string;
+  /** Text, or an icon for a control too narrow to spell its options out. */
+  label: ReactNode;
+  /** Tooltip and accessible name, needed whenever the label is an icon. */
+  title?: string;
   disabled?: boolean;
 }
 

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.constants.ts
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.constants.ts
@@ -1,0 +1,73 @@
+/* @layer renderer-components @kind constants */
+/**
+ * Icon geometry and option tables for the tracker.
+ *
+ * The tracker used to draw its states and view modes with text glyphs, which
+ * inherited the body font and sat at a different weight and baseline from every
+ * other control in the app. These are the same 16x16 outline shapes the title
+ * bar and search palette use, so a status reads as an icon everywhere.
+ */
+
+/* Taken: a plain checkmark. */
+const CHECK_PATHS = [
+  'M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0',
+];
+
+/* Available: a filled dot, the one solid mark in the set. */
+const DOT_CIRCLES = [{ cx: 8, cy: 8, r: 4 }];
+
+/* Left: the same dot, hollow. */
+const RING_PATHS = [
+  'M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16',
+];
+
+/* Every check: a stack of rows. */
+const STACK_PATHS = [
+  'M2.5 3.5a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m2-2a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5m-2 4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5M0 8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2z',
+];
+
+/* Compact rows. */
+const LIST_PATHS = [
+  'M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5',
+];
+
+/* Rows carrying a second column. */
+const LIST_DETAIL_PATHS = [
+  'M5 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5M3 3.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0m0 4a1 1 0 1 1-2 0 1 1 0 0 1 2 0m0 4a1 1 0 1 1-2 0 1 1 0 0 1 2 0',
+];
+
+/* Item cards. */
+const GRID_PATHS = [
+  'M1 2.5A1.5 1.5 0 0 1 2.5 1h3A1.5 1.5 0 0 1 7 2.5v3A1.5 1.5 0 0 1 5.5 7h-3A1.5 1.5 0 0 1 1 5.5zm8 0A1.5 1.5 0 0 1 10.5 1h3A1.5 1.5 0 0 1 15 2.5v3A1.5 1.5 0 0 1 13.5 7h-3A1.5 1.5 0 0 1 9 5.5zm-8 8A1.5 1.5 0 0 1 2.5 9h3A1.5 1.5 0 0 1 7 10.5v3A1.5 1.5 0 0 1 5.5 15h-3A1.5 1.5 0 0 1 1 13.5zm8 0A1.5 1.5 0 0 1 10.5 9h3a1.5 1.5 0 0 1 1.5 1.5v3a1.5 1.5 0 0 1-1.5 1.5h-3A1.5 1.5 0 0 1 9 13.5z',
+];
+
+/* The filter drawer's own toggle. */
+const FUNNEL_PATHS = [
+  'M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5zm1 1v.793l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.349L13.5 3.293V2.5z',
+];
+
+/* Facets. */
+const TAG_PATHS = [
+  'M6 4.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0',
+  'M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm0 1h4.586l7 7L9 13.586l-7-7z',
+];
+
+/* Grouping axes: rows at descending indents. */
+const NESTED_PATHS = [
+  'M4.5 11.5A.5.5 0 0 1 5 11h10a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5m-2-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m-2-4A.5.5 0 0 1 1 3h10a.5.5 0 0 1 0 1H1a.5.5 0 0 1-.5-.5',
+];
+
+/* Remove. */
+const CLOSE_PATHS = [
+  'M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8z',
+];
+
+/* Search. */
+const SEARCH_PATHS = [
+  'M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0',
+];
+
+export {
+  CHECK_PATHS, CLOSE_PATHS, DOT_CIRCLES, FUNNEL_PATHS, GRID_PATHS, LIST_DETAIL_PATHS,
+  LIST_PATHS, NESTED_PATHS, RING_PATHS, SEARCH_PATHS, STACK_PATHS, TAG_PATHS,
+};

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.css
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.css
@@ -5,142 +5,10 @@
 @import url('./sub-components/ChecksTracker.filters.css');
 @import url('./sub-components/ChecksTracker.checks.css');
 
-/* ─── Tracker panel (legacy overlay frame) ─── */
-
-.tracker-panel {
-  --tracker-frame-opacity: 1;
-
-  position: fixed;
-  top: 38px; /* below titlebar */
-  bottom: 0;
-  width: 380px;
-  color: var(--c-text);
-  display: flex;
-  flex-direction: column;
-  z-index: var(--z-panel);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  overflow: hidden;
-  background: rgb(14 14 18 / calc(0.96 * var(--tracker-frame-opacity))); /* stylelint-disable-line function-disallowed-list */
-  border-color: rgb(255 255 255 / calc(0.08 * var(--tracker-frame-opacity))); /* stylelint-disable-line function-disallowed-list */
-  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
-}
-
-/* Docked sides */
-.tracker-panel--docked.tracker-panel--right {
-  right: 0;
-  border-left: 1px solid rgb(255 255 255 / calc(0.08 * var(--tracker-frame-opacity))); /* stylelint-disable-line function-disallowed-list */
-}
-
-.tracker-panel--docked.tracker-panel--left {
-  left: 0;
-  border-right: 1px solid rgb(255 255 255 / calc(0.08 * var(--tracker-frame-opacity))); /* stylelint-disable-line function-disallowed-list */
-}
-
-/* Floating mode */
-.tracker-panel--floating {
-  top: auto;
-  bottom: auto;
-  right: auto;
-  border: 1px solid rgb(255 255 255 / calc(0.12 * var(--tracker-frame-opacity))); /* stylelint-disable-line function-disallowed-list */
-  border-radius: var(--r-lg);
-  box-shadow: 0 8px 32px rgb(0 0 0 / calc(0.6 * var(--tracker-frame-opacity))); /* stylelint-disable-line function-disallowed-list */
-  resize: both;
-  min-width: 280px;
-  min-height: 200px;
-  max-width: 90vw;
-  max-height: 90vh;
-}
-
-/* Compact variant (inventory-only panel when split) */
-.tracker-panel--compact {
-  width: auto;
-  min-width: 200px;
-  max-width: 420px;
-  bottom: auto;
-}
-
-/* ─── Panel Header ─── */
-
-.tracker-panel__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-sm) var(--space-sm);
-  border-bottom: 1px solid rgb(255 255 255 / calc(0.08 * var(--tracker-frame-opacity))); /* stylelint-disable-line function-disallowed-list */
-  flex-shrink: 0;
-  gap: var(--space-sm);
-  user-select: none;
-}
-
-.tracker-panel--floating .tracker-panel__header {
-  cursor: grab;
-}
-
-.tracker-panel--floating .tracker-panel__header:active {
-  cursor: grabbing;
-}
-
-.tracker-panel__title {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-semi);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.tracker-panel__controls {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  flex: 1;
-  justify-content: flex-end;
-}
-
-/* Compact SegmentedControl in tracker header */
-.tracker-panel__controls .segmented {
-  gap: 0;
-}
-
-.tracker-panel__controls .segmented__track {
-  padding: var(--space-xs);
-}
-
-.tracker-panel__controls .segmented__btn {
-  padding: var(--space-xs) var(--space-sm);
-  font-size: var(--text-sm);
-}
-
-/* Compact Slider in tracker header */
-.tracker-panel__controls .slider {
-  max-width: 60px;
-  gap: 0;
-}
-
-.tracker-panel__controls .slider__input {
-  height: 4px;
-}
-
-.tracker-panel__icon-btn {
-  background: none;
-  border: 1px solid transparent;
-  color: var(--c-text-dim);
-  font-size: var(--text-base);
-  width: 22px;
-  height: 22px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--r-sm);
-  cursor: pointer;
-  padding: 0;
-}
-
-.tracker-panel__icon-btn:hover {
-  background: var(--c-hover);
-  color: var(--c-text);
-}
-
-/* ─── The tracker itself: summary, filters, then the tree in a scroller ─── */
+/* ─── Shell: a header band over a list ───
+   Sticky pins the header and hands the list the height that is left, so only
+   the list moves. Unpinned, the tracker is one column at its natural height and
+   whatever holds it (a widget body, a page pane) does the scrolling. */
 
 .checks-tracker {
   display: flex;
@@ -148,17 +16,35 @@
   min-height: 0;
 }
 
-/* ─── Checks scrollable area ─── */
+.checks-tracker[data-sticky='yes'] {
+  height: 100%;
+}
 
-.tracker-view__checks {
-  flex: 1;
-  overflow-y: auto;
+/* Header and list are siblings, not layers: the pinned header holds its place by
+   giving the list the remaining height, so it needs no ground of its own to sit
+   on and a widget floating over the game stays translucent through it. */
+.checks-tracker__header {
+  display: flex;
+  flex-direction: column;
+}
+
+.checks-tracker[data-sticky='yes'] .checks-tracker__header {
+  flex-shrink: 0;
+}
+
+.checks-tracker__list {
   padding: var(--space-xs) 0;
 }
 
-/* ─── Filtered stats line ─── */
+.checks-tracker[data-sticky='yes'] .checks-tracker__list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
 
-.tracker-view__filtered-stats {
+/* ─── Subtotal line, shown only while something narrows the set ─── */
+
+.checks-tracker__subtotal {
   padding: var(--space-xs) var(--space-md);
   font-size: var(--text-xs);
   color: var(--c-text-dim);
@@ -166,141 +52,13 @@
   flex-shrink: 0;
 }
 
-/* ═══════════════════════════════════════════════════════════════
-   VISUAL INVENTORY
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Status marks, one shape per state everywhere in the tracker ─── */
 
-.tracker-inventory {
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--c-border);
+.tracker-status-icon {
   flex-shrink: 0;
-  max-height: 220px;
-  overflow-y: auto;
 }
 
-.tracker-inventory__category {
-  margin-bottom: var(--space-sm);
-}
-
-.tracker-inventory__category-label {
-  display: block;
-  font-size: var(--text-xs);
-  font-weight: var(--weight-semi);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--c-text-dim);
-  margin-bottom: var(--space-xs);
-}
-
-.tracker-inventory__grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-xs);
-}
-
-.tracker-inventory__slot {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 40px;
-  padding: var(--space-xs) var(--space-xs);
-  border-radius: var(--r-sm);
-  transition: opacity 0.2s;
-}
-
-.tracker-inventory__slot--obtained {
-  opacity: 1;
-}
-
-.tracker-inventory__slot--missing {
-  opacity: 0.25;
-  filter: grayscale(1);
-}
-
-.tracker-inventory__sprite {
-  width: 24px;
-  height: 24px;
-  image-rendering: pixelated;
-}
-
-.tracker-inventory__name {
-  font-size: var(--text-xs);
-  text-align: center;
-  color: var(--c-text-dim);
-  line-height: 1.1;
-  margin-top: var(--space-xs);
-  max-width: 40px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* ─── In-game layout ─── */
-
-.tracker-inventory--ingame {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: auto auto;
-  gap: var(--space-sm);
-  max-height: none;
-}
-
-.tracker-inventory__ingame-main {
-  grid-column: 1;
-  grid-row: 1;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
-.tracker-inventory__ingame-row {
-  display: flex;
-  gap: var(--space-xs);
-}
-
-.tracker-inventory__ingame-side {
-  grid-column: 2;
-  grid-row: 1;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-  padding-left: var(--space-sm);
-  border-left: 1px solid var(--c-border);
-}
-
-.tracker-inventory__ingame-bottom {
-  grid-column: 1 / -1;
-  grid-row: 2;
-  display: flex;
-  gap: var(--space-xs);
-  padding-top: var(--space-xs);
-  border-top: 1px solid var(--c-border);
-}
-
-/* ─── Compact layout ─── */
-
-.tracker-inventory--compact {
-  max-height: none;
-}
-
-.tracker-inventory__grid--compact {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, 36px);
-  gap: var(--space-xs);
-}
-
-.tracker-inventory--compact .tracker-inventory__slot {
-  width: 36px;
-  padding: var(--space-xs) var(--space-xs);
-}
-
-.tracker-inventory--compact .tracker-inventory__sprite {
-  width: 20px;
-  height: 20px;
-}
-
-.tracker-inventory--compact .tracker-inventory__name {
-  font-size: var(--text-xs);
-  max-width: 36px;
-}
-
+.tracker-status-icon--completed { color: var(--c-green); }
+.tracker-status-icon--reachable { color: var(--c-warning); }
+.tracker-status-icon--blocked   { color: var(--c-text-muted); }
+.tracker-status-icon--total     { color: var(--c-text-dim); }

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.tsx
@@ -5,6 +5,10 @@
  * component serves the small Checks widget and the full-size spoiler tab, and
  * both show a check the same way.
  *
+ * The summary and filters are one header band, and the tree is the scroller
+ * under it: with `stickyHeader` the header holds its place while the list moves,
+ * without it the whole tracker scrolls as one piece.
+ *
  * With a `run` supplied, checks display what THIS seed put in them instead of
  * their vanilla contents; without one, nothing changes for a vanilla profile.
  */
@@ -25,31 +29,33 @@ const isNarrowed = (filter: ChecksTrackerProps['filter']): boolean =>
 const ChecksTracker = (props: ChecksTrackerProps) => {
   const {
     stats, filter, onFilterChange, grouping, onGroupingChange, viewMode, onViewModeChange,
-    groupTree, statuses, run, dimensions, notice, className,
+    groupTree, statuses, run, dimensions, notice, stickyHeader = true, className,
   } = props;
 
   return (
-    <Box className={`checks-tracker${className ? ` ${className}` : ''}`}>
-      <TrackerSummary {...stats} />
-      <TrackerFilters
-        filter={filter}
-        onFilterChange={onFilterChange}
-        grouping={grouping}
-        onGroupingChange={onGroupingChange}
-        viewMode={viewMode}
-        onViewModeChange={onViewModeChange}
-        dimensions={dimensions}
-      />
-      {isNarrowed(filter) && (
-        <Box className="tracker-view__filtered-stats">
-          Showing {groupTree.stats.total} checks:
-          <Text className="tracker-summary__stat--completed"> {groupTree.stats.completed} taken</Text>,
-          <Text className="tracker-summary__stat--reachable"> {groupTree.stats.reachable} available</Text>,
-          <Text className="tracker-summary__stat--blocked"> {groupTree.stats.blocked} left</Text>
-        </Box>
-      )}
-      {notice}
-      <Box className="tracker-view__checks">
+    <Box className={`checks-tracker${className ? ` ${className}` : ''}`} data-sticky={stickyHeader ? 'yes' : 'no'}>
+      <Box className="checks-tracker__header">
+        <TrackerSummary {...stats} />
+        <TrackerFilters
+          filter={filter}
+          onFilterChange={onFilterChange}
+          grouping={grouping}
+          onGroupingChange={onGroupingChange}
+          viewMode={viewMode}
+          onViewModeChange={onViewModeChange}
+          dimensions={dimensions}
+        />
+        {isNarrowed(filter) && (
+          <Box className="checks-tracker__subtotal">
+            Showing {groupTree.stats.total} checks:
+            <Text className="tracker-summary__stat--completed"> {groupTree.stats.completed} taken</Text>,
+            <Text className="tracker-summary__stat--reachable"> {groupTree.stats.reachable} available</Text>,
+            <Text className="tracker-summary__stat--blocked"> {groupTree.stats.blocked} left</Text>
+          </Box>
+        )}
+        {notice}
+      </Box>
+      <Box className="checks-tracker__list">
         <TrackerGroupTree node={groupTree} statuses={statuses} viewMode={viewMode} run={run} />
       </Box>
     </Box>

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.type.ts
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.type.ts
@@ -4,7 +4,9 @@ import type { CheckStatus } from '@shared/game/logic/eval';
 import type {
   FilterState, GroupDimension, GroupDimensionDef, GroupNode, RunContext,
 } from '@shared/game/logic/queries/check-grouping';
-import type { ViewMode } from './sub-components/TrackerFilters';
+
+/** How a check leaf is drawn: a bare row, a row with its item, or an item card. */
+type ViewMode = 'compact' | 'detailed' | 'visual';
 
 interface TrackerStats {
   completed: number;
@@ -30,7 +32,13 @@ interface ChecksTrackerProps {
   dimensions?: readonly GroupDimensionDef[];
   /** Rendered between the filters and the tree: a caveat, a count, a warning. */
   notice?: ReactNode;
+  /**
+   * Pins the summary and filters, leaving the check list as the only thing that
+   * scrolls. Off, the whole tracker scrolls as one and the header goes with it,
+   * which is what a short widget wants when the list is the point.
+   */
+  stickyHeader?: boolean;
   className?: string;
 }
 
-export type { ChecksTrackerProps, TrackerStats };
+export type { ChecksTrackerProps, TrackerStats, ViewMode };

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/index.ts
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/index.ts
@@ -1,4 +1,3 @@
 /* @layer renderer-components @kind barrel */
 export { ChecksTracker } from './ChecksTracker';
-export type { ChecksTrackerProps, TrackerStats } from './ChecksTracker.type';
-export type { ViewMode } from './sub-components/TrackerFilters';
+export type { ChecksTrackerProps, TrackerStats, ViewMode } from './ChecksTracker.type';

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/CheckList.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/CheckList.tsx
@@ -14,7 +14,7 @@ import type { CheckStatus } from '@shared/game/logic/eval';
 import type { RunContext } from '@shared/game/logic/queries/check-grouping';
 import { getItemSprite } from '@shared/game/logic/queries/item-sprites';
 import { TrackerCheckRow } from './TrackerCheckRow';
-import type { ViewMode } from './TrackerFilters';
+import type { ViewMode } from '../ChecksTracker.type';
 import '../ChecksTracker.css';
 
 interface CheckListProps {

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/CheckStatusIcon.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/CheckStatusIcon.tsx
@@ -1,0 +1,47 @@
+/* @layer renderer-components @kind component */
+/**
+ * The one mark for a check's state, so the summary, the filter buttons and the
+ * rows can never disagree about what "taken" looks like.
+ */
+import { Icon } from '@ds/primitives';
+import type { IconProps } from '@ds/primitives';
+import type { CheckStatus } from '@shared/game/logic/eval';
+import { CHECK_PATHS, DOT_CIRCLES, RING_PATHS, STACK_PATHS } from '../ChecksTracker.constants';
+
+/** The three check states plus the whole-set total the summary also marks. */
+type StatusKey = CheckStatus | 'total';
+
+interface CheckStatusIconProps {
+  status: StatusKey;
+  size?: number;
+}
+
+const STATUS_LABELS: Record<StatusKey, string> = {
+  completed: 'Already collected',
+  reachable: 'Reachable right now',
+  blocked: 'Still out of reach',
+  total: 'Every check',
+};
+
+const STATUS_SHAPES: Record<StatusKey, Pick<IconProps, 'paths' | 'circles'>> = {
+  completed: { paths: CHECK_PATHS },
+  reachable: { circles: DOT_CIRCLES },
+  blocked: { paths: RING_PATHS },
+  total: { paths: STACK_PATHS },
+};
+
+const CheckStatusIcon = (props: CheckStatusIconProps) => {
+  const { status, size = 12 } = props;
+  return (
+    <Icon
+      {...STATUS_SHAPES[status]}
+      className={`tracker-status-icon tracker-status-icon--${status}`}
+      size={size}
+      role="img"
+      aria-label={STATUS_LABELS[status]}
+    />
+  );
+};
+
+export { CheckStatusIcon, STATUS_LABELS };
+export type { CheckStatusIconProps, StatusKey };

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/ChecksTracker.checks.css
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/ChecksTracker.checks.css
@@ -39,14 +39,12 @@
   font-size: var(--text-xs);
 }
 
-.tracker-check__icon {
-  width: 14px;
-  text-align: center;
-  flex-shrink: 0;
-}
-
 .tracker-check__name {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tracker-check__item {
@@ -77,10 +75,12 @@
    VISUAL CHECK CARDS
    ═══════════════════════════════════════════════════════════════ */
 
+/* Columns come from the space there is, not a fixed count: the same grid has to
+   read in a 300px widget and across a full-width spoiler pane. */
 .tracker-checks--visual {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-sm);
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-xs);
   padding: var(--space-sm) var(--space-md);
 }
 
@@ -89,10 +89,10 @@
   align-items: center;
   gap: var(--space-sm);
   padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--r-sm);
+  border-radius: var(--radius-sm);
   border-left: 3px solid transparent;
   background: var(--c-hover);
-  transition: border-color 0.2s, opacity 0.2s;
+  transition: border-color var(--transition-normal), opacity var(--transition-normal);
   min-width: 0;
 }
 
@@ -123,14 +123,14 @@
   height: 24px;
   flex-shrink: 0;
   background: var(--c-hover);
-  border-radius: var(--r-sm);
+  border-radius: var(--radius-sm);
 }
 
 .tracker-card__text {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  gap: var(--space-xs);
+  gap: var(--space-2xs);
 }
 
 .tracker-card__item-name {
@@ -152,43 +152,3 @@
   white-space: nowrap;
   min-width: 0;
 }
-
-/* ═══════════════════════════════════════════════════════════════
-   LEGACY (kept for TrackerRegionSection if still referenced)
-   ═══════════════════════════════════════════════════════════════ */
-
-.tracker-area__header {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  padding: var(--space-xs) var(--space-md);
-  background: none;
-  border: none;
-  color: var(--c-text);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: var(--text-sm);
-  text-align: left;
-}
-
-.tracker-area__header:hover { background: var(--c-hover); }
-
-.tracker-area__chevron {
-  width: 16px;
-  flex-shrink: 0;
-  font-size: var(--text-xs);
-  color: var(--c-text-dim);
-}
-
-.tracker-area__name {
-  flex: 1;
-  font-weight: var(--weight-semi);
-}
-
-.tracker-area__counts {
-  font-size: var(--text-xs);
-  color: var(--c-text-dim);
-}
-.tracker-area__count--completed { color: var(--c-green); }
-.tracker-area__count--reachable { color: var(--c-warning); }
-.tracker-area__checks { padding-left: var(--space-md); }

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/ChecksTracker.filters.css
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/ChecksTracker.filters.css
@@ -6,55 +6,53 @@
 
 .tracker-summary {
   container-type: inline-size;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
   padding: var(--space-sm) var(--space-md);
   border-bottom: 1px solid var(--c-border);
   flex-shrink: 0;
 }
 
-.tracker-summary__bar {
+.tracker-summary__meter {
   display: flex;
-  height: 6px;
-  border-radius: var(--r-sm);
-  background: var(--c-hover);
-  overflow: hidden;
-  margin-bottom: var(--space-xs);
+  align-items: center;
+  gap: var(--space-sm);
 }
 
-.tracker-summary__fill {
-  height: 100%;
-  transition: width 0.3s ease;
+.tracker-summary__pct {
+  font-size: var(--text-xs);
+  color: var(--c-text-dim);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
 }
-
-.tracker-summary__fill--completed { background: var(--c-green); }
-.tracker-summary__fill--reachable { background: var(--c-warning); }
 
 .tracker-summary__stats {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-sm);
+  gap: var(--space-xs) var(--space-md);
   font-size: var(--text-xs);
 }
 
 .tracker-summary__stat {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
   white-space: nowrap;
-}
-
-.tracker-summary__stat--completed { color: var(--c-green); }
-.tracker-summary__stat--reachable { color: var(--c-warning); }
-.tracker-summary__stat--blocked { color: var(--c-text-dim); }
-.tracker-summary__stat--total { color: var(--c-text); }
-
-.tracker-summary__stat--pct {
   color: var(--c-text-dim);
-  margin-left: auto;
 }
 
-/* Labels by default; swap to compact icons when the widget gets narrow. */
-.tracker-summary__stat-icon { display: none; }
+.tracker-summary__stat-value {
+  color: var(--c-text);
+  font-variant-numeric: tabular-nums;
+}
 
-@container (max-width: 340px) {
+.tracker-summary__stat--completed .tracker-summary__stat-value { color: var(--c-green); }
+.tracker-summary__stat--reachable .tracker-summary__stat-value { color: var(--c-warning); }
+
+/* The word is the first thing to go when the widget cannot fit the row. */
+@container (max-width: 320px) {
   .tracker-summary__stat-label { display: none; }
-  .tracker-summary__stat-icon { display: inline; }
 }
 
 /* ═══════════════════════════════════════════════════════════════
@@ -62,61 +60,52 @@
    ═══════════════════════════════════════════════════════════════ */
 
 .tracker-filters {
-  padding: var(--space-xs) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
   border-bottom: 1px solid var(--c-border);
   flex-shrink: 0;
 }
 
 .tracker-filters__search {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-sm);
-  margin-bottom: var(--space-sm);
 }
 
+.tracker-filters__search-icon {
+  position: absolute;
+  left: var(--space-sm);
+  color: var(--c-text-muted);
+  pointer-events: none;
+}
+
+/* Room for the leading icon, and a row height that matches the 26px buttons. */
 .tracker-filters__input {
   flex: 1;
   min-width: 0;
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--c-sunken);
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  color: var(--c-text);
-  font-family: inherit;
-  font-size: var(--text-xs);
-  outline: none;
+  padding: var(--space-xs) var(--space-sm) var(--space-xs) var(--space-xl);
+  font-size: var(--text-sm);
 }
 
 .tracker-filters__toggle {
+  position: relative;
+  display: inline-flex;
   flex-shrink: 0;
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--c-sunken);
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  color: var(--c-text-dim);
+}
+
+/* A corner count, so the funnel keeps its square footprint. */
+.tracker-filters__count {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  pointer-events: none;
   font-size: var(--text-xs);
-  font-family: inherit;
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.tracker-filters__toggle:hover {
-  background: var(--c-hover);
-  color: var(--c-text);
-}
-
-.tracker-filters__toggle--active {
-  background: var(--c-selected);
-  border-color: var(--c-gold);
-  color: var(--c-gold-bright);
-}
-
-.tracker-filters__input::placeholder {
-  color: var(--c-text-muted);
-}
-
-.tracker-filters__input:focus {
-  border-color: var(--c-gold);
+  padding: 0 var(--space-2xs);
+  min-width: 13px;
+  text-align: center;
 }
 
 /* Toolbar wraps, and never produces a horizontal scrollbar in a narrow widget. */
@@ -127,163 +116,28 @@
   gap: var(--space-sm);
 }
 
-/* ─── Connected segmented groups (view modes + status) ─── */
-.tracker-filters__view-modes,
-.tracker-filters__status-group {
-  display: inline-flex;
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  background: var(--c-sunken);
-  overflow: hidden;
-}
-
-.tracker-filters__mode-btn,
-.tracker-filters__status-btn {
-  padding: var(--space-xs) var(--space-sm);
-  background: transparent;
-  border: none;
-  border-right: 1px solid var(--c-border);
-  color: var(--c-text-dim);
-  font-size: var(--text-sm);
-  font-family: inherit;
-  cursor: pointer;
-  min-width: 28px;
-  text-align: center;
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.tracker-filters__mode-btn:last-child,
-.tracker-filters__status-btn:last-child {
-  border-right: none;
-}
-
-.tracker-filters__mode-btn:hover,
-.tracker-filters__status-btn:hover {
-  background: var(--c-hover);
-  color: var(--c-text);
-}
-
-.tracker-filters__mode-btn--active,
-.tracker-filters__status-btn--active {
-  background: var(--c-selected);
-  color: var(--c-gold-bright);
-}
-
-/* Status actives keep their semantic colour (override the gold default) */
-.tracker-filters__status-btn--reachable.tracker-filters__status-btn--active {
-  background: var(--c-warning-soft);
-  color: var(--c-warning);
-}
-
-.tracker-filters__status-btn--completed.tracker-filters__status-btn--active {
-  background: var(--c-green-soft);
-  color: var(--c-green-bright);
-}
-
-.tracker-filters__status-btn--blocked.tracker-filters__status-btn--active {
-  background: var(--c-border-strong);
-  color: var(--c-text);
-}
-
-/* ─── Standalone toggle buttons (Tags, Group) ─── */
-.tracker-filters__btn {
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--c-sunken);
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  color: var(--c-text-dim);
-  font-size: var(--text-xs);
-  font-family: inherit;
-  cursor: pointer;
-}
-
-.tracker-filters__btn:hover {
-  background: var(--c-hover);
-  color: var(--c-text);
-}
-
-.tracker-filters__btn--active {
-  background: var(--c-selected);
-  border-color: var(--c-gold);
-  color: var(--c-gold-bright);
-}
-
-/* ─── Tag filter panel ─── */
-.tracker-filters__tags-panel {
-  margin-top: var(--space-sm);
-  padding: var(--space-sm);
-  background: var(--c-inset);
-  border: 1px solid var(--c-hairline);
-  border-radius: var(--r-sm);
-}
-
-.tracker-filters__tag-mode {
+/* An icon segment is square; the text ones keep the control's own padding. */
+.tracker-filters__controls .segmented__btn {
   display: flex;
-  gap: var(--space-xs);
-  margin-bottom: var(--space-sm);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xs) var(--space-sm);
+  min-height: 20px;
 }
 
-.tracker-filters__tag-mode button {
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--c-sunken);
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  color: var(--c-text-dim);
-  font-size: var(--text-xs);
-  font-family: inherit;
-  cursor: pointer;
-}
+/* ─── Drawer panels (tags, grouping) ─── */
 
-.tracker-filters__tag-group {
-  margin-bottom: var(--space-xs);
-}
-
-.tracker-filters__tag-group-label {
-  font-size: var(--text-xs);
-  font-weight: var(--weight-semi);
-  text-transform: uppercase;
-  color: var(--c-text-dim);
-  display: block;
-  margin-bottom: var(--space-xs);
-}
-
-.tracker-filters__tag-list {
+.tracker-filters__panel {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-xs);
-}
-
-.tracker-filters__tag {
-  padding: var(--space-xs) var(--space-sm);
-  font-size: var(--text-xs);
-  background: var(--c-sunken);
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-pill);
-  color: var(--c-text-dim);
-  font-family: inherit;
-  cursor: pointer;
-}
-
-.tracker-filters__tag--active {
-  background: var(--c-selected);
-  border-color: var(--c-gold);
-  color: var(--c-gold-bright);
-}
-
-/* ─── Grouping config panel ─── */
-.tracker-filters__group-panel {
-  margin-top: var(--space-sm);
+  flex-direction: column;
+  gap: var(--space-sm);
   padding: var(--space-sm);
-  background: var(--c-inset);
-  border: 1px solid var(--c-hairline);
-  border-radius: var(--r-sm);
 }
 
 .tracker-filters__group-current {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-xs);
-  margin-bottom: var(--space-sm);
 }
 
 .tracker-filters__group-empty {
@@ -295,44 +149,23 @@
 .tracker-filters__group-chip {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-xs) var(--space-sm);
-  background: var(--c-selected);
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-2xs) var(--space-2xs) var(--space-sm);
+  background: var(--c-gold-soft);
   border: 1px solid var(--c-gold);
-  border-radius: var(--r-pill);
+  border-radius: var(--radius-sm);
   font-size: var(--text-xs);
   color: var(--c-gold-bright);
 }
 
 .tracker-filters__group-remove {
-  background: none;
-  border: none;
+  width: 16px;
+  height: 16px;
   color: var(--c-gold-bright);
-  font-size: var(--text-sm);
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
 }
 
 .tracker-filters__group-add {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-xs);
-}
-
-.tracker-filters__group-add-btn {
-  padding: var(--space-xs) var(--space-sm);
-  font-size: var(--text-xs);
-  background: var(--c-sunken);
-  border: 1px dashed var(--c-border-strong);
-  border-radius: var(--r-pill);
-  color: var(--c-text-dim);
-  font-family: inherit;
-  cursor: pointer;
-}
-
-.tracker-filters__group-add-btn:hover {
-  background: var(--c-hover);
-  border-color: var(--c-gold);
-  color: var(--c-text);
 }

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerCheckRow.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerCheckRow.tsx
@@ -4,6 +4,7 @@ import type { CheckRecord, ItemId } from '@shared/game/data';
 import { getItem } from '@shared/game/data';
 import type { CheckStatus } from '@shared/game/logic/eval';
 import type { RunContext } from '@shared/game/logic/queries/check-grouping';
+import { CheckStatusIcon } from './CheckStatusIcon';
 import '../ChecksTracker.css';
 
 interface TrackerCheckRowProps {
@@ -16,19 +17,13 @@ interface TrackerCheckRowProps {
   run?: RunContext;
 }
 
-const STATUS_ICONS: Record<CheckStatus, string> = {
-  completed: '✓',
-  reachable: '●',
-  blocked: '○',
-};
-
 const TrackerCheckRow = (props: TrackerCheckRowProps) => {
   const { check, status, detailed, itemOverride, run } = props;
   const itemId = itemOverride ?? run?.placedItems?.get(check.id) ?? check.vanillaItemIds[0];
   const displayItem = itemId ? getItem(itemId).randomizerName : undefined;
   return (
     <Box className={`tracker-check tracker-check--${status}`}>
-      <Text className="tracker-check__icon">{STATUS_ICONS[status]}</Text>
+      <CheckStatusIcon status={status} size={11} />
       <Text className="tracker-check__name">{check.randomizerName}</Text>
       {detailed && (
         <Text className="tracker-check__item">{displayItem ?? '-'}</Text>
@@ -36,6 +31,6 @@ const TrackerCheckRow = (props: TrackerCheckRowProps) => {
       <Text className="tracker-check__type">{check.kind}</Text>
     </Box>
   );
-}
+};
 
 export { TrackerCheckRow };

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerFilterPanels.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerFilterPanels.tsx
@@ -1,8 +1,15 @@
 /* @layer renderer-components @kind component */
-import { useCallback } from 'react';
+/**
+ * The two drawers behind the filter bar: facet tags, and the grouping stack.
+ * Both are design-system controls, so a tag chip here is the same chip as a tag
+ * chip anywhere else in the app.
+ */
+import { useCallback, useMemo } from 'react';
 import type { GroupDimension, GroupDimensionDef, FilterState } from '@shared/game/logic/queries/check-grouping';
 import { CHECK_FACET_DEFS, GROUP_DIMENSIONS } from '@shared/game/logic/queries/check-grouping';
-import { Box, Text, Button } from '@ds/primitives';
+import { Box, Button, Card, Icon, IconButton, SegmentedControl, Text, TagPicker } from '@ds/primitives';
+import type { SegmentOption, TagPickerGroup } from '@ds/primitives';
+import { CLOSE_PATHS } from '../ChecksTracker.constants';
 
 interface TrackerFilterPanelsProps {
   filter: FilterState;
@@ -17,76 +24,82 @@ interface TrackerFilterPanelsProps {
 
 const TAG_CATEGORIES = ['world', 'location', 'area', 'content'] as const;
 
+const TAG_GROUPS: TagPickerGroup[] = TAG_CATEGORIES.map((category) => ({
+  id: category,
+  label: category,
+  options: CHECK_FACET_DEFS.filter(t => t.category === category).map(t => ({ value: t.id, label: t.label })),
+}));
+
+const TAG_MODE_OPTIONS: SegmentOption<'any' | 'all'>[] = [
+  { value: 'any', label: 'Any', title: 'Match any active tag' },
+  { value: 'all', label: 'All', title: 'Match every active tag' },
+];
+
+/** Five axes is the tree's depth limit, past which a group holds one check. */
+const MAX_DIMENSIONS = 5;
+
 const TrackerFilterPanels = (props: TrackerFilterPanelsProps) => {
   const {
     filter, onFilterChange, grouping, onGroupingChange, showTagFilter, showGroupConfig,
     dimensions = GROUP_DIMENSIONS,
   } = props;
 
-  const toggleFacet = useCallback((facetId: string) => {
-    const active = filter.activeFacets.includes(facetId)
-      ? filter.activeFacets.filter(f => f !== facetId)
-      : [...filter.activeFacets, facetId];
-    onFilterChange({ ...filter, activeFacets: active });
+  const setFacets = useCallback((activeFacets: string[]) => {
+    onFilterChange({ ...filter, activeFacets });
   }, [filter, onFilterChange]);
 
   const addDimension = useCallback((dim: GroupDimension) => {
-    if (grouping.length < 5 && !grouping.includes(dim)) onGroupingChange([...grouping, dim]);
+    if (grouping.length < MAX_DIMENSIONS && !grouping.includes(dim)) onGroupingChange([...grouping, dim]);
   }, [grouping, onGroupingChange]);
 
   const removeDimension = useCallback((idx: number) => {
     onGroupingChange(grouping.filter((_, i) => i !== idx));
   }, [grouping, onGroupingChange]);
 
+  const unused = useMemo(() => dimensions.filter(d => !grouping.includes(d.id)), [dimensions, grouping]);
+
   return (
     <>
       {showTagFilter && (
-        <Box className="tracker-filters__tags-panel">
-          <Box className="tracker-filters__tag-mode">
-            <Button variant="bare" className={filter.tagMode === 'any' ? 'tracker-filters__mode-btn--active' : ''} onClick={() => onFilterChange({ ...filter, tagMode: 'any' })}>Any</Button>
-            <Button variant="bare" className={filter.tagMode === 'all' ? 'tracker-filters__mode-btn--active' : ''} onClick={() => onFilterChange({ ...filter, tagMode: 'all' })}>All</Button>
-          </Box>
-          {TAG_CATEGORIES.map(cat => (
-            <Box key={cat} className="tracker-filters__tag-group">
-              <Text className="tracker-filters__tag-group-label">{cat}</Text>
-              <Box className="tracker-filters__tag-list">
-                {CHECK_FACET_DEFS.filter(t => t.category === cat).map(t => (
-                  <Button
-                    variant="bare"
-                    key={t.id}
-                    className={`tracker-filters__tag ${filter.activeFacets.includes(t.id) ? 'tracker-filters__tag--active' : ''}`}
-                    onClick={() => toggleFacet(t.id)}
-                  >
-                    {t.label}
-                  </Button>
-                ))}
-              </Box>
-            </Box>
-          ))}
-        </Box>
+        <Card className="tracker-filters__panel">
+          <SegmentedControl
+            value={filter.tagMode}
+            options={TAG_MODE_OPTIONS}
+            onChange={(tagMode) => onFilterChange({ ...filter, tagMode })}
+          />
+          <TagPicker value={filter.activeFacets} groups={TAG_GROUPS} onChange={setFacets} />
+        </Card>
       )}
 
       {showGroupConfig && (
-        <Box className="tracker-filters__group-panel">
+        <Card className="tracker-filters__panel">
           <Box className="tracker-filters__group-current">
             {grouping.length === 0 && <Text className="tracker-filters__group-empty">No grouping (flat list)</Text>}
             {grouping.map((dim, i) => (
-              <Text key={dim} className="tracker-filters__group-chip">
-                {i + 1}. {dimensions.find(d => d.id === dim)?.label}
-                <Button variant="bare" className="tracker-filters__group-remove" onClick={() => removeDimension(i)}>×</Button>
-              </Text>
+              <Box key={dim} className="tracker-filters__group-chip">
+                <Text>{i + 1}. {dimensions.find(d => d.id === dim)?.label}</Text>
+                <IconButton
+                  variant="ghost"
+                  size="sm"
+                  label={`Remove ${dim} grouping`}
+                  className="tracker-filters__group-remove"
+                  onClick={() => removeDimension(i)}
+                >
+                  <Icon paths={CLOSE_PATHS} size={9} />
+                </IconButton>
+              </Box>
             ))}
           </Box>
-          {grouping.length < 5 && (
+          {grouping.length < MAX_DIMENSIONS && (
             <Box className="tracker-filters__group-add">
-              {dimensions.filter(d => !grouping.includes(d.id)).map(d => (
-                <Button variant="bare" key={d.id} className="tracker-filters__group-add-btn" onClick={() => addDimension(d.id)} title={d.description}>
+              {unused.map(d => (
+                <Button key={d.id} variant="ghost" size="sm" title={d.description} onClick={() => addDimension(d.id)}>
                   + {d.label}
                 </Button>
               ))}
             </Box>
           )}
-        </Box>
+        </Card>
       )}
     </>
   );

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerFilters.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerFilters.tsx
@@ -1,13 +1,22 @@
 /* @layer renderer-components @kind component */
+/**
+ * The tracker's filter bar: a search box that is always there, and a drawer of
+ * the rest. Every control is a design-system one, so the tracker picks up the
+ * app's segmented-control and button treatment instead of restating it.
+ */
 import { useState } from 'react';
 import type {
-  FilterState, GroupDimension, GroupDimensionDef, StatusFilter,
+  FilterState, GroupDimension, GroupDimensionDef, ItemFilter, StatusFilter,
 } from '@shared/game/logic/queries/check-grouping';
-import { Box, TextInput, Button } from '@ds/primitives';
+import { Badge, Box, Button, Icon, IconButton, SegmentedControl, TextInput } from '@ds/primitives';
+import type { SegmentOption } from '@ds/primitives';
+import {
+  FUNNEL_PATHS, GRID_PATHS, LIST_DETAIL_PATHS, LIST_PATHS, NESTED_PATHS, SEARCH_PATHS, TAG_PATHS,
+} from '../ChecksTracker.constants';
+import type { ViewMode } from '../ChecksTracker.type';
+import { CheckStatusIcon } from './CheckStatusIcon';
 import { TrackerFilterPanels } from './TrackerFilterPanels';
 import '../ChecksTracker.css';
-
-type ViewMode = 'compact' | 'detailed' | 'visual';
 
 interface TrackerFiltersProps {
   filter: FilterState;
@@ -20,24 +29,24 @@ interface TrackerFiltersProps {
   dimensions?: readonly GroupDimensionDef[];
 }
 
-const VIEW_MODES: { mode: ViewMode; icon: string; title: string }[] = [
-  { mode: 'compact', icon: '≡', title: 'Compact' },
-  { mode: 'detailed', icon: '☰', title: 'Detailed' },
-  { mode: 'visual', icon: '⊞', title: 'Visual' },
+const VIEW_MODE_OPTIONS: SegmentOption<ViewMode>[] = [
+  { value: 'compact', label: <Icon paths={LIST_PATHS} size={13} />, title: 'Compact rows' },
+  { value: 'detailed', label: <Icon paths={LIST_DETAIL_PATHS} size={13} />, title: 'Rows with items' },
+  { value: 'visual', label: <Icon paths={GRID_PATHS} size={13} />, title: 'Item cards' },
 ];
 
-const ITEM_FILTERS = [
+const ITEM_FILTER_OPTIONS: SegmentOption<ItemFilter>[] = [
   { value: 'all', label: 'All' },
   { value: 'rewards', label: 'Rewards' },
   { value: 'non-rewards', label: 'Non-rewards' },
-] as const;
+];
 
-const STATUS_FILTERS = [
-  { value: 'all', label: 'All', cls: '' },
-  { value: 'reachable', label: '●', cls: 'tracker-filters__status-btn--reachable' },
-  { value: 'completed', label: '✓', cls: 'tracker-filters__status-btn--completed' },
-  { value: 'blocked', label: '✕', cls: 'tracker-filters__status-btn--blocked' },
-] as const;
+const STATUS_OPTIONS: SegmentOption<StatusFilter>[] = [
+  { value: 'all', label: 'All', title: 'Every status' },
+  { value: 'completed', label: <CheckStatusIcon status="completed" />, title: 'Taken' },
+  { value: 'reachable', label: <CheckStatusIcon status="reachable" />, title: 'Available' },
+  { value: 'blocked', label: <CheckStatusIcon status="blocked" />, title: 'Left' },
+];
 
 const TrackerFilters = (props: TrackerFiltersProps) => {
   const { filter, onFilterChange, grouping, onGroupingChange, viewMode, onViewModeChange, dimensions } = props;
@@ -53,77 +62,59 @@ const TrackerFilters = (props: TrackerFiltersProps) => {
   return (
     <Box className="tracker-filters">
       <Box className="tracker-filters__search">
+        <Icon className="tracker-filters__search-icon" paths={SEARCH_PATHS} size={12} />
         <TextInput
           type="text"
           className="tracker-filters__input"
           placeholder="Search checks..."
           value={filter.searchQuery}
           onChange={(e) => onFilterChange({ ...filter, searchQuery: e.target.value })}
+          aria-label="Search checks"
         />
-        <Button
-          variant="bare"
-          className={`tracker-filters__toggle ${showFilters ? 'tracker-filters__toggle--active' : ''}`}
-          onClick={() => setShowFilters(v => !v)}
-          title="Filters & view options"
-        >
-          ⚑{activeCount > 0 ? ` ${activeCount}` : ''}
-        </Button>
+        <Box className="tracker-filters__toggle">
+          <IconButton
+            variant="ghost"
+            size="sm"
+            active={showFilters}
+            label="Filters and view options"
+            title="Filters and view options"
+            onClick={() => setShowFilters(v => !v)}
+          >
+            <Icon paths={FUNNEL_PATHS} size={13} />
+          </IconButton>
+          {activeCount > 0 && (
+            <Badge className="tracker-filters__count" variant="warning">{activeCount}</Badge>
+          )}
+        </Box>
       </Box>
 
       {showFilters && (
         <Box className="tracker-filters__controls">
-          <Box className="tracker-filters__view-modes">
-            {VIEW_MODES.map(({ mode, icon, title }) => (
-              <Button
-                variant="bare"
-                key={mode}
-                title={title}
-                className={`tracker-filters__mode-btn ${viewMode === mode ? 'tracker-filters__mode-btn--active' : ''}`}
-                onClick={() => onViewModeChange(mode)}
-              >
-                {icon}
-              </Button>
-            ))}
-          </Box>
-
-          <Box className="tracker-filters__view-modes">
-            {ITEM_FILTERS.map(opt => (
-              <Button
-                variant="bare"
-                key={opt.value}
-                className={`tracker-filters__mode-btn ${itemFilter === opt.value ? 'tracker-filters__mode-btn--active' : ''}`}
-                onClick={() => onFilterChange({ ...filter, itemFilter: opt.value })}
-              >
-                {opt.label}
-              </Button>
-            ))}
-          </Box>
-
-          <Box className="tracker-filters__status-group">
-            {STATUS_FILTERS.map(opt => (
-              <Button
-                variant="bare"
-                key={opt.value}
-                className={`tracker-filters__status-btn ${opt.cls} ${statusFilter === opt.value ? 'tracker-filters__status-btn--active' : ''}`}
-                onClick={() => onFilterChange({ ...filter, statusFilter: opt.value as StatusFilter })}
-                title={opt.value.charAt(0).toUpperCase() + opt.value.slice(1)}
-              >
-                {opt.label}
-              </Button>
-            ))}
-          </Box>
-
+          <SegmentedControl value={viewMode} options={VIEW_MODE_OPTIONS} onChange={onViewModeChange} />
+          <SegmentedControl
+            value={statusFilter}
+            options={STATUS_OPTIONS}
+            onChange={(value) => onFilterChange({ ...filter, statusFilter: value })}
+          />
+          <SegmentedControl
+            value={itemFilter}
+            options={ITEM_FILTER_OPTIONS}
+            onChange={(value) => onFilterChange({ ...filter, itemFilter: value })}
+          />
           <Button
-            variant="bare"
-            className={`tracker-filters__btn ${filter.activeFacets.length > 0 ? 'tracker-filters__btn--active' : ''}`}
+            variant="tertiary"
+            size="sm"
+            active={filter.activeFacets.length > 0}
+            icon={<Icon paths={TAG_PATHS} size={12} />}
             onClick={() => setShowTagFilter(!showTagFilter)}
           >
             Tags{filter.activeFacets.length > 0 ? ` (${filter.activeFacets.length})` : ''}
           </Button>
-
           <Button
-            variant="bare"
-            className={`tracker-filters__btn ${grouping.length > 0 ? 'tracker-filters__btn--active' : ''}`}
+            variant="tertiary"
+            size="sm"
+            active={grouping.length > 0}
+            icon={<Icon paths={NESTED_PATHS} size={12} />}
             onClick={() => setShowGroupConfig(!showGroupConfig)}
           >
             Group{grouping.length > 0 ? ` (${grouping.length})` : ''}
@@ -147,4 +138,3 @@ const TrackerFilters = (props: TrackerFiltersProps) => {
 };
 
 export { TrackerFilters };
-export type { ViewMode };

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerGroupTree.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerGroupTree.tsx
@@ -11,7 +11,7 @@ import type { TreeNode } from '@ds/composites/GroupTree';
 import type { CheckRecord } from '@shared/game/data';
 import type { CheckStatus } from '@shared/game/logic/eval';
 import type { GroupNode, RunContext } from '@shared/game/logic/queries/check-grouping';
-import type { ViewMode } from './TrackerFilters';
+import type { ViewMode } from '../ChecksTracker.type';
 import { CheckList } from './CheckList';
 import '../ChecksTracker.css';
 

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerSummary.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerSummary.tsx
@@ -1,5 +1,7 @@
 /* @layer renderer-components @kind component */
-import { Box, Text } from '@ds/primitives';
+import { Box, ProgressBar, Text } from '@ds/primitives';
+import { CheckStatusIcon, STATUS_LABELS } from './CheckStatusIcon';
+import type { StatusKey } from './CheckStatusIcon';
 import '../ChecksTracker.css';
 
 interface TrackerSummaryProps {
@@ -11,33 +13,39 @@ interface TrackerSummaryProps {
 
 // Wording is the reader's, not the model's: a check is one you have taken, one
 // you can go and take now, or one still out of reach.
-const STATS = [
-  { key: 'completed', label: 'taken', icon: '✓', title: 'Already collected' },
-  { key: 'reachable', label: 'available', icon: '●', title: 'Reachable right now' },
-  { key: 'blocked', label: 'left', icon: '✕', title: 'Still out of reach' },
-  { key: 'total', label: 'total', icon: 'Σ', title: 'Every check' },
-] as const;
+const STATS: { key: StatusKey; label: string }[] = [
+  { key: 'completed', label: 'taken' },
+  { key: 'reachable', label: 'available' },
+  { key: 'blocked', label: 'left' },
+  { key: 'total', label: 'total' },
+];
 
 const TrackerSummary = (props: TrackerSummaryProps) => {
   const { completed, reachable, blocked, total } = props;
-  const counts = { completed, reachable, blocked, total };
+  const counts: Record<StatusKey, number> = { completed, reachable, blocked, total };
   const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
 
   return (
     <Box className="tracker-summary">
-      <Box className="tracker-summary__bar">
-        <Box className="tracker-summary__fill tracker-summary__fill--completed" style={{ width: `${(completed / total) * 100}%` }} />
-        <Box className="tracker-summary__fill tracker-summary__fill--reachable" style={{ width: `${(reachable / total) * 100}%` }} />
+      <Box className="tracker-summary__meter">
+        <ProgressBar
+          className="tracker-summary__bar"
+          value={completed}
+          secondaryValue={completed + reachable}
+          secondaryVariant="gold"
+          variant="green"
+          max={Math.max(total, 1)}
+        />
+        <Text className="tracker-summary__pct" title="Percent complete">{pct}%</Text>
       </Box>
       <Box className="tracker-summary__stats">
-        {STATS.map(s => (
-          <Text key={s.key} className={`tracker-summary__stat tracker-summary__stat--${s.key}`} title={s.title}>
-            {counts[s.key]}
-            <Box as="span" className="tracker-summary__stat-label"> {s.label}</Box>
-            <Box as="span" className="tracker-summary__stat-icon"> {s.icon}</Box>
-          </Text>
+        {STATS.map(({ key, label }) => (
+          <Box key={key} className={`tracker-summary__stat tracker-summary__stat--${key}`} title={STATUS_LABELS[key]}>
+            <CheckStatusIcon status={key} />
+            <Text className="tracker-summary__stat-value">{counts[key]}</Text>
+            <Text className="tracker-summary__stat-label">{label}</Text>
+          </Box>
         ))}
-        <Text className="tracker-summary__stat tracker-summary__stat--pct" title="Percent complete">{pct}%</Text>
       </Box>
     </Box>
   );

--- a/apps/web/src/ui/domains/app/compounds/TrackerInventory/TrackerInventory.css
+++ b/apps/web/src/ui/domains/app/compounds/TrackerInventory/TrackerInventory.css
@@ -1,0 +1,136 @@
+/* @layer renderer-components @kind style */
+
+.tracker-inventory {
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--c-border);
+  flex-shrink: 0;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.tracker-inventory__category {
+  margin-bottom: var(--space-sm);
+}
+
+.tracker-inventory__category-label {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semi);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--c-text-dim);
+  margin-bottom: var(--space-xs);
+}
+
+.tracker-inventory__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.tracker-inventory__slot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 40px;
+  padding: var(--space-xs) var(--space-xs);
+  border-radius: var(--r-sm);
+  transition: opacity 0.2s;
+}
+
+.tracker-inventory__slot--obtained {
+  opacity: 1;
+}
+
+.tracker-inventory__slot--missing {
+  opacity: 0.25;
+  filter: grayscale(1);
+}
+
+.tracker-inventory__sprite {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+}
+
+.tracker-inventory__name {
+  font-size: var(--text-xs);
+  text-align: center;
+  color: var(--c-text-dim);
+  line-height: 1.1;
+  margin-top: var(--space-xs);
+  max-width: 40px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── In-game layout ─── */
+
+.tracker-inventory--ingame {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: var(--space-sm);
+  max-height: none;
+}
+
+.tracker-inventory__ingame-main {
+  grid-column: 1;
+  grid-row: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.tracker-inventory__ingame-row {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.tracker-inventory__ingame-side {
+  grid-column: 2;
+  grid-row: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-left: var(--space-sm);
+  border-left: 1px solid var(--c-border);
+}
+
+.tracker-inventory__ingame-bottom {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  display: flex;
+  gap: var(--space-xs);
+  padding-top: var(--space-xs);
+  border-top: 1px solid var(--c-border);
+}
+
+/* ─── Compact layout ─── */
+
+.tracker-inventory--compact {
+  max-height: none;
+}
+
+.tracker-inventory__grid--compact {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 36px);
+  gap: var(--space-xs);
+}
+
+.tracker-inventory--compact .tracker-inventory__slot {
+  width: 36px;
+  padding: var(--space-xs) var(--space-xs);
+}
+
+.tracker-inventory--compact .tracker-inventory__sprite {
+  width: 20px;
+  height: 20px;
+}
+
+.tracker-inventory--compact .tracker-inventory__name {
+  font-size: var(--text-xs);
+  max-width: 36px;
+}
+

--- a/apps/web/src/ui/domains/app/compounds/TrackerInventory/TrackerInventory.tsx
+++ b/apps/web/src/ui/domains/app/compounds/TrackerInventory/TrackerInventory.tsx
@@ -5,7 +5,7 @@ import {
   INVENTORY_LAYOUT, INGAME_ITEMS_GRID, INGAME_EQUIPMENT, INGAME_PASSIVES, COMPACT_LAYOUT,
 } from '@shared/game/data';
 import { resolveItemSprite, getSpritesBase } from '@shared/game/logic/queries/item-sprites';
-import '../ChecksTracker/ChecksTracker.css';
+import './TrackerInventory.css';
 
 interface TrackerInventoryProps {
   inventory: ReadonlySet<ItemId>;

--- a/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
+++ b/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo } from 'react';
 import { Box, Image } from '@ds/primitives';
 import { WidgetManager, useWidgetLayout } from '@ds/composites/Widget';
-import { InventoryWidgetContent, InventoryWidgetSettings, ChecksWidgetContent, LogsWidgetContent, DebugWidgetContent, NavigationWidgetContent, LiveDataInspectorContent, CheatsWidgetContent, SimulatorWidgetContent, MusicWidgetContent } from '@domains/widgets';
+import { InventoryWidgetContent, InventoryWidgetSettings, ChecksWidgetContent, ChecksWidgetSettings, LogsWidgetContent, DebugWidgetContent, NavigationWidgetContent, LiveDataInspectorContent, CheatsWidgetContent, SimulatorWidgetContent, MusicWidgetContent } from '@domains/widgets';
 import { loadTrackerStateBlob, saveTrackerStateBlob } from '@app/lib/tracker-state-io';
 import { primeLiveSettings } from '@app/lib/game';
 import { useExclusiveInsetsStore } from '@app/stores/exclusive-insets-store';
@@ -169,7 +169,7 @@ const AppMain = () => {
           onUpdate={widgets.update}
           onClose={widgets.close}
           onInsetsChange={setExclusiveInsets}
-          settingsContent={{ inventory: <InventoryWidgetSettings /> }}
+          settingsContent={{ inventory: <InventoryWidgetSettings />, checks: <ChecksWidgetSettings /> }}
           developerToolsEnabled={developerToolsEnabled}
           startupForcedWidgetIds={window.api.startup.widgets}
           vanillaSafe={vanillaSafe}

--- a/apps/web/src/ui/domains/app/views/Randomizer/Randomizer.css
+++ b/apps/web/src/ui/domains/app/views/Randomizer/Randomizer.css
@@ -167,11 +167,7 @@
   gap: var(--space-sm);
 }
 
-.spoiler-tracker .tracker-view__checks {
-  flex: 1;
-  min-height: 0;
-  max-height: none;
-  overflow-y: auto;
+.spoiler-tracker .checks-tracker__list {
   border: 1px solid var(--c-hairline);
   border-radius: var(--radius-md);
   background: var(--c-sunken);

--- a/apps/web/src/ui/domains/widgets/checks/ChecksWidget.tsx
+++ b/apps/web/src/ui/domains/widgets/checks/ChecksWidget.tsx
@@ -7,11 +7,13 @@
  */
 import { ChecksTracker } from '@domains/app/compounds/ChecksTracker';
 import { useTrackerData } from '../../../../hooks/useTrackerData';
+import { useStickyHeader } from './behavior/useStickyHeader';
 
 const ChecksWidgetContent = () => {
   const {
     viewMode, setViewMode, grouping, setGrouping, filter, setFilter, snapshot, stats, groupTree, run,
   } = useTrackerData();
+  const stickyHeader = useStickyHeader();
 
   return (
     <ChecksTracker
@@ -26,6 +28,7 @@ const ChecksWidgetContent = () => {
       groupTree={groupTree}
       statuses={snapshot}
       run={run}
+      stickyHeader={stickyHeader}
     />
   );
 };

--- a/apps/web/src/ui/domains/widgets/checks/behavior/useStickyHeader.ts
+++ b/apps/web/src/ui/domains/widgets/checks/behavior/useStickyHeader.ts
@@ -1,0 +1,26 @@
+/* @layer renderer-widgets @kind hook */
+/**
+ * The widget's pinned-header preference, read live so the settings popover and
+ * the tracker below it never disagree. Same localStorage-plus-storage-event
+ * shape the inventory widget's view mode uses.
+ */
+import { useState, useEffect } from 'react';
+import { STICKY_HEADER_KEY } from '../checks.constants';
+
+const readSticky = (): boolean => localStorage.getItem(STICKY_HEADER_KEY) !== 'off';
+
+const useStickyHeader = () => {
+  const [sticky, setSticky] = useState<boolean>(readSticky);
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === STICKY_HEADER_KEY) setSticky(readSticky());
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  return sticky;
+};
+
+export { readSticky, useStickyHeader };

--- a/apps/web/src/ui/domains/widgets/checks/checks.constants.ts
+++ b/apps/web/src/ui/domains/widgets/checks/checks.constants.ts
@@ -1,0 +1,6 @@
+/* @layer renderer-widgets @kind constants */
+
+/** Where the pinned-header preference lives, shared by the widget and its settings. */
+const STICKY_HEADER_KEY = 'checks-widget-sticky-header';
+
+export { STICKY_HEADER_KEY };

--- a/apps/web/src/ui/domains/widgets/checks/index.ts
+++ b/apps/web/src/ui/domains/widgets/checks/index.ts
@@ -1,2 +1,3 @@
 /* @layer renderer-widgets @kind barrel */
 export { ChecksWidgetContent } from './ChecksWidget';
+export { ChecksWidgetSettings } from './sub-components/ChecksWidgetSettings';

--- a/apps/web/src/ui/domains/widgets/checks/sub-components/ChecksWidgetSettings.tsx
+++ b/apps/web/src/ui/domains/widgets/checks/sub-components/ChecksWidgetSettings.tsx
@@ -1,0 +1,29 @@
+/* @layer renderer-widgets @kind component */
+import { useState } from 'react';
+import { Box, Text, Toggle } from '@ds/primitives';
+import { STICKY_HEADER_KEY } from '../checks.constants';
+import { readSticky } from '../behavior/useStickyHeader';
+
+const ChecksWidgetSettings = () => {
+  const [sticky, setSticky] = useState<boolean>(readSticky);
+
+  const handleChange = (next: boolean) => {
+    setSticky(next);
+    const value = next ? 'on' : 'off';
+    localStorage.setItem(STICKY_HEADER_KEY, value);
+    window.dispatchEvent(new StorageEvent('storage', { key: STICKY_HEADER_KEY, newValue: value }));
+  };
+
+  return (
+    <Box className="widget-settings__row">
+      <Text className="widget-settings__label">Pin header</Text>
+      <Toggle
+        checked={sticky}
+        onChange={handleChange}
+        description="Keep the summary and filters in place; scroll the list only."
+      />
+    </Box>
+  );
+};
+
+export { ChecksWidgetSettings };

--- a/apps/web/src/ui/domains/widgets/index.ts
+++ b/apps/web/src/ui/domains/widgets/index.ts
@@ -1,6 +1,6 @@
 /* @layer renderer-widgets @kind barrel */
 export { InventoryWidgetContent, InventoryWidgetSettings } from './inventory';
-export { ChecksWidgetContent } from './checks';
+export { ChecksWidgetContent, ChecksWidgetSettings } from './checks';
 export { LogsWidgetContent } from './logs';
 export { DebugWidgetContent } from './debug';
 export { NavigationWidgetContent, LiveDataInspectorContent } from './navigation';


### PR DESCRIPTION
The checks tracker had drifted from the rest of the app: text glyphs where everything else draws icons, its own button and chip styling sitting next to the primitives that already do that, and a summary bar that scrolled away the moment you moved down the list. The filtering and grouping behaviour is untouched.

- The summary and filters are one header band over the list. A new setting on the Checks widget pins them so only the list scrolls, on by default.
- The card grid picks its column count from the width it has instead of always asking for three, so it reads in a narrow widget and across the spoiler pane. It is now the default view.
- Controls are design-system ones throughout: SegmentedControl for view mode, status and item filters, TagPicker for the facet panel, ProgressBar for the meter, Button and IconButton for the rest. That removed about 180 lines of restated CSS.
- Status marks are real SVG icons now, drawn through one CheckStatusIcon, so the summary, the filter buttons and the rows can never disagree about what taken looks like.
- Three primitives grew a little to carry it: SegmentOption takes a ReactNode label and a title, Button takes active the way IconButton already did, and ProgressBar can colour its secondary fill in its own right.
- The tracker-inventory styles moved out of ChecksTracker.css into the component that actually uses them.
