### PR TITLE
Keep widget state with the profile

### DIFF
--- a/apps/web/src/App/behavior/useWidgetPrefs.ts
+++ b/apps/web/src/App/behavior/useWidgetPrefs.ts
@@ -1,0 +1,40 @@
+/* @layer renderer-appshell @kind hook */
+/**
+ * Binds the widget-prefs store to the active profile: loads what that profile had
+ * saved, and makes sure whatever is still pending reaches disk before the window
+ * goes away.
+ *
+ * The flush covers the layout too, because both halves share one repository and
+ * one debounced write.
+ */
+import { useEffect } from 'react';
+import { flushWidgetBlob, loadWidgetBlob } from '@app/lib/storage/widget-state';
+import { readWidgetUi } from '@app/lib/storage/widget-prefs';
+import { useWidgetUiStore } from '@app/stores/widget-ui-store';
+
+const useWidgetPrefs = (profileId: string | null): void => {
+  const hydrate = useWidgetUiStore((s) => s.hydrate);
+
+  useEffect(() => {
+    if (!profileId) return;
+    let cancelled = false;
+    void loadWidgetBlob(profileId).then((blob) => {
+      if (!cancelled) hydrate(profileId, readWidgetUi(blob).byWidget);
+    });
+    return () => { cancelled = true; };
+  }, [profileId, hydrate]);
+
+  useEffect(() => {
+    // pagehide, not beforeunload alone: Electron tears the window down without
+    // running a beforeunload handler that does not call preventDefault.
+    const onHide = () => { void flushWidgetBlob(); };
+    window.addEventListener('pagehide', onHide);
+    window.addEventListener('beforeunload', onHide);
+    return () => {
+      window.removeEventListener('pagehide', onHide);
+      window.removeEventListener('beforeunload', onHide);
+    };
+  }, []);
+};
+
+export { useWidgetPrefs };

--- a/apps/web/src/hooks/useTrackerData.ts
+++ b/apps/web/src/hooks/useTrackerData.ts
@@ -14,7 +14,7 @@
  * standard-mode escape gating and per-dungeon key counts included, because
  * the vanilla dataset models neither the seed nor the escape sequence.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { computeTrackerSnapshot } from '@shared/game/logic/eval';
 import { resolveRules } from '@shared/game/logic/resolver';
 import { VANILLA_CONFIG } from '@shared/game/data/presets';
@@ -33,24 +33,47 @@ import {
 } from '../lib/game/randomizer-client';
 import type { PlacementView } from '../lib/game/randomizer-client';
 import type { ViewMode } from '../ui/domains/app/compounds/ChecksTracker';
+import { CLOSED_PANELS } from '../ui/domains/app/compounds/ChecksTracker';
+import type { TrackerPanels } from '../ui/domains/app/compounds/ChecksTracker';
+import { useWidgetPref } from './useWidgetPref';
 
 interface TrackerDataOptions {
   initialGrouping?: GroupDimension[];
   initialViewMode?: ViewMode;
+  /**
+   * Widget id the view settings belong to. With one, everything the user arranged
+   * (grouping, view mode, filter, which panels are open, which groups are expanded)
+   * is remembered by the profile and survives the widget being unmounted by an open
+   * screen. Without one (the randomizer page's spoiler tab) it is plain local state,
+   * as before.
+   */
+  prefKey?: string;
 }
 
 const EMPTY_FILTER: FilterState = { searchQuery: '', activeFacets: [], tagMode: 'any' };
+/** Module-level so an unset pref hands back the same array every render, and the
+ *  group tree below is not rebuilt on each one. */
+const DEFAULT_GROUPING: GroupDimension[] = ['world', 'dungeon'];
+const NO_GROUPS: readonly string[] = [];
 
 const useTrackerData = (options: TrackerDataOptions = {}) => {
-  const { initialGrouping = ['world', 'dungeon'], initialViewMode = 'compact' } = options;
+  const { initialGrouping = DEFAULT_GROUPING, initialViewMode = 'compact', prefKey = null } = options;
 
   const [inventory, setInventory] = useState<Set<ItemId>>(() => getCurrentInventory());
   const [completedChecks, setCompletedChecks] = useState<Set<CheckId>>(() => getCompletedChecks());
   const [placement, setPlacement] = useState(() => getSessionState().placement);
   const [fired, setFired] = useState<ReadonlySet<string>>(() => firedLocations());
-  const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
-  const [grouping, setGrouping] = useState<GroupDimension[]>(initialGrouping);
-  const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER);
+  const [viewMode, setViewMode] = useWidgetPref<ViewMode>(prefKey, 'viewMode', initialViewMode);
+  const [grouping, setGrouping] = useWidgetPref<GroupDimension[]>(prefKey, 'grouping', initialGrouping);
+  const [filter, setFilter] = useWidgetPref<FilterState>(prefKey, 'filter', EMPTY_FILTER);
+  const [panels, setPanels] = useWidgetPref<TrackerPanels>(prefKey, 'panels', CLOSED_PANELS);
+  const [expandedGroups, setExpandedGroups] = useWidgetPref<readonly string[]>(prefKey, 'expanded', NO_GROUPS);
+
+  const toggleGroup = useCallback((key: string) => {
+    setExpandedGroups(expandedGroups.includes(key)
+      ? expandedGroups.filter((k) => k !== key)
+      : [...expandedGroups, key]);
+  }, [expandedGroups, setExpandedGroups]);
 
   useEffect(() => onInventoryChanged((inv) => setInventory(new Set(inv))), []);
   useEffect(() => onCompletedChecksChanged((checks) => setCompletedChecks(new Set(checks))), []);
@@ -114,6 +137,8 @@ const useTrackerData = (options: TrackerDataOptions = {}) => {
     viewMode, setViewMode,
     grouping, setGrouping,
     filter, setFilter,
+    panels, setPanels,
+    expandedGroups, toggleGroup,
     snapshot, stats, groupTree,
     placement, placementView, run,
   };

--- a/apps/web/src/hooks/useWidgetPref.ts
+++ b/apps/web/src/hooks/useWidgetPref.ts
@@ -1,0 +1,37 @@
+/* @layer renderer-other @kind hook */
+/**
+ * A `useState` drop-in whose value belongs to the profile instead of the
+ * component. Point it at a widget id and the value survives the widget being
+ * unmounted by an open screen, a profile switch and a restart; pass `null` and
+ * it degrades to plain local state with no store write and no disk read, the
+ * same bargain `useViewState` makes for a composite used without a ViewKey.
+ *
+ * The value must survive a JSON round-trip. See widget-prefs.ts for why that is
+ * the only constraint.
+ */
+import { useCallback, useState } from 'react';
+import { useWidgetUiStore } from '@app/stores/widget-ui-store';
+
+const useWidgetPref = <T,>(
+  widgetId: string | null,
+  key: string,
+  fallback: T,
+): readonly [T, (next: T) => void] => {
+  const [local, setLocal] = useState<T>(fallback);
+  const stored = useWidgetUiStore((s) => (widgetId ? s.byWidget[widgetId]?.[key] : undefined));
+  const setPref = useWidgetUiStore((s) => s.setPref);
+
+  const set = useCallback((next: T) => {
+    if (widgetId) setPref(widgetId, key, next);
+    else setLocal(next);
+  }, [widgetId, key, setPref]);
+
+  // The cast is the one place the `unknown` storage shape meets a caller's type.
+  // A pref written by an older build with a different shape lands here; the widget
+  // reads it as T and the next write corrects it.
+  const value = widgetId ? ((stored ?? fallback) as T) : local;
+
+  return [value, set] as const;
+};
+
+export { useWidgetPref };

--- a/apps/web/src/lib/storage/widget-prefs.ts
+++ b/apps/web/src/lib/storage/widget-prefs.ts
@@ -1,0 +1,54 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Memento for what a widget's CONTENT remembers, as opposed to the frame around
+ * it: the tab it was on, the filter it was showing, the view mode it was in.
+ * Plain JSON in, plain JSON out, and nothing here knows a disk or a store exists.
+ *
+ * Values are `unknown` on purpose. Every widget owns its own keys and its own
+ * shapes, and a shared union would have to grow a member per widget forever. The
+ * bargain instead is that a value must survive a JSON round-trip, which is what
+ * `sanitizeWidgetUi` checks on the way back in.
+ *
+ * Known keys today: `tab` (cheats, live data inspector), `viewMode` (checks,
+ * inventory), `grouping` and `filter` (checks), `mode` (navigation).
+ */
+
+/** Bump to discard stale prefs instead of migrating them. Same bargain as SNAPSHOT_VERSION. */
+const WIDGET_PREFS_VERSION = 1;
+
+/** One widget's remembered content settings, keyed by whatever that widget calls them. */
+type WidgetPrefs = Readonly<Record<string, unknown>>;
+
+interface WidgetUiState {
+  v: typeof WIDGET_PREFS_VERSION;
+  /** Keyed by widget id, the same ids as WIDGET_DEFINITIONS. */
+  byWidget: Readonly<Record<string, WidgetPrefs>>;
+}
+
+const emptyWidgetUi = (): WidgetUiState => ({ v: WIDGET_PREFS_VERSION, byWidget: {} });
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Prefs arrive from untrusted JSON, so a wrong-shaped file must be dropped
+ * instead of crashing a widget. A version mismatch fails here by design, and a
+ * single malformed widget entry is dropped without taking its neighbours.
+ */
+const sanitizeWidgetUi = (raw: unknown): WidgetUiState => {
+  if (!isPlainObject(raw) || raw.v !== WIDGET_PREFS_VERSION || !isPlainObject(raw.byWidget)) {
+    return emptyWidgetUi();
+  }
+  const byWidget: Record<string, WidgetPrefs> = {};
+  for (const [id, prefs] of Object.entries(raw.byWidget)) {
+    if (isPlainObject(prefs)) byWidget[id] = prefs;
+  }
+  return { v: WIDGET_PREFS_VERSION, byWidget };
+};
+
+/** Reads the prefs half out of a profile's tracker blob. */
+const readWidgetUi = (blob: Record<string, unknown> | null): WidgetUiState =>
+  sanitizeWidgetUi(blob?.widgetUi);
+
+export { WIDGET_PREFS_VERSION, emptyWidgetUi, readWidgetUi, sanitizeWidgetUi };
+export type { WidgetPrefs, WidgetUiState };

--- a/apps/web/src/lib/storage/widget-state.ts
+++ b/apps/web/src/lib/storage/widget-state.ts
@@ -1,0 +1,107 @@
+/* @layer renderer-lib @kind logic */
+/**
+ * Repository (single boundary) for everything about a profile's widgets: the
+ * layout the Widget composite writes, and the per-widget content prefs. Both
+ * live in the same file (profiles/<id>/tracker.json), so one cache and one
+ * debounced write serve both and neither can clobber the other.
+ *
+ * Whole-file semantics, the same bargain as ui-views.ts: the blob loads once per
+ * profile and caches, every mutation rewrites the cached whole, and rapid writes
+ * coalesce into one. What this adds is `flushWidgetBlob`, because a debounce
+ * nobody forces drops whatever the user did just before the window closed.
+ *
+ * Before this existed, a drag wrote the whole file on every mousemove, and two
+ * overlapping read-modify-writes both read the same "before", so the earlier
+ * one was lost.
+ */
+import { loadTrackerStateBlob, saveTrackerStateBlob } from '../tracker-state-io';
+import type { TrackerStateBlob } from '../tracker-state-io';
+import { log } from '../log-bus';
+
+const DEBOUNCE_MS = 250;
+
+let cacheId: string | null = null;
+let cache: TrackerStateBlob | null = null;
+let loadingId: string | null = null;
+let loading: Promise<TrackerStateBlob> | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let dirty = false;
+let inFlight: Promise<void> = Promise.resolve();
+
+const writePending = (): void => {
+  if (timer !== null) { clearTimeout(timer); timer = null; }
+  if (!dirty || !cacheId || !cache) return;
+  dirty = false;
+  const [id, blob] = [cacheId, cache];
+  inFlight = saveTrackerStateBlob(id, blob).catch((error: unknown) => {
+    log.ipc(`Failed to save widget state for ${id}: ${String(error)}`, 'error');
+  });
+};
+
+const scheduleWrite = (): void => {
+  dirty = true;
+  if (timer !== null) clearTimeout(timer);
+  timer = setTimeout(writePending, DEBOUNCE_MS);
+};
+
+/** Forces any pending write out and resolves once it has landed. */
+const flushWidgetBlob = async (): Promise<void> => {
+  writePending();
+  await inFlight;
+};
+
+/**
+ * The profile's blob, cached. A second profile flushes the first one's pending
+ * write before its own read, so switching profiles never strands an edit.
+ */
+const loadWidgetBlob = (profileId: string): Promise<TrackerStateBlob> => {
+  if (cacheId === profileId && cache) return Promise.resolve(cache);
+  if (loadingId === profileId && loading) return loading;
+  loadingId = profileId;
+  loading = (async () => {
+    await flushWidgetBlob();
+    const raw = await loadTrackerStateBlob(profileId).catch((error: unknown) => {
+      log.ipc(`Failed to load widget state for ${profileId}: ${String(error)}`, 'error');
+      return null;
+    });
+    cache = raw ?? {};
+    cacheId = profileId;
+    loading = null;
+    loadingId = null;
+    return cache;
+  })();
+  return loading;
+};
+
+const applyPatch = (profileId: string, patch: Partial<TrackerStateBlob>): void => {
+  if (cacheId !== profileId || !cache) return;
+  Object.assign(cache, patch);
+  scheduleWrite();
+};
+
+/**
+ * Merges keys into the cached blob and schedules one write. Patching before the
+ * file is known would write a blob holding only this key, so an unloaded profile
+ * reads first and patches on the way back.
+ */
+const patchWidgetBlob = (profileId: string, patch: Partial<TrackerStateBlob>): void => {
+  if (cacheId === profileId && cache) {
+    applyPatch(profileId, patch);
+    return;
+  }
+  void loadWidgetBlob(profileId).then(() => applyPatch(profileId, patch));
+};
+
+/**
+ * The persistence round-trip the bare Widget composite takes by injection. `save`
+ * is fire-and-forget: it lands in the cache now and on disk once the writes stop.
+ */
+const widgetLayoutIO = {
+  load: (profileId: string): Promise<TrackerStateBlob | null> => loadWidgetBlob(profileId),
+  save: (profileId: string, blob: TrackerStateBlob): Promise<void> => {
+    patchWidgetBlob(profileId, blob);
+    return Promise.resolve();
+  },
+};
+
+export { flushWidgetBlob, loadWidgetBlob, patchWidgetBlob, widgetLayoutIO };

--- a/apps/web/src/stores/widget-ui-store.ts
+++ b/apps/web/src/stores/widget-ui-store.ts
@@ -1,0 +1,48 @@
+/* @layer renderer-stores @kind logic */
+/**
+ * The live tier of every widget's content prefs: the tab it is on, the filter it
+ * is showing, the view mode it is in.
+ *
+ * A widget is unmounted the moment any screen opens, which is intended, so
+ * nothing a widget wants to keep can live in its own component state. It lives
+ * here, where it outlasts the unmount, and is written through to the profile so
+ * it also outlasts the app. Same reasoning as navigation-overlay-store, applied
+ * to all of them instead of one.
+ */
+import { create } from 'zustand';
+import { patchWidgetBlob } from '@app/lib/storage/widget-state';
+import { WIDGET_PREFS_VERSION } from '@app/lib/storage/widget-prefs';
+import type { WidgetPrefs } from '@app/lib/storage/widget-prefs';
+
+interface WidgetUiStoreState {
+  /** The profile these prefs belong to; writes are dropped until one is known. */
+  profileId: string | null;
+  /**
+   * False until the profile's saved prefs have arrived. A consumer that has to
+   * apply a pref exactly once (the navigation mode) waits on this, so it applies
+   * the saved value and not the fallback that preceded it.
+   */
+  hydrated: boolean;
+  byWidget: Readonly<Record<string, WidgetPrefs>>;
+  /** Replaces everything with what the profile had saved. */
+  hydrate: (profileId: string, byWidget: Readonly<Record<string, WidgetPrefs>>) => void;
+  /** Updates one key of one widget and writes the whole set back to the profile. */
+  setPref: (widgetId: string, key: string, value: unknown) => void;
+}
+
+const useWidgetUiStore = create<WidgetUiStoreState>((set, get) => ({
+  profileId: null,
+  hydrated: false,
+  byWidget: {},
+
+  hydrate: (profileId, byWidget) => set({ profileId, byWidget, hydrated: true }),
+
+  setPref: (widgetId, key, value) => {
+    const { profileId, byWidget } = get();
+    const next = { ...byWidget, [widgetId]: { ...byWidget[widgetId], [key]: value } };
+    set({ byWidget: next });
+    if (profileId) patchWidgetBlob(profileId, { widgetUi: { v: WIDGET_PREFS_VERSION, byWidget: next } });
+  },
+}));
+
+export { useWidgetUiStore };

--- a/apps/web/src/ui/design-system/composites/GroupTree/GroupTree.tsx
+++ b/apps/web/src/ui/design-system/composites/GroupTree/GroupTree.tsx
@@ -7,14 +7,17 @@
  *
  * A root with no children renders its own items flat, the ungrouped case.
  */
+import { useMemo } from 'react';
 import { Box } from '../../primitives';
 import { GroupSection } from './sub-components/GroupSection';
 import type { GroupTreeProps } from './GroupTree.type';
 import './GroupTree.css';
 
 const GroupTree = <T,>(props: GroupTreeProps<T>) => {
-  const { root, renderItems, expandToDepth = 0, className, emptyLabel = 'Nothing to show.' } = props;
+  const { root, renderItems, expandToDepth = 0, className, emptyLabel = 'Nothing to show.', expandedKeys, onToggleKey } = props;
   const classes = `group-tree${className ? ` ${className}` : ''}`;
+  // undefined, not an empty set, is what tells a section it owns its own state.
+  const openKeys = useMemo(() => (expandedKeys ? new Set(expandedKeys) : undefined), [expandedKeys]);
 
   if (root.children.length > 0) {
     return (
@@ -26,6 +29,8 @@ const GroupTree = <T,>(props: GroupTreeProps<T>) => {
             depth={1}
             expandToDepth={expandToDepth}
             renderItems={renderItems}
+            expandedKeys={openKeys}
+            onToggle={onToggleKey}
           />
         ))}
       </Box>

--- a/apps/web/src/ui/design-system/composites/GroupTree/GroupTree.type.ts
+++ b/apps/web/src/ui/design-system/composites/GroupTree/GroupTree.type.ts
@@ -21,6 +21,14 @@ interface GroupTreeProps<T> {
   renderItems: (items: T[]) => ReactNode;
   /** Sections at a depth below this mount expanded. 0 (default) = all collapsed. */
   expandToDepth?: number;
+  /**
+   * Controlled expansion: the keys currently open, plus the toggle. Supply both
+   * and the caller owns which sections are open, so the set can outlive the tree
+   * being unmounted. Omit both and each section keeps its own state, which is
+   * what a surface with nothing to remember wants.
+   */
+  expandedKeys?: readonly string[];
+  onToggleKey?: (key: string) => void;
   className?: string;
   emptyLabel?: string;
 }

--- a/apps/web/src/ui/design-system/composites/GroupTree/sub-components/GroupSection.tsx
+++ b/apps/web/src/ui/design-system/composites/GroupTree/sub-components/GroupSection.tsx
@@ -14,17 +14,26 @@ interface GroupSectionProps<T> {
   depth: number;
   expandToDepth: number;
   renderItems: (items: T[]) => ReactNode;
+  /** Present when the caller owns expansion (see GroupTreeProps.expandedKeys). */
+  expandedKeys?: ReadonlySet<string>;
+  onToggle?: (key: string) => void;
 }
 
 const MAX_DEPTH_CLASS = 4;
 
 const GroupSection = <T,>(props: GroupSectionProps<T>) => {
-  const { node, depth, expandToDepth, renderItems } = props;
-  const [expanded, setExpanded] = useState(depth <= expandToDepth);
+  const { node, depth, expandToDepth, renderItems, expandedKeys, onToggle } = props;
+  const [localExpanded, setLocalExpanded] = useState(depth <= expandToDepth);
+  const controlled = expandedKeys !== undefined;
+  const expanded = controlled ? expandedKeys.has(node.key) : localExpanded;
+  const toggle = () => {
+    if (controlled) onToggle?.(node.key);
+    else setLocalExpanded((v) => !v);
+  };
 
   return (
     <Box className={`group-tree__group group-tree__group--depth-${Math.min(depth, MAX_DEPTH_CLASS)}`}>
-      <Button variant="bare" className="group-tree__header" onClick={() => setExpanded(!expanded)}>
+      <Button variant="bare" className="group-tree__header" onClick={toggle}>
         <Text className="group-tree__chevron">{expanded ? '▼' : '▶'}</Text>
         <Text className="group-tree__name">{node.label}</Text>
         {node.meta !== undefined && <Text className="group-tree__meta">{node.meta}</Text>}
@@ -39,6 +48,8 @@ const GroupSection = <T,>(props: GroupSectionProps<T>) => {
                 depth={depth + 1}
                 expandToDepth={expandToDepth}
                 renderItems={renderItems}
+                expandedKeys={expandedKeys}
+                onToggle={onToggle}
               />
             ))
             : renderItems(node.items)}

--- a/apps/web/src/ui/design-system/composites/Widget/behavior/useWidgetLayout.ts
+++ b/apps/web/src/ui/design-system/composites/Widget/behavior/useWidgetLayout.ts
@@ -14,13 +14,19 @@ interface StartupOverride {
 
 /**
  * Force the requested widgets open + docked (shrinking the game) on their default
- * side. `visibility: 'always'` so they render even when no game is running yet.
+ * side.
+ *
+ * It deliberately does NOT touch `visibility`. Writing 'always' here was persisted,
+ * so one `--widgets=` screenshot run permanently converted those widgets into ones
+ * that never leave the screen, in a profile the flag was never meant to change.
+ * WidgetManager exempts the forced ids from the game-only filter instead, which is
+ * where a render-time override belongs.
  */
 const applyStartupWidgets = (layout: WidgetLayout, ids: string[]): WidgetLayout => {
   if (ids.length === 0) return layout;
   return {
     widgets: layout.widgets.map((w) => (ids.includes(w.id)
-      ? { ...w, visible: true, mode: 'docked', exclusive: true, visibility: 'always', side: getWidgetDefinition(w.id)?.defaultSide ?? w.side }
+      ? { ...w, visible: true, mode: 'docked', exclusive: true, side: getWidgetDefinition(w.id)?.defaultSide ?? w.side }
       : w)),
   };
 };

--- a/apps/web/src/ui/design-system/composites/Widget/behavior/widgetStore.ts
+++ b/apps/web/src/ui/design-system/composites/Widget/behavior/widgetStore.ts
@@ -10,7 +10,7 @@
 
 import type { WidgetLayout, WidgetState } from '../Widget.type';
 import { WIDGET_DEFINITIONS } from '../Widget.constants';
-import { createDefaultLayout, createDefaultWidgetState } from './createWidgetState';
+import { createDefaultLayout, createDefaultWidgetState, getWidgetDefinition } from './createWidgetState';
 
 /** Persistence round-trip injected by the View tier (keeps IPC out of the composite). */
 interface WidgetPersistenceIO {
@@ -63,14 +63,26 @@ const saveLayoutForProfile = async (profileId: string, layout: WidgetLayout, io:
 
 // ─── Helpers ───
 
-/** Adds entries for any defined widget the layout is missing (forward-compat). */
+/**
+ * Adds entries for any defined widget the layout is missing (forward-compat), and
+ * takes `visibility` back from the definition.
+ *
+ * Nothing in the UI can change a widget's visibility, so a stored value that
+ * disagrees with its definition is corruption, not a choice. The `--widgets=`
+ * startup flag used to write 'always' into the saved layout, which turned a
+ * game-only widget into one that never left the screen, permanently, in a profile
+ * the flag was only meant to pass through. Reading it from the definition here
+ * repairs any layout already carrying that.
+ */
 const ensureAllWidgets = (layout: WidgetLayout): WidgetLayout => {
   const existing = new Set(layout.widgets.map((w) => w.id));
   const missing = WIDGET_DEFINITIONS.filter((d) => !existing.has(d.id));
-  if (missing.length === 0) return layout;
   return {
     widgets: [
-      ...layout.widgets,
+      ...layout.widgets.map((w) => {
+        const def = getWidgetDefinition(w.id);
+        return def ? { ...w, visibility: def.defaultVisibility } : w;
+      }),
       ...missing.map((def, i) => createDefaultWidgetState(def, layout.widgets.length + i)),
     ],
   };

--- a/apps/web/src/ui/design-system/composites/Widget/sub-components/WidgetManager.tsx
+++ b/apps/web/src/ui/design-system/composites/Widget/sub-components/WidgetManager.tsx
@@ -16,7 +16,11 @@ import { resolveWidgetDisabledState } from '../behavior/resolveWidgetDisabledSta
 
 interface WidgetManagerProps {
   layout: WidgetLayout;
+  /** The game core is running. Says nothing about what the user is looking at. */
   gameRunning: boolean;
+  /** A full-window page is covering the game. A game-only widget steps aside for it,
+   *  which is what Escape-to-home does, and no startup flag overrides that. */
+  pageOpen?: boolean;
   onUpdate: (id: string, patch: Partial<WidgetState>) => void;
   onClose: (id: string) => void;
   /** Notified when docked-widget exclusive insets change (wired to a store by a view). */
@@ -43,18 +47,24 @@ interface WidgetManagerProps {
 
 const WidgetManager = (props: WidgetManagerProps) => {
   const {
-    layout, gameRunning, onUpdate, onClose, onInsetsChange, children, settingsContent,
+    layout, gameRunning, pageOpen = false, onUpdate, onClose, onInsetsChange, children, settingsContent,
     developerToolsEnabled = false, startupForcedWidgetIds = [],
     vanillaSafe = false, settings = null, onOpenSettings = () => {},
   } = props;
   const activeWidgets = useMemo(() => {
     return layout.widgets.filter((w) => {
       if (!w.visible) return false;
-      if (w.visibility === 'game-only' && !gameRunning) return false;
-      if (getWidgetDefinition(w.id)?.devOnly && !developerToolsEnabled && !startupForcedWidgetIds.includes(w.id)) return false;
+      // A startup-forced id is exempt from the no-game and dev gates, so the
+      // `--widgets=` baselines can run with no game and dev tools off, and the flag
+      // never has to write anything into the profile's saved layout. It is NOT
+      // exempt from the open-page gate: a game-only widget always steps aside.
+      const forced = startupForcedWidgetIds.includes(w.id);
+      if (w.visibility === 'game-only' && pageOpen) return false;
+      if (w.visibility === 'game-only' && !gameRunning && !forced) return false;
+      if (getWidgetDefinition(w.id)?.devOnly && !developerToolsEnabled && !forced) return false;
       return true;
     });
-  }, [layout.widgets, gameRunning, developerToolsEnabled, startupForcedWidgetIds]);
+  }, [layout.widgets, gameRunning, pageOpen, developerToolsEnabled, startupForcedWidgetIds]);
 
   const { styles: dockedStyles, exclusiveInsets } = useMemo(() => computeDockedStyles(activeWidgets), [activeWidgets]);
 

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.tsx
@@ -26,6 +26,7 @@ const ChecksTracker = (props: ChecksTrackerProps) => {
   const {
     stats, filter, onFilterChange, grouping, onGroupingChange, viewMode, onViewModeChange,
     groupTree, statuses, run, dimensions, notice, className,
+    panels, onPanelsChange, expandedGroups, onToggleGroup,
   } = props;
 
   return (
@@ -39,6 +40,8 @@ const ChecksTracker = (props: ChecksTrackerProps) => {
         viewMode={viewMode}
         onViewModeChange={onViewModeChange}
         dimensions={dimensions}
+        panels={panels}
+        onPanelsChange={onPanelsChange}
       />
       {isNarrowed(filter) && (
         <Box className="tracker-view__filtered-stats">
@@ -50,7 +53,14 @@ const ChecksTracker = (props: ChecksTrackerProps) => {
       )}
       {notice}
       <Box className="tracker-view__checks">
-        <TrackerGroupTree node={groupTree} statuses={statuses} viewMode={viewMode} run={run} />
+        <TrackerGroupTree
+          node={groupTree}
+          statuses={statuses}
+          viewMode={viewMode}
+          run={run}
+          expandedGroups={expandedGroups}
+          onToggleGroup={onToggleGroup}
+        />
       </Box>
     </Box>
   );

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.type.ts
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/ChecksTracker.type.ts
@@ -4,7 +4,7 @@ import type { CheckStatus } from '@shared/game/logic/eval';
 import type {
   FilterState, GroupDimension, GroupDimensionDef, GroupNode, RunContext,
 } from '@shared/game/logic/queries/check-grouping';
-import type { ViewMode } from './sub-components/TrackerFilters';
+import type { TrackerPanels, ViewMode } from './sub-components/TrackerFilters';
 
 interface TrackerStats {
   completed: number;
@@ -28,6 +28,13 @@ interface ChecksTrackerProps {
   run?: RunContext;
   /** Grouping axes the config panel offers. Defaults to the base catalog. */
   dimensions?: readonly GroupDimensionDef[];
+  /** Controlled disclosure + expansion. A surface that has somewhere to keep them
+   *  passes them in, so they outlive this tree being unmounted; one that does not
+   *  omits them and each piece keeps its own state. */
+  panels?: TrackerPanels;
+  onPanelsChange?: (next: TrackerPanels) => void;
+  expandedGroups?: readonly string[];
+  onToggleGroup?: (key: string) => void;
   /** Rendered between the filters and the tree: a caveat, a count, a warning. */
   notice?: ReactNode;
   className?: string;

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/index.ts
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/index.ts
@@ -1,4 +1,5 @@
 /* @layer renderer-components @kind barrel */
 export { ChecksTracker } from './ChecksTracker';
 export type { ChecksTrackerProps, TrackerStats } from './ChecksTracker.type';
-export type { ViewMode } from './sub-components/TrackerFilters';
+export { CLOSED_PANELS } from './sub-components/TrackerFilters';
+export type { TrackerPanels, ViewMode } from './sub-components/TrackerFilters';

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerFilters.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerFilters.tsx
@@ -9,6 +9,16 @@ import '../ChecksTracker.css';
 
 type ViewMode = 'compact' | 'detailed' | 'visual';
 
+/** Which disclosure panels are open. Small enough to travel as one value, which
+ *  keeps the controlled form to a single prop pair. */
+interface TrackerPanels {
+  filters: boolean;
+  groupConfig: boolean;
+  tags: boolean;
+}
+
+const CLOSED_PANELS: TrackerPanels = { filters: false, groupConfig: false, tags: false };
+
 interface TrackerFiltersProps {
   filter: FilterState;
   onFilterChange: (filter: FilterState) => void;
@@ -18,6 +28,13 @@ interface TrackerFiltersProps {
   onViewModeChange: (mode: ViewMode) => void;
   /** Grouping axes the config panel offers. Defaults to the base catalog. */
   dimensions?: readonly GroupDimensionDef[];
+  /**
+   * Controlled disclosure state. Supply both and the caller owns which panels are
+   * open, so they survive this component being unmounted. Omit both and the panels
+   * keep their own state, closed on every mount.
+   */
+  panels?: TrackerPanels;
+  onPanelsChange?: (next: TrackerPanels) => void;
 }
 
 const VIEW_MODES: { mode: ViewMode; icon: string; title: string }[] = [
@@ -40,10 +57,14 @@ const STATUS_FILTERS = [
 ] as const;
 
 const TrackerFilters = (props: TrackerFiltersProps) => {
-  const { filter, onFilterChange, grouping, onGroupingChange, viewMode, onViewModeChange, dimensions } = props;
-  const [showFilters, setShowFilters] = useState(false);
-  const [showGroupConfig, setShowGroupConfig] = useState(false);
-  const [showTagFilter, setShowTagFilter] = useState(false);
+  const { filter, onFilterChange, grouping, onGroupingChange, viewMode, onViewModeChange, dimensions, panels, onPanelsChange } = props;
+  const [localPanels, setLocalPanels] = useState<TrackerPanels>(CLOSED_PANELS);
+  const open = panels ?? localPanels;
+  const setOpen = (next: TrackerPanels) => {
+    if (panels && onPanelsChange) onPanelsChange(next);
+    else setLocalPanels(next);
+  };
+  const { filters: showFilters, groupConfig: showGroupConfig, tags: showTagFilter } = open;
 
   const itemFilter = filter.itemFilter ?? 'all';
   const statusFilter = filter.statusFilter ?? 'all';
@@ -63,7 +84,7 @@ const TrackerFilters = (props: TrackerFiltersProps) => {
         <Button
           variant="bare"
           className={`tracker-filters__toggle ${showFilters ? 'tracker-filters__toggle--active' : ''}`}
-          onClick={() => setShowFilters(v => !v)}
+          onClick={() => setOpen({ ...open, filters: !showFilters })}
           title="Filters & view options"
         >
           ⚑{activeCount > 0 ? ` ${activeCount}` : ''}
@@ -116,7 +137,7 @@ const TrackerFilters = (props: TrackerFiltersProps) => {
           <Button
             variant="bare"
             className={`tracker-filters__btn ${filter.activeFacets.length > 0 ? 'tracker-filters__btn--active' : ''}`}
-            onClick={() => setShowTagFilter(!showTagFilter)}
+            onClick={() => setOpen({ ...open, tags: !showTagFilter })}
           >
             Tags{filter.activeFacets.length > 0 ? ` (${filter.activeFacets.length})` : ''}
           </Button>
@@ -124,7 +145,7 @@ const TrackerFilters = (props: TrackerFiltersProps) => {
           <Button
             variant="bare"
             className={`tracker-filters__btn ${grouping.length > 0 ? 'tracker-filters__btn--active' : ''}`}
-            onClick={() => setShowGroupConfig(!showGroupConfig)}
+            onClick={() => setOpen({ ...open, groupConfig: !showGroupConfig })}
           >
             Group{grouping.length > 0 ? ` (${grouping.length})` : ''}
           </Button>
@@ -147,4 +168,5 @@ const TrackerFilters = (props: TrackerFiltersProps) => {
 };
 
 export { TrackerFilters };
-export type { ViewMode };
+export { CLOSED_PANELS };
+export type { TrackerPanels, ViewMode };

--- a/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerGroupTree.tsx
+++ b/apps/web/src/ui/domains/app/compounds/ChecksTracker/sub-components/TrackerGroupTree.tsx
@@ -20,6 +20,9 @@ interface TrackerGroupTreeProps {
   statuses: Map<string, CheckStatus>;
   viewMode: ViewMode;
   run?: RunContext;
+  /** Controlled expansion, passed straight through to GroupTree. */
+  expandedGroups?: readonly string[];
+  onToggleGroup?: (key: string) => void;
 }
 
 /** taken / available / still to find: the same three the summary bar counts. */
@@ -43,7 +46,7 @@ const toTreeNode = (node: GroupNode): TreeNode<CheckRecord> => ({
 });
 
 const TrackerGroupTree = (props: TrackerGroupTreeProps) => {
-  const { node, statuses, viewMode, run } = props;
+  const { node, statuses, viewMode, run, expandedGroups, onToggleGroup } = props;
 
   const root = useMemo(() => toTreeNode(node), [node]);
   const renderItems = useCallback(
@@ -53,7 +56,13 @@ const TrackerGroupTree = (props: TrackerGroupTreeProps) => {
 
   return (
     <Box className="tracker-groups">
-      <GroupTree root={root} renderItems={renderItems} emptyLabel="No checks match." />
+      <GroupTree
+        root={root}
+        renderItems={renderItems}
+        emptyLabel="No checks match."
+        expandedKeys={expandedGroups}
+        onToggleKey={onToggleGroup}
+      />
     </Box>
   );
 };

--- a/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
+++ b/apps/web/src/ui/domains/app/views/AppMain/AppMain.tsx
@@ -3,10 +3,11 @@ import { useEffect, useMemo } from 'react';
 import { Box, Image } from '@ds/primitives';
 import { WidgetManager, useWidgetLayout } from '@ds/composites/Widget';
 import { InventoryWidgetContent, InventoryWidgetSettings, ChecksWidgetContent, LogsWidgetContent, DebugWidgetContent, NavigationWidgetContent, LiveDataInspectorContent, CheatsWidgetContent, SimulatorWidgetContent, MusicWidgetContent } from '@domains/widgets';
-import { loadTrackerStateBlob, saveTrackerStateBlob } from '@app/lib/tracker-state-io';
+import { widgetLayoutIO } from '@app/lib/storage/widget-state';
 import { primeLiveSettings } from '@app/lib/game';
 import { useExclusiveInsetsStore } from '@app/stores/exclusive-insets-store';
 import { useDevToolsWidgetGate } from '@app/App/behavior/useDevToolsWidgetGate';
+import { useWidgetPrefs } from '@app/App/behavior/useWidgetPrefs';
 import { useWidgetDisabledGate } from '@app/App/behavior/useWidgetDisabledGate';
 import { applyNotchMode } from '@app/hooks/useSafeAreaInsets';
 import { useAutoUpdate } from '@app/hooks/useAutoUpdate';
@@ -42,9 +43,6 @@ import { DebugFloatingControls } from '../../compounds/DebugFloatingControls';
 import { AppDialogs } from './sub-components/AppDialogs';
 import './AppMain.css';
 
-// Profile-layout persistence injected into the bare Widget composite (keeps IPC out of it).
-const widgetIO = { load: loadTrackerStateBlob, save: saveTrackerStateBlob };
-
 const AppMain = () => {
   const windowChrome = useCapability('windowChrome');
   const canUpdate = useCapability('selfUpdate');
@@ -77,7 +75,9 @@ const AppMain = () => {
     onGameClear: () => game.clearGame(),
   });
   const nav = useAppNavigation({ activeProfile: profileMgmt.activeProfile, refreshLists: profileMgmt.refreshProfilesAndRoms });
-  const widgets = useWidgetLayout(profileMgmt.activeProfile?.id ?? null, widgetIO, window.api.startup);
+  // Layout and content prefs share one debounced, flushed writer (lib/storage/widget-state).
+  const widgets = useWidgetLayout(profileMgmt.activeProfile?.id ?? null, widgetLayoutIO, window.api.startup);
+  useWidgetPrefs(profileMgmt.activeProfile?.id ?? null);
   // Master gate for developer-only UI (widgets, dev pages, shadow editor); also closes
   // devOnly widgets the moment it flips off.
   const developerToolsEnabled = useDevToolsWidgetGate(widgets.layout, widgets.close, window.api.startup.widgets);
@@ -165,7 +165,8 @@ const AppMain = () => {
 
         <WidgetManager
           layout={widgets.layout}
-          gameRunning={game.isRunning && nav.activePage === 'none'}
+          gameRunning={game.isRunning}
+          pageOpen={nav.activePage !== 'none'}
           onUpdate={widgets.update}
           onClose={widgets.close}
           onInsetsChange={setExclusiveInsets}

--- a/apps/web/src/ui/domains/widgets/cheats/CheatsWidget.tsx
+++ b/apps/web/src/ui/domains/widgets/cheats/CheatsWidget.tsx
@@ -3,7 +3,7 @@
  * Widget content providing cheat controls for the game.
  * Tabs: Items, Stats, Mechanics, Bottles
  */
-import { useState } from 'react';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
 import { Box } from '../../../design-system/primitives/Box';
 import { TabBar } from '../../../design-system/primitives/TabBar';
 import { ItemsTab } from './tabs/ItemsTab';
@@ -22,7 +22,7 @@ const TABS = [
 ];
 
 const CheatsWidgetContent = () => {
-  const [tab, setTab] = useState<CheatTab>('stats');
+  const [tab, setTab] = useWidgetPref<CheatTab>('cheats', 'tab', 'stats');
 
   return (
     <Box className="cheats-widget">

--- a/apps/web/src/ui/domains/widgets/cheats/tabs/ItemsTab.tsx
+++ b/apps/web/src/ui/domains/widgets/cheats/tabs/ItemsTab.tsx
@@ -14,6 +14,7 @@ import {
   cheatGiveItem, cheatTriggerCheck, cheatTriggerNpcCheck,
   getCompletedChecks, onCompletedChecksChanged,
 } from '../../../../../lib/game';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
 
 type Mode = 'free' | 'checks';
 
@@ -28,8 +29,8 @@ const CATEGORY_LABELS: Record<string, string> = Object.fromEntries(
 );
 
 const ItemsTab = () => {
-  const [mode, setMode] = useState<Mode>('free');
-  const [search, setSearch] = useState('');
+  const [mode, setMode] = useWidgetPref<Mode>('cheats', 'itemsMode', 'free');
+  const [search, setSearch] = useWidgetPref<string>('cheats', 'itemsSearch', '');
   const [completedChecks, setCompletedChecks] = useState<Set<CheckId>>(() => getCompletedChecks());
 
   useEffect(() => onCompletedChecksChanged(checks => setCompletedChecks(new Set(checks))), []);

--- a/apps/web/src/ui/domains/widgets/checks/ChecksWidget.tsx
+++ b/apps/web/src/ui/domains/widgets/checks/ChecksWidget.tsx
@@ -11,7 +11,8 @@ import { useTrackerData } from '../../../../hooks/useTrackerData';
 const ChecksWidgetContent = () => {
   const {
     viewMode, setViewMode, grouping, setGrouping, filter, setFilter, snapshot, stats, groupTree, run,
-  } = useTrackerData();
+    panels, setPanels, expandedGroups, toggleGroup,
+  } = useTrackerData({ prefKey: 'checks' });
 
   return (
     <ChecksTracker
@@ -26,6 +27,10 @@ const ChecksWidgetContent = () => {
       groupTree={groupTree}
       statuses={snapshot}
       run={run}
+      panels={panels}
+      onPanelsChange={setPanels}
+      expandedGroups={expandedGroups}
+      onToggleGroup={toggleGroup}
     />
   );
 };

--- a/apps/web/src/ui/domains/widgets/inventory/InventoryWidget.tsx
+++ b/apps/web/src/ui/domains/widgets/inventory/InventoryWidget.tsx
@@ -11,7 +11,7 @@ import { useInventoryViewMode } from './behavior/useInventoryViewMode';
 
 const InventoryWidgetContent = () => {
   const [inventory, setInventory] = useState<Set<ItemId>>(() => getCurrentInventory());
-  const viewMode = useInventoryViewMode();
+  const [viewMode] = useInventoryViewMode();
 
   useEffect(() => onInventoryChanged((inv) => setInventory(new Set(inv))), []);
 

--- a/apps/web/src/ui/domains/widgets/inventory/behavior/useInventoryViewMode.ts
+++ b/apps/web/src/ui/domains/widgets/inventory/behavior/useInventoryViewMode.ts
@@ -1,24 +1,17 @@
 /* @layer renderer-widgets @kind hook */
-import { useState, useEffect } from 'react';
+/**
+ * The inventory widget's view mode. Both the widget and its settings popover read
+ * this, so picking a mode in one is seen by the other with no event plumbing.
+ *
+ * It used to be a single localStorage key, which meant every profile on the
+ * machine shared one view mode and neither reader saw the other's write without a
+ * hand-dispatched StorageEvent.
+ */
 import type { InventoryViewMode } from '@shared/game/data';
-import { STORAGE_KEY } from '../inventory.constants';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
+import { DEFAULT_VIEW_MODE } from '../inventory.constants';
 
-const useInventoryViewMode = () => {
-  const [viewMode, setViewMode] = useState<InventoryViewMode>(() => {
-    return (localStorage.getItem(STORAGE_KEY) as InventoryViewMode) || 'default';
-  });
-
-  useEffect(() => {
-    const handler = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY && e.newValue) {
-        setViewMode(e.newValue as InventoryViewMode);
-      }
-    };
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
-  }, []);
-
-  return viewMode;
-};
+const useInventoryViewMode = (): readonly [InventoryViewMode, (next: InventoryViewMode) => void] =>
+  useWidgetPref<InventoryViewMode>('inventory', 'viewMode', DEFAULT_VIEW_MODE);
 
 export { useInventoryViewMode };

--- a/apps/web/src/ui/domains/widgets/inventory/inventory.constants.ts
+++ b/apps/web/src/ui/domains/widgets/inventory/inventory.constants.ts
@@ -1,7 +1,7 @@
 /* @layer renderer-widgets @kind constants */
 import type { InventoryViewMode } from '@shared/game/data';
 
-const STORAGE_KEY = 'inventory-view-mode';
+const DEFAULT_VIEW_MODE: InventoryViewMode = 'default';
 
 const VIEW_OPTIONS: { value: InventoryViewMode; label: string }[] = [
   { value: 'default', label: 'List' },
@@ -9,4 +9,4 @@ const VIEW_OPTIONS: { value: InventoryViewMode; label: string }[] = [
   { value: 'compact', label: 'Grid' },
 ];
 
-export { STORAGE_KEY, VIEW_OPTIONS };
+export { DEFAULT_VIEW_MODE, VIEW_OPTIONS };

--- a/apps/web/src/ui/domains/widgets/inventory/sub-components/InventoryWidgetSettings.tsx
+++ b/apps/web/src/ui/domains/widgets/inventory/sub-components/InventoryWidgetSettings.tsx
@@ -1,24 +1,16 @@
 /* @layer renderer-widgets @kind component */
-import { useState } from 'react';
 import type { InventoryViewMode } from '@shared/game/data';
 import { Box, Text, SegmentedControl } from '../../../../design-system/primitives';
-import { STORAGE_KEY, VIEW_OPTIONS } from '../inventory.constants';
+import { useInventoryViewMode } from '../behavior/useInventoryViewMode';
+import { VIEW_OPTIONS } from '../inventory.constants';
 
 const InventoryWidgetSettings = () => {
-  const [viewMode, setViewMode] = useState<InventoryViewMode>(() => {
-    return (localStorage.getItem(STORAGE_KEY) as InventoryViewMode) || 'default';
-  });
-
-  const handleChange = (v: InventoryViewMode) => {
-    setViewMode(v);
-    localStorage.setItem(STORAGE_KEY, v);
-    window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY, newValue: v }));
-  };
+  const [viewMode, setViewMode] = useInventoryViewMode();
 
   return (
     <Box className="widget-settings__row">
       <Text className="widget-settings__label">View</Text>
-      <SegmentedControl value={viewMode} options={VIEW_OPTIONS} onChange={handleChange} />
+      <SegmentedControl<InventoryViewMode> value={viewMode} options={VIEW_OPTIONS} onChange={setViewMode} />
     </Box>
   );
 };

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/LiveDataInspector.tsx
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/LiveDataInspector.tsx
@@ -14,7 +14,7 @@
  * `useComparison` feeds each card its own record's live differences, keyed by
  * id, so a wrong field shows inline where it lives.
  */
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Box, EmptyState, ScrollArea } from '@ds/primitives';
 import { buildSchema } from '@ds/data';
 import { COLLECTION_SOURCES } from '@app/ui/domains/app/views/DataInspector/behavior/collection-sources';
@@ -22,6 +22,7 @@ import { openInPassOrder, useRecommendations } from '@app/ui/domains/app/views/D
 import { defaultIdRefDisplay } from '@app/ui/domains/app/views/DataInspector/behavior/record-links';
 import { useIdRefNavigation } from '@app/ui/domains/app/views/DataInspector/behavior/useIdRefNavigation';
 import { useDataViewStore } from '@app/stores/data-view-store';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
 import type { EntityKind } from '@shared/game/data';
 import { DEFAULT_KIND } from './LiveDataInspector.constants';
 import { useComparison } from './behavior/use-comparison';
@@ -46,7 +47,7 @@ const LiveDataInspectorContent = () => {
   useDetectionPass(context);
   const diffsByRecord = useComparison(context);
 
-  const [kind, setKind] = useState<EntityKind>(DEFAULT_KIND);
+  const [kind, setKind] = useWidgetPref<EntityKind>('dataset', 'tab', DEFAULT_KIND);
   const allEntries = useRecommendations();
   const screenEntries = useMemo(
     () => openInPassOrder(allEntries.filter(entry => entry.screenId === context.screenId)),

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/behavior/use-recommendation-filter.ts
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/behavior/use-recommendation-filter.ts
@@ -10,6 +10,7 @@
  */
 import { useMemo, useState } from 'react';
 import type { Recommendation, RecommendationAction } from '@shared/game/recommendations';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
 
 type RecommendationFilter = 'all' | RecommendationAction;
 
@@ -51,7 +52,7 @@ const filterEntries = (
   filter === 'all' ? entries : entries.filter(entry => entry.action === filter);
 
 const useRecommendationFilter = (entries: readonly Recommendation[]): UseRecommendationFilterResult => {
-  const [filter, setFilter] = useState<RecommendationFilter>('all');
+  const [filter, setFilter] = useWidgetPref<RecommendationFilter>('dataset', 'recFilter', 'all');
 
   const tabs = useMemo(() => buildFilterTabs(entries), [entries]);
 

--- a/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationList.tsx
+++ b/apps/web/src/ui/domains/widgets/navigation/LiveDataInspector/sub-components/RecommendationList.tsx
@@ -18,6 +18,7 @@ import { RecommendationCard } from './RecommendationCard';
 import { RecommendationTabs } from './RecommendationTabs';
 import type { Recommendation } from '@shared/game/recommendations';
 import './RecommendationList.css';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
 
 const MIN_BATCH = 2;
 
@@ -27,7 +28,7 @@ interface RecommendationListProps {
 
 const RecommendationList = (props: RecommendationListProps) => {
   const { entries } = props;
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useWidgetPref<boolean>('dataset', 'recCollapsed', false);
   const [busy, setBusy] = useState(false);
   const { tabs, filter, setFilter, filtered } = useRecommendationFilter(entries);
   const certainCount = certainOnly(filtered).length;

--- a/apps/web/src/ui/domains/widgets/navigation/sub-components/DescRow.tsx
+++ b/apps/web/src/ui/domains/widgets/navigation/sub-components/DescRow.tsx
@@ -1,6 +1,6 @@
 /* @layer renderer-widgets @kind component */
-import { useState } from 'react';
 import type { ReactNode, CSSProperties } from 'react';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
 import { Box, Text } from '../../../../design-system/primitives';
 import { S } from '../styles';
 
@@ -11,11 +11,12 @@ const IL: Record<string, CSSProperties> = {
 
 /** A clickable info-row label that expands an inline description. */
 const DescRow = ({ label, desc, children }: { label: string; desc: string; children: ReactNode }) => {
-  const [open, setOpen] = useState(false);
+  // Keyed by label so each row remembers itself, not the last one opened.
+  const [open, setOpen] = useWidgetPref<boolean>('navigation', `desc:${label}`, false);
   return (
     <Box>
       <Box style={S.infoRow}>
-        <Text style={{ ...S.infoLabel, cursor: 'pointer', textDecoration: 'underline', textDecorationStyle: 'dotted', textUnderlineOffset: '2px' } as CSSProperties} onClick={() => setOpen(o => !o)}>{label}</Text>
+        <Text style={{ ...S.infoLabel, cursor: 'pointer', textDecoration: 'underline', textDecorationStyle: 'dotted', textUnderlineOffset: '2px' } as CSSProperties} onClick={() => setOpen(!open)}>{label}</Text>
         <Text style={IL.valueRow}>{children}</Text>
       </Box>
       {open && (

--- a/apps/web/src/ui/domains/widgets/navigation/useNavigation.ts
+++ b/apps/web/src/ui/domains/widgets/navigation/useNavigation.ts
@@ -5,6 +5,8 @@ import { usableEntrances } from '@shared/game/navigation';
 import { annotateFlooded } from './nav-flood/annotate-flooded';
 import { liveGameStates } from '../../../../lib/game/live-game-states';
 import { useNavigationOverlayStore } from '../../../../stores/navigation-overlay-store';
+import { useWidgetUiStore } from '../../../../stores/widget-ui-store';
+import { useWidgetPref } from '../../../../hooks/useWidgetPref';
 import type { NavMode } from '../../../../stores/navigation-overlay-store';
 import type { ConnectionInfo } from '@shared/game/navigation';
 import { wasmGetViewportInfo, wasmGetOverworldVariant, wasmGetProgressIndicator, wasmGetIndoorLayer0Grid, wasmGetLinkLayer, wasmGetOverworldEntrances, wasmGetFallHoles, wasmGetExitScreenMap, wasmGetEntranceSpawns, wasmGetRoomLayoutInfo, wasmGetDungeonMapPosition } from '../../../../lib/game';
@@ -22,6 +24,10 @@ import { useNavConnections } from './nav-flood/use-nav-connections';
 /** Set once per app run, so remounting the widget cannot re-apply the --auto-flood flag. */
 let didApplyAutoFloodFlag = false;
 
+/** Same reasoning for the saved mode: it is restored the first time the widget mounts in
+ *  this run, and after that the overlay store is the live value the pref follows. */
+let didRestoreSavedMode = false;
+
 /** All Navigation-widget state, data acquisition, and flood-fill orchestration. */
 const useNavigation = () => {
   const { overworldScreenIndex, roomIndex, isIndoors, isDarkWorld, palaceIndex, whichEntrance, linkX: playerX, linkY: playerY } = useGameUIStore(s => s.map);
@@ -34,6 +40,12 @@ const useNavigation = () => {
   const { result, connections, screenBundle, respawnEntIds, mode, setScreenBundle } = overlayStore;
   const fallHoleLandings = overlayStore.fallHoleSpawns;
   const autoRun = mode === 'auto';
+
+  // Manual/auto is remembered by the profile. The overlay store stays the live value,
+  // because auto mode has to survive the widget unmounting mid-run; the pref is the copy
+  // that survives the app closing.
+  const [savedMode, setSavedMode] = useWidgetPref<NavMode>('navigation', 'mode', 'manual');
+  const prefsHydrated = useWidgetUiStore(s => s.hydrated);
 
   const [running, setRunning] = useState(false);
   const [variant, setVariant] = useState<OverworldVariantInfo | null>(null);
@@ -195,6 +207,14 @@ const useNavigation = () => {
 
   handleRunRef.current = handleRun;
 
+  // Restore the saved mode once, and only after the profile's prefs have landed: before
+  // that the pref reads as the 'manual' fallback, which would overwrite a real 'auto'.
+  useEffect(() => {
+    if (!prefsHydrated || didRestoreSavedMode) return;
+    didRestoreSavedMode = true;
+    if (savedMode !== mode) overlayStore.setMode(savedMode);
+  }, [prefsHydrated, savedMode, mode]);
+
   // Auto-flood CLI flag: put the widget in auto mode and take the first flood once the
   // active screen is known. The guard is module-level, not a ref: a ref resets when the
   // hub unmounts the widget, which would force auto back on after the user chose manual.
@@ -249,8 +269,9 @@ const useNavigation = () => {
   /** Switching to auto floods straight away, so the overlay matches the mode you just picked. */
   const setMode = useCallback((next: NavMode) => {
     overlayStore.setMode(next);
+    setSavedMode(next);
     if (next === 'auto' && !running) handleRunRef.current?.();
-  }, [running]);
+  }, [running, setSavedMode]);
 
   // Derived: classify connections as internal vs external (with dedup).
   const { externalConnections, internalConnections } = useNavConnections(connections, screenBundle, isIndoors);

--- a/apps/web/src/ui/domains/widgets/simulator/behavior/useSimulatorRun.ts
+++ b/apps/web/src/ui/domains/widgets/simulator/behavior/useSimulatorRun.ts
@@ -18,6 +18,7 @@ import { useSimulatorStore } from '@app/stores/simulator-store';
 import { buildObservation, fanOutEvents, waitAfterTrigger, screenFloodEvent, exitsEvent, sequenceEvent } from './runner-loop';
 import type { DetectCache } from './runner-loop';
 import { computeProgress, buildRunResults } from './run-results';
+import { useWidgetPref } from '@app/hooks/useWidgetPref';
 
 const SAFETY_CAP = 50_000;
 
@@ -29,8 +30,8 @@ interface Control {
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 const useSimulatorRun = () => {
-  const [stopAtCheckId, setStopAtCheckId] = useState<CheckId | ''>('');
-  const [screenLimit, setScreenLimit] = useState<number | null>(null);
+  const [stopAtCheckId, setStopAtCheckId] = useWidgetPref<CheckId | ''>('simulator', 'stopAtCheckId', '');
+  const [screenLimit, setScreenLimit] = useWidgetPref<number | null>('simulator', 'screenLimit', null);
   const [canRestore, setCanRestore] = useState(false);
   const screenLimitRef = useRef<number | null>(null);
   screenLimitRef.current = screenLimit;


### PR DESCRIPTION
Open any screen and the widgets came back changed, and quitting reset them again. Only the layout was ever saved to the profile, so everything a widget held in component state went with it when a screen unmounted it: the tab, the filter, which panels were open, which groups were expanded.

Widget content state now lives in a store outside React and is written through to the profile, so it survives both an open screen and a restart.

* One writer for the whole profile blob, with coalesced writes and a flush before the window closes. A drag used to rewrite tracker.json on every mousemove, and two overlapping writes both read the same "before", so the earlier one was lost.
* `useWidgetPref` is a `useState` drop-in. Pass no widget id and it stays local, which is how the randomizer spoiler tab keeps its old behaviour.
* Migrated: checks view mode, grouping, filter, open panels and expanded groups; cheats tab, items mode and search; inventory view mode, which used to be one localStorage key shared by every profile; the inspector's collection and recommendation filter; each navigation description row; navigation manual/auto; simulator stop-at-check and screen limit.

Two defects turned up on the way.

* The `--widgets=` startup flag wrote `visibility: 'always'` into the saved layout, which permanently turned a game-only widget into one that never left the screen. Nothing in the UI sets visibility, so it is read back from the definition on load and any layout already carrying the bad value is repaired.
* `WidgetManager`'s `gameRunning` prop was doing two jobs at once. Split into `gameRunning` and `pageOpen`, so a game-only widget always steps aside for an open page and no startup flag can override that.

Verified with a throwaway Playwright probe against the built app: open the filter panel, expand a group, Escape to home and assert the widget is gone from the DOM, Escape back and assert the panel and expansion are intact, then read tracker.json off disk and boot a second process that shows both restored. Probe deleted.